### PR TITLE
feat(kiro): route Claude Opus 4.7 model

### DIFF
--- a/internal/config/oauth_model_alias_defaults.go
+++ b/internal/config/oauth_model_alias_defaults.go
@@ -14,6 +14,8 @@ func defaultKiroAliases() []OAuthModelAlias {
 		// Sonnet 4
 		{Name: "kiro-claude-sonnet-4", Alias: "claude-sonnet-4-20250514", Fork: true},
 		{Name: "kiro-claude-sonnet-4", Alias: "claude-sonnet-4", Fork: true},
+		// Opus 4.7
+		{Name: "kiro-claude-opus-4-7", Alias: "claude-opus-4-7", Fork: true},
 		// Opus 4.6
 		{Name: "kiro-claude-opus-4-6", Alias: "claude-opus-4-6", Fork: true},
 		// Opus 4.5

--- a/internal/config/oauth_model_alias_test.go
+++ b/internal/config/oauth_model_alias_test.go
@@ -82,6 +82,7 @@ func TestSanitizeOAuthModelAlias_InjectsDefaultKiroAliases(t *testing.T) {
 		"claude-sonnet-4-5",
 		"claude-sonnet-4-20250514",
 		"claude-sonnet-4",
+		"claude-opus-4-7",
 		"claude-opus-4-6",
 		"claude-opus-4-5-20251101",
 		"claude-opus-4-5",

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -644,6 +644,18 @@ func GetKiroModels() []*ModelInfo {
 			Thinking:            &ThinkingSupport{Min: 1024, Max: 32000, ZeroAllowed: true, DynamicAllowed: true},
 		},
 		{
+			ID:                  "kiro-claude-opus-4-7",
+			Object:              "model",
+			Created:             1746057600, // 2025-05-01
+			OwnedBy:             "aws",
+			Type:                "kiro",
+			DisplayName:         "Kiro Claude Opus 4.7",
+			Description:         "Claude Opus 4.7 via Kiro (2.2x credit)",
+			ContextLength:       200000,
+			MaxCompletionTokens: 64000,
+			Thinking:            &ThinkingSupport{Min: 1024, Max: 32000, ZeroAllowed: true, DynamicAllowed: true},
+		},
+		{
 			ID:                  "kiro-claude-opus-4-6",
 			Object:              "model",
 			Created:             1736899200, // 2025-01-15
@@ -797,6 +809,18 @@ func GetKiroModels() []*ModelInfo {
 			MaxCompletionTokens: 4096,
 		},
 		// --- Agentic Variants (Optimized for coding agents with chunked writes) ---
+		{
+			ID:                  "kiro-claude-opus-4-7-agentic",
+			Object:              "model",
+			Created:             1746057600, // 2025-05-01
+			OwnedBy:             "aws",
+			Type:                "kiro",
+			DisplayName:         "Kiro Claude Opus 4.7 (Agentic)",
+			Description:         "Claude Opus 4.7 optimized for coding agents (chunked writes)",
+			ContextLength:       200000,
+			MaxCompletionTokens: 64000,
+			Thinking:            &ThinkingSupport{Min: 1024, Max: 32000, ZeroAllowed: true, DynamicAllowed: true},
+		},
 		{
 			ID:                  "kiro-claude-opus-4-6-agentic",
 			Object:              "model",

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -33,6 +33,39 @@ func TestCodexStaticModelsIncludeGPT55(t *testing.T) {
 	assertGPT55ModelInfo(t, "lookup", model)
 }
 
+func TestKiroStaticModelsIncludeClaudeOpus47Variants(t *testing.T) {
+	tests := []struct {
+		id          string
+		displayName string
+	}{
+		{
+			id:          "kiro-claude-opus-4-7",
+			displayName: "Kiro Claude Opus 4.7",
+		},
+		{
+			id:          "kiro-claude-opus-4-7-agentic",
+			displayName: "Kiro Claude Opus 4.7 (Agentic)",
+		},
+	}
+
+	kiroModels := GetKiroModels()
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			model := findModelInfo(kiroModels, tt.id)
+			if model == nil {
+				t.Fatalf("expected GetKiroModels to include %q", tt.id)
+			}
+			if model.DisplayName != tt.displayName {
+				t.Fatalf("display name mismatch for %q: got %q, want %q", tt.id, model.DisplayName, tt.displayName)
+			}
+			lookup := LookupStaticModelInfo(tt.id)
+			if lookup == nil {
+				t.Fatalf("expected LookupStaticModelInfo to find %q", tt.id)
+			}
+		})
+	}
+}
+
 func findModelInfo(models []*ModelInfo, id string) *ModelInfo {
 	for _, model := range models {
 		if model != nil && model.ID == id {

--- a/internal/runtime/executor/kiro_executor.go
+++ b/internal/runtime/executor/kiro_executor.go
@@ -1676,6 +1676,7 @@ func (e *KiroExecutor) mapModelToKiro(model string) string {
 		"amazonq-claude-sonnet-4-20250514":   "claude-sonnet-4",
 		"amazonq-claude-haiku-4-5":           "claude-haiku-4.5",
 		// Kiro format (kiro- prefix) - valid model names that should be preserved
+		"kiro-claude-opus-4-7":            "claude-opus-4.7",
 		"kiro-claude-opus-4-6":            "claude-opus-4.6",
 		"kiro-claude-sonnet-4-6":          "claude-sonnet-4.6",
 		"kiro-claude-opus-4-5":            "claude-opus-4.5",
@@ -1686,6 +1687,8 @@ func (e *KiroExecutor) mapModelToKiro(model string) string {
 		"kiro-claude-haiku-4-5":           "claude-haiku-4.5",
 		"kiro-auto":                       "auto",
 		// Native format (no prefix) - used by Kiro IDE directly
+		"claude-opus-4-7":            "claude-opus-4.7",
+		"claude-opus-4.7":            "claude-opus-4.7",
 		"claude-opus-4-6":            "claude-opus-4.6",
 		"claude-opus-4.6":            "claude-opus-4.6",
 		"claude-sonnet-4-6":          "claude-sonnet-4.6",
@@ -1701,6 +1704,8 @@ func (e *KiroExecutor) mapModelToKiro(model string) string {
 		"claude-sonnet-4-20250514":   "claude-sonnet-4",
 		"auto":                       "auto",
 		// Agentic variants (same backend model IDs, but with special system prompt)
+		"claude-opus-4.7-agentic":        "claude-opus-4.7",
+		"kiro-claude-opus-4-7-agentic":   "claude-opus-4.7",
 		"claude-opus-4.6-agentic":        "claude-opus-4.6",
 		"claude-sonnet-4.6-agentic":      "claude-sonnet-4.6",
 		"claude-opus-4.5-agentic":        "claude-opus-4.5",
@@ -1749,6 +1754,10 @@ func (e *KiroExecutor) mapModelToKiro(model string) string {
 
 	// Check for Opus variants
 	if strings.Contains(modelLower, "opus") {
+		if strings.Contains(modelLower, "4-7") || strings.Contains(modelLower, "4.7") {
+			log.Debugf("kiro: unknown Opus 4.7 model '%s', mapping to claude-opus-4.7", model)
+			return "claude-opus-4.7"
+		}
 		if strings.Contains(modelLower, "4-6") || strings.Contains(modelLower, "4.6") {
 			log.Debugf("kiro: unknown Opus 4.6 model '%s', mapping to claude-opus-4.6", model)
 			return "claude-opus-4.6"

--- a/internal/runtime/executor/kiro_executor_test.go
+++ b/internal/runtime/executor/kiro_executor_test.go
@@ -421,3 +421,51 @@ func TestEndpointAliases(t *testing.T) {
 		t.Errorf("unexpected number of aliases: got %d, want %d", len(endpointAliases), len(expectedAliases))
 	}
 }
+
+func TestMapModelToKiro_MapsClaudeOpus47Variants(t *testing.T) {
+	executor := &KiroExecutor{}
+	tests := []struct {
+		name     string
+		model    string
+		expected string
+	}{
+		{
+			name:     "kiro alias",
+			model:    "kiro-claude-opus-4-7",
+			expected: "claude-opus-4.7",
+		},
+		{
+			name:     "kiro agentic alias",
+			model:    "kiro-claude-opus-4-7-agentic",
+			expected: "claude-opus-4.7",
+		},
+		{
+			name:     "native hyphen alias",
+			model:    "claude-opus-4-7",
+			expected: "claude-opus-4.7",
+		},
+		{
+			name:     "native dotted alias",
+			model:    "claude-opus-4.7",
+			expected: "claude-opus-4.7",
+		},
+		{
+			name:     "native agentic alias",
+			model:    "claude-opus-4.7-agentic",
+			expected: "claude-opus-4.7",
+		},
+		{
+			name:     "unknown opus 4.7 fallback",
+			model:    "partner-opus-4.7-preview",
+			expected: "claude-opus-4.7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := executor.mapModelToKiro(tt.model); got != tt.expected {
+				t.Fatalf("mapModelToKiro(%q) = %q, want %q", tt.model, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `kiro-claude-opus-4-7` → `claude-opus-4.7` mapping (plus the `-agentic` variant and native `claude-opus-4-7` / `claude-opus-4.7` aliases) in `mapModelToKiro`
- Add a 4.7 branch to the opus pattern fallback so unknown 4.7 variants no longer silently downgrade to `claude-opus-4.5`
- Register `kiro-claude-opus-4-7` (and its agentic variant) in the static `GetKiroModels` catalog so the model surfaces in `/v1/models` with correct metadata

Without this, requests for `kiro-claude-opus-4-7` hit the smart fallback in `mapModelToKiro` and get routed to `claude-opus-4.5`, because the Opus version detector only knew about `4-6`/`4.6`.

## Test plan

- [ ] `go build ./...`
- [ ] Unit/integration coverage for `mapModelToKiro` with `kiro-claude-opus-4-7` and `kiro-claude-opus-4-7-agentic` inputs
- [ ] Smoke test: chat completion request with `model: kiro-claude-opus-4-7` reaches the Kiro backend as `claude-opus-4.7`
- [ ] `/v1/models` lists `kiro-claude-opus-4-7` and `kiro-claude-opus-4-7-agentic`