### PR TITLE
fix: dispatch release after fork tag sync

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
     # run only against tags
     tags:
       - '*'
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/sync-release-tag.yml
+++ b/.github/workflows/sync-release-tag.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
 
 concurrency:
@@ -35,6 +36,8 @@ jobs:
           git fetch upstream main --tags
 
       - name: Create missing fork release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           UPSTREAM_TAG=""
 
@@ -54,10 +57,17 @@ jobs:
 
           FORK_TAG="${UPSTREAM_TAG}-0"
           if git ls-remote --exit-code --tags origin "refs/tags/${FORK_TAG}" >/dev/null 2>&1; then
-            echo "[i] ${FORK_TAG} already exists; nothing to tag."
+            if gh release view "${FORK_TAG}" >/dev/null 2>&1; then
+              echo "[i] ${FORK_TAG} release already exists; nothing to tag."
+              exit 0
+            fi
+
+            echo "[i] ${FORK_TAG} tag already exists but release is missing; dispatching release workflow."
+            gh workflow run release.yaml --ref "${FORK_TAG}"
             exit 0
           fi
 
           echo "[i] Creating ${FORK_TAG} for upstream ${UPSTREAM_TAG}."
           git tag -a "$FORK_TAG" -m "CLIProxyAPIPlus ${FORK_TAG} (upstream ${UPSTREAM_TAG})"
           git push origin "refs/tags/${FORK_TAG}"
+          gh workflow run release.yaml --ref "${FORK_TAG}"


### PR DESCRIPTION
## Summary
- allow the Goreleaser workflow to run via workflow_dispatch
- have the fork tag sync workflow dispatch Goreleaser after creating a tag
- dispatch release generation when a fork tag exists but the GitHub release is missing

## Validation
- ruby YAML parse for release workflows
- git diff --check
- go test ./... -count=1 -timeout 10m

This fixes the gap where v6.9.36-0 was tagged but no release artifacts were created because GITHUB_TOKEN tag pushes do not trigger downstream workflows.