### PR TITLE
fix(ci): keep Plus releases aligned with upstream source

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: goreleaser-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -23,10 +27,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.tag || github.ref }}
-      - name: Refresh models catalog
-        run: |
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
       - run: git fetch --force --tags
       - uses: actions/setup-go@v4
         with:
@@ -42,7 +42,19 @@ jobs:
           echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
           echo "COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
           echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+      - name: Check existing release
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${VERSION}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "[i] ${VERSION} release already exists; skipping GoReleaser."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
       - uses: goreleaser/goreleaser-action@v4
+        if: steps.release.outputs.exists != 'true'
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/sync-release-tag.yml
+++ b/.github/workflows/sync-release-tag.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   schedule:
-    - cron: '30 6 * * *'
+    - cron: '47 * * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,13 +1,13 @@
 name: Upstream Sync
 
-# Pulls daily changes from router-for-me/CLIProxyAPI into this fork.
+# Polls for changes from router-for-me/CLIProxyAPI and merges them into this fork.
 # Plus-only provider dirs are shielded via .gitattributes (merge=ours).
 # If the merge is clean AND build passes, push directly to main.
 # Otherwise, open a PR for manual review.
 
 on:
   schedule:
-    - cron: '0 6 * * *'   # daily 06:00 UTC
+    - cron: '17 * * * *'   # hourly; GitHub does not emit cross-repo release events
   workflow_dispatch:
     inputs:
       force_pr:
@@ -125,16 +125,6 @@ jobs:
         with:
           go-version: '>=1.26.0'
           cache: true
-
-      - name: Refresh models catalog
-        if: steps.check.outputs.has_changes == 'true'
-        run: |
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
-          if ! git diff --quiet -- internal/registry/models/models.json; then
-            git add internal/registry/models/models.json
-            git commit -m "chore(upstream-sync): refresh models catalog"
-          fi
 
       - name: Record synced upstream version
         if: steps.check.outputs.has_changes == 'true'


### PR DESCRIPTION
## Summary
- poll upstream hourly instead of daily so Plus catches upstream changes faster
- stop rewriting `internal/registry/models/models.json` from the separate models repo during sync/release
- serialize GoReleaser per tag and skip if a release already exists, avoiding duplicate asset upload failures

## Validation
- ruby YAML parse for upstream-sync, sync-release-tag, release workflows
