### PR TITLE
ci(docker): publish to GHCR via self-hosted runner, chain dispatch from sync-release-tag

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,148 +1,119 @@
 name: docker-image
 
+# Builds and publishes the multi-arch Docker image for CLIProxyAPIPlus to GHCR.
+#
+# Triggers:
+#   - push of any v* tag (works when a PAT pushes the tag; sync-release-tag.yml
+#     pushes via GITHUB_TOKEN and explicitly dispatches this workflow because
+#     GITHUB_TOKEN events do not cascade)
+#   - workflow_dispatch with optional `tag` input
+#
+# Runner: self-hosted `cliproxy` (docker host LXC). QEMU + buildx produce both
+# linux/amd64 and linux/arm64 from a single x64 host.
+#
+# Registry: ghcr.io/<owner>/cli-proxy-api-plus. Auth uses the built-in
+# GITHUB_TOKEN — no Docker Hub credentials required.
+
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to build, e.g. v6.9.45-0'
+        required: false
+        type: string
   push:
     tags:
-      - v*
+      - 'v*'
 
 env:
   APP_NAME: CLIProxyAPI
-  DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_USERNAME }}/cli-proxy-api-plus
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/cli-proxy-api-plus
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-image-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
-  docker_amd64:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: [self-hosted, cliproxy]
     steps:
+      - name: Resolve build ref
+        id: ref
+        run: |
+          REF="${{ inputs.tag }}"
+          if [ -z "${REF}" ]; then REF="${GITHUB_REF_NAME}"; fi
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
+          fetch-depth: 0
+
       - name: Refresh models catalog
         run: |
           git fetch --depth 1 https://github.com/router-for-me/models.git main
           git show FETCH_HEAD:models.json > internal/registry/models/models.json
+
+      - name: Set up QEMU (for arm64 emulation on x64 self-hosted runner)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub
+
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Generate Build Metadata
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lowercase image name
+        id: img
         run: |
-          echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
-          echo COMMIT=`git rev-parse --short HEAD` >> $GITHUB_ENV
-          echo BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` >> $GITHUB_ENV
-      - name: Build and push (amd64)
+          IMG="${REGISTRY}/${IMAGE_NAME}"
+          IMG_LC="$(echo "${IMG}" | tr '[:upper:]' '[:lower:]')"
+          echo "ref=${IMG_LC}" >> "$GITHUB_OUTPUT"
+
+      - name: Build metadata
+        id: meta
+        run: |
+          VERSION="${{ steps.ref.outputs.ref }}"
+          COMMIT="$(git rev-parse --short HEAD)"
+          BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          {
+            echo "version=${VERSION}"
+            echo "commit=${COMMIT}"
+            echo "build_date=${BUILD_DATE}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push (multi-arch)
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
-            VERSION=${{ env.VERSION }}
-            COMMIT=${{ env.COMMIT }}
-            BUILD_DATE=${{ env.BUILD_DATE }}
+            VERSION=${{ steps.meta.outputs.version }}
+            COMMIT=${{ steps.meta.outputs.commit }}
+            BUILD_DATE=${{ steps.meta.outputs.build_date }}
           tags: |
-            ${{ env.DOCKERHUB_REPO }}:latest-amd64
-            ${{ env.DOCKERHUB_REPO }}:${{ env.VERSION }}-amd64
+            ${{ steps.img.outputs.ref }}:${{ steps.meta.outputs.version }}
+            ${{ steps.img.outputs.ref }}:latest
 
-  docker_arm64:
-    runs-on: ubuntu-24.04-arm
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Refresh models catalog
+      - name: Summary
         run: |
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Generate Build Metadata
-        run: |
-          echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
-          echo COMMIT=`git rev-parse --short HEAD` >> $GITHUB_ENV
-          echo BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` >> $GITHUB_ENV
-      - name: Build and push (arm64)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/arm64
-          push: true
-          build-args: |
-            VERSION=${{ env.VERSION }}
-            COMMIT=${{ env.COMMIT }}
-            BUILD_DATE=${{ env.BUILD_DATE }}
-          tags: |
-            ${{ env.DOCKERHUB_REPO }}:latest-arm64
-            ${{ env.DOCKERHUB_REPO }}:${{ env.VERSION }}-arm64
-
-  docker_manifest:
-    runs-on: ubuntu-latest
-    needs:
-      - docker_amd64
-      - docker_arm64
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Generate Build Metadata
-        run: |
-          echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
-          echo COMMIT=`git rev-parse --short HEAD` >> $GITHUB_ENV
-          echo BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` >> $GITHUB_ENV
-      - name: Create and push multi-arch manifests
-        run: |
-          docker buildx imagetools create \
-            --tag "${DOCKERHUB_REPO}:latest" \
-            "${DOCKERHUB_REPO}:latest-amd64" \
-            "${DOCKERHUB_REPO}:latest-arm64"
-          docker buildx imagetools create \
-            --tag "${DOCKERHUB_REPO}:${VERSION}" \
-            "${DOCKERHUB_REPO}:${VERSION}-amd64" \
-            "${DOCKERHUB_REPO}:${VERSION}-arm64"
-      - name: Cleanup temporary tags
-        continue-on-error: true
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          namespace="${DOCKERHUB_REPO%%/*}"
-          repo_name="${DOCKERHUB_REPO#*/}"
-
-          token="$(
-            curl -fsSL \
-              -H 'Content-Type: application/json' \
-              -d "{\"username\":\"${DOCKERHUB_USERNAME}\",\"password\":\"${DOCKERHUB_TOKEN}\"}" \
-              'https://hub.docker.com/v2/users/login/' \
-              | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])'
-          )"
-
-          delete_tag() {
-            local tag="$1"
-            local url="https://hub.docker.com/v2/repositories/${namespace}/${repo_name}/tags/${tag}/"
-            local http_code
-            http_code="$(curl -sS -o /dev/null -w "%{http_code}" -X DELETE -H "Authorization: JWT ${token}" "${url}" || true)"
-            if [ "${http_code}" = "204" ] || [ "${http_code}" = "404" ]; then
-              echo "Docker Hub tag removed (or missing): ${DOCKERHUB_REPO}:${tag} (HTTP ${http_code})"
-              return 0
-            fi
-            echo "Docker Hub tag delete failed: ${DOCKERHUB_REPO}:${tag} (HTTP ${http_code})"
-            return 0
-          }
-
-          delete_tag "latest-amd64"
-          delete_tag "latest-arm64"
-          delete_tag "${VERSION}-amd64"
-          delete_tag "${VERSION}-arm64"
+          {
+            echo "## Published"
+            echo "- \`${{ steps.img.outputs.ref }}:${{ steps.meta.outputs.version }}\`"
+            echo "- \`${{ steps.img.outputs.ref }}:latest\`"
+            echo
+            echo "Pull: \`docker pull ${{ steps.img.outputs.ref }}:${{ steps.meta.outputs.version }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-release-tag.yml
+++ b/.github/workflows/sync-release-tag.yml
@@ -56,18 +56,26 @@ jobs:
           fi
 
           FORK_TAG="${UPSTREAM_TAG}-0"
+          # GITHUB_TOKEN tag pushes do NOT trigger downstream workflows, so we
+          # explicitly dispatch release.yaml AND docker-image.yml after tagging.
+          dispatch_downstream() {
+            local tag="$1"
+            gh workflow run release.yaml --repo "${GITHUB_REPOSITORY}" --ref "${GITHUB_REF_NAME}" -f tag="${tag}" || true
+            gh workflow run docker-image.yml --repo "${GITHUB_REPOSITORY}" --ref "${GITHUB_REF_NAME}" -f tag="${tag}" || true
+          }
+
           if git ls-remote --exit-code --tags origin "refs/tags/${FORK_TAG}" >/dev/null 2>&1; then
             if gh release view "${FORK_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
               echo "[i] ${FORK_TAG} release already exists; nothing to tag."
               exit 0
             fi
 
-            echo "[i] ${FORK_TAG} tag already exists but release is missing; dispatching release workflow."
-            gh workflow run release.yaml --repo "${GITHUB_REPOSITORY}" --ref "${GITHUB_REF_NAME}" -f tag="${FORK_TAG}"
+            echo "[i] ${FORK_TAG} tag already exists but release is missing; dispatching downstream workflows."
+            dispatch_downstream "${FORK_TAG}"
             exit 0
           fi
 
           echo "[i] Creating ${FORK_TAG} for upstream ${UPSTREAM_TAG}."
           git tag -a "$FORK_TAG" -m "CLIProxyAPIPlus ${FORK_TAG} (upstream ${UPSTREAM_TAG})"
           git push origin "refs/tags/${FORK_TAG}"
-          gh workflow run release.yaml --repo "${GITHUB_REPOSITORY}" --ref "${GITHUB_REF_NAME}" -f tag="${FORK_TAG}"
+          dispatch_downstream "${FORK_TAG}"


### PR DESCRIPTION
Closes #6 — provides a published Docker image for CLIProxyAPIPlus.

## Why the previous setup never produced an image

1. **Tag-push didn't cascade.** \`docker-image.yml\` triggered on \`push: tags: v*\`, but \`sync-release-tag.yml\` pushes tags using \`GITHUB_TOKEN\` — and GITHUB_TOKEN-pushed tags don't trigger other workflows ([documented limitation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)).
2. **The one manual run (2026-04-22) failed** — likely missing \`DOCKERHUB_USERNAME\` / \`DOCKERHUB_TOKEN\` secrets.

Result: 3 fork tags published (\`v6.9.41-0\`, \`v6.9.36-0\`, \`v6.9.29-0\`), zero Docker images.

## What changes

### \`docker-image.yml\` — full rewrite

| Aspect | Before | After |
|---|---|---|
| Runner | \`ubuntu-latest\` + \`ubuntu-24.04-arm\` (3 jobs) | \`[self-hosted, cliproxy]\` (1 job, QEMU multi-arch) |
| Registry | Docker Hub (needs secrets) | GHCR via built-in \`GITHUB_TOKEN\` |
| Image | \`secrets.DOCKERHUB_USERNAME/cli-proxy-api-plus\` | \`ghcr.io/\${owner}/cli-proxy-api-plus\` |
| Tags | \`:latest\`, \`:VERSION\`, \`:VERSION-amd64\`, \`:VERSION-arm64\` (+ cleanup logic) | \`:latest\`, \`:VERSION\` (single multi-arch manifest each) |
| Cost | GitHub-hosted minutes | Free (self-hosted on docker host LXC) |
| GitHub infra load | Heavy | None |

\`workflow_dispatch.inputs.tag\` accepts an explicit tag for the chained-dispatch flow.

### \`sync-release-tag.yml\` — extend the dispatch chain

Already dispatched \`release.yaml\` after creating each fork tag (same GITHUB_TOKEN limitation). Now also dispatches \`docker-image.yml\` so every fork tag produces a published image. Each dispatch is best-effort (\`|| true\`) so a transient failure in one doesn't block the other.

## Self-hosted runner

Registered \`cliproxyplus-runner\` on the existing docker host LXC (\`/opt/actions-runner-cliproxyplus\`, systemd unit \`actions-runner-cliproxyplus.service\`, labels \`self-hosted, linux, x64, cliproxy\`). Online and idle.

## How users will pull

\`\`\`
docker pull ghcr.io/kaitranntt/cli-proxy-api-plus:latest
docker pull ghcr.io/kaitranntt/cli-proxy-api-plus:v6.9.45-0
\`\`\`

GHCR images on a public repo are public by default after the first push.

## Test plan

- [ ] Merge PR
- [ ] Manually trigger: \`gh workflow run docker-image.yml -R kaitranntt/CLIProxyAPIPlus -f tag=v6.9.41-0\` — confirm it lands on the self-hosted runner and pushes to GHCR
- [ ] Manually trigger \`sync-release-tag.yml\` — confirm it creates \`v6.9.45-0\` (since main is now at v6.9.45 code) and dispatches both downstream workflows
- [ ] Confirm pulls work: \`docker pull ghcr.io/kaitranntt/cli-proxy-api-plus:v6.9.45-0\`
- [ ] Close #6 with a comment pointing at the GHCR URL