### PR TITLE
ci(upstream-sync): assign tracking issue to repo owner for email notification

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -372,6 +372,7 @@ jobs:
               --repo "${{ github.repository }}" \
               --title "${ISSUE_TITLE}" \
               --label "${TRACKING_ISSUE_LABEL}" \
+              --assignee "${{ github.repository_owner }}" \
               --body "${ISSUE_BODY}" || exit 1
           fi
           set -e


### PR DESCRIPTION
Adds `--assignee \${{ github.repository_owner }}` to the `gh issue create` call when upstream-sync opens the `upstream-sync-blocked` tracking issue. GitHub emails the assignee on creation and every subsequent comment, so the maintainer gets notified when sync gets stuck without needing to watch the repo.

Single line change, idempotent — re-assigning an already-assigned issue is a no-op.