### PR TITLE
fix(docker): point compose default at GHCR + document Docker usage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,9 @@ go.sum merge=union
 .github/workflows/upstream-sync.yml merge=ours
 .gitattributes merge=ours
 README-ccs-fork.md merge=ours
+
+# Image references diverge from upstream (Plus publishes to
+# ghcr.io/kaitranntt/cli-proxy-api-plus, upstream publishes to
+# eceasy/cli-proxy-api). Keep ours so upstream sync does not silently revert
+# the image path back to upstream's.
+docker-compose.yml merge=ours

--- a/README.md
+++ b/README.md
@@ -70,6 +70,28 @@ VisionCoder is also offering our users a limited-time <a href="https://coder.vis
 
 CLIProxyAPI Guides: [https://help.router-for.me/](https://help.router-for.me/)
 
+### Run with Docker
+
+Multi-arch images (`linux/amd64`, `linux/arm64`) are published to GitHub Container Registry on every release tag.
+
+```sh
+# Pull a specific version (recommended)
+docker pull ghcr.io/kaitranntt/cli-proxy-api-plus:v6.9.45-0
+
+# Or pull the latest published release
+docker pull ghcr.io/kaitranntt/cli-proxy-api-plus:latest
+```
+
+Or use the included `docker-compose.yml` (defaults to the GHCR image, builds from source if `CLI_PROXY_IMAGE` is overridden):
+
+```sh
+git clone https://github.com/kaitranntt/CLIProxyAPIPlus.git
+cd CLIProxyAPIPlus
+docker compose up -d
+```
+
+Available tags: [`ghcr.io/kaitranntt/cli-proxy-api-plus`](https://github.com/kaitranntt/CLIProxyAPIPlus/pkgs/container/cli-proxy-api-plus).
+
 ## Management API
 
 see [MANAGEMENT_API.md](https://help.router-for.me/management/api)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   cli-proxy-api:
-    image: ${CLI_PROXY_IMAGE:-eceasy/cli-proxy-api-plus:latest}
+    image: ${CLI_PROXY_IMAGE:-ghcr.io/kaitranntt/cli-proxy-api-plus:latest}
     pull_policy: always
     build:
       context: .


### PR DESCRIPTION
Follow-up to #6 / #44 — addresses [@simonsmh's comment](https://github.com/kaitranntt/CLIProxyAPIPlus/issues/6#issuecomment-4357363054) ("Please edit docker-compose.yml") on a closed issue.

## What was actually broken for end users

PR #44 published the image to GHCR and I closed #6 with `docker pull` instructions. But the primary onboarding path is `git clone && docker compose up`, and `docker-compose.yml:3` defaulted to:

```yaml
image: ${CLI_PROXY_IMAGE:-eceasy/cli-proxy-api-plus:latest}
```

That image **has never existed**. eceasy publishes `cli-proxy-api`, not `-plus`. Plus's old `DOCKERHUB_USERNAME/cli-proxy-api-plus` workflow never ran successfully (failed once 2026-04-22, never again until #44). So users running `docker compose up` got a Docker Hub 404.

## Changes

| File | Why |
|---|---|
| `docker-compose.yml` | Default image → `ghcr.io/kaitranntt/cli-proxy-api-plus:latest`. Override still works via `CLI_PROXY_IMAGE`. |
| `.gitattributes` | Add `docker-compose.yml merge=ours`. Otherwise the next upstream sync rebases ours back to upstream's `eceasy/cli-proxy-api:latest` and silently breaks users again. |
| `README.md` | New "Run with Docker" subsection under Getting Started — pull commands + compose snippet. So users find install info without grepping closed issues. |

## Why this slipped through PR #44

PR #44's "test plan" verified `docker pull` and the GHCR upload but not the **end-user workflow** (`docker compose up`). The migration touchpoint checklist I should have followed:

1. Registry push works
2. `docker-compose.yml` default points at the new path
3. README has Docker quick-start
4. `.gitattributes` protects fork-specific config from upstream drift
5. CHANGELOG / closure comment match reality

I caught 1 and skipped 2-5. Adding 2-4 here.

## Test plan

- [ ] After merge: \`git clone https://github.com/kaitranntt/CLIProxyAPIPlus.git && cd CLIProxyAPIPlus && docker compose up -d\` pulls and starts cleanly with no override env var
- [ ] After merge: comment on #6 with apology + working command
- [ ] Next upstream sync run does NOT regenerate `docker-compose.yml` with upstream's default