### PR TITLE
fix: dispatch fork releases by tag input

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,11 @@ on:
     tags:
       - '*'
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing fork tag to release, for example v6.9.36-0
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -17,6 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
       - name: Refresh models catalog
         run: |
           git fetch --depth 1 https://github.com/router-for-me/models.git main
@@ -28,9 +34,14 @@ jobs:
           cache: true
       - name: Generate Build Metadata
         run: |
-          echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
-          echo COMMIT=`git rev-parse --short HEAD` >> $GITHUB_ENV
-          echo BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` >> $GITHUB_ENV
+          VERSION="${{ inputs.tag }}"
+          if [ -z "$VERSION" ]; then
+            VERSION="${GITHUB_REF_NAME}"
+          fi
+
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          echo "COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
       - uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser

--- a/.github/workflows/sync-release-tag.yml
+++ b/.github/workflows/sync-release-tag.yml
@@ -57,17 +57,17 @@ jobs:
 
           FORK_TAG="${UPSTREAM_TAG}-0"
           if git ls-remote --exit-code --tags origin "refs/tags/${FORK_TAG}" >/dev/null 2>&1; then
-            if gh release view "${FORK_TAG}" >/dev/null 2>&1; then
+            if gh release view "${FORK_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
               echo "[i] ${FORK_TAG} release already exists; nothing to tag."
               exit 0
             fi
 
             echo "[i] ${FORK_TAG} tag already exists but release is missing; dispatching release workflow."
-            gh workflow run release.yaml --ref "${FORK_TAG}"
+            gh workflow run release.yaml --repo "${GITHUB_REPOSITORY}" --ref "${GITHUB_REF_NAME}" -f tag="${FORK_TAG}"
             exit 0
           fi
 
           echo "[i] Creating ${FORK_TAG} for upstream ${UPSTREAM_TAG}."
           git tag -a "$FORK_TAG" -m "CLIProxyAPIPlus ${FORK_TAG} (upstream ${UPSTREAM_TAG})"
           git push origin "refs/tags/${FORK_TAG}"
-          gh workflow run release.yaml --ref "${FORK_TAG}"
+          gh workflow run release.yaml --repo "${GITHUB_REPOSITORY}" --ref "${GITHUB_REF_NAME}" -f tag="${FORK_TAG}"


### PR DESCRIPTION
## Summary
- let the release workflow accept an existing fork tag as a manual input
- make sync-release-tag dispatch the fork workflow on main with the tag input
- pin gh release/workflow commands to this fork via --repo

## Why
The existing v6.9.36-0 tag was created before release.yaml had workflow_dispatch, so dispatching directly against that tag fails. Dispatching the current main workflow with a tag input lets the fork publish assets for existing tags without moving tags.

## Validation
- ruby YAML parse for release.yaml and sync-release-tag.yml
- git diff --check
