### PR TITLE
ci(docker): publish official Docker Hub image

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,8 +17,8 @@ go.sum merge=union
 .gitattributes merge=ours
 README-ccs-fork.md merge=ours
 
-# Image references diverge from upstream (Plus publishes to
-# ghcr.io/kaitranntt/cli-proxy-api-plus, upstream publishes to
+# Image references diverge from upstream (Plus publishes official images to
+# kaitranntt/cli-proxy-api-plus with a GHCR mirror; upstream publishes to
 # eceasy/cli-proxy-api). Keep ours so upstream sync does not silently revert
 # the image path back to upstream's.
 docker-compose.yml merge=ours

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,6 +1,6 @@
 name: docker-image
 
-# Builds and publishes the multi-arch Docker image for CLIProxyAPIPlus to GHCR.
+# Builds and publishes the multi-arch Docker image for CLIProxyAPIPlus.
 #
 # Triggers:
 #   - push of any v* tag (works when a PAT pushes the tag; sync-release-tag.yml
@@ -11,8 +11,10 @@ name: docker-image
 # Runner: self-hosted `cliproxy` (docker host LXC). QEMU + buildx produce both
 # linux/amd64 and linux/arm64 from a single x64 host.
 #
-# Registry: ghcr.io/<owner>/cli-proxy-api-plus. Auth uses the built-in
-# GITHUB_TOKEN — no Docker Hub credentials required.
+# Registries:
+#   - GHCR: ghcr.io/<owner>/cli-proxy-api-plus using built-in GITHUB_TOKEN
+#   - Docker Hub: kaitranntt/cli-proxy-api-plus when DOCKERHUB_TOKEN is
+#     configured (DOCKERHUB_USERNAME is optional; defaults to kaitranntt)
 
 on:
   workflow_dispatch:
@@ -27,8 +29,9 @@ on:
 
 env:
   APP_NAME: CLIProxyAPI
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/cli-proxy-api-plus
+  GHCR_REGISTRY: ghcr.io
+  GHCR_IMAGE_NAME: ${{ github.repository_owner }}/cli-proxy-api-plus
+  DOCKERHUB_IMAGE_NAME: kaitranntt/cli-proxy-api-plus
 
 permissions:
   contents: read
@@ -71,16 +74,38 @@ jobs:
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Lowercase image name
+      - name: Detect Docker Hub credentials
+        id: dockerhub
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -n "${DOCKERHUB_TOKEN}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Login to Docker Hub
+        if: steps.dockerhub.outputs.enabled == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME || 'kaitranntt' }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Lowercase image names
         id: img
         run: |
-          IMG="${REGISTRY}/${IMAGE_NAME}"
-          IMG_LC="$(echo "${IMG}" | tr '[:upper:]' '[:lower:]')"
-          echo "ref=${IMG_LC}" >> "$GITHUB_OUTPUT"
+          GHCR_IMG="${GHCR_REGISTRY}/${GHCR_IMAGE_NAME}"
+          GHCR_IMG_LC="$(echo "${GHCR_IMG}" | tr '[:upper:]' '[:lower:]')"
+          DOCKERHUB_IMG_LC="$(echo "${DOCKERHUB_IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
+          {
+            echo "ghcr_ref=${GHCR_IMG_LC}"
+            echo "dockerhub_ref=${DOCKERHUB_IMG_LC}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build metadata
         id: meta
@@ -94,6 +119,25 @@ jobs:
             echo "build_date=${BUILD_DATE}"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Build tag list
+        id: tags
+        env:
+          GHCR_REF: ${{ steps.img.outputs.ghcr_ref }}
+          DOCKERHUB_REF: ${{ steps.img.outputs.dockerhub_ref }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          DOCKERHUB_ENABLED: ${{ steps.dockerhub.outputs.enabled }}
+        run: |
+          {
+            echo "tags<<EOF"
+            echo "${GHCR_REF}:${VERSION}"
+            echo "${GHCR_REF}:latest"
+            if [ "${DOCKERHUB_ENABLED}" = "true" ]; then
+              echo "${DOCKERHUB_REF}:${VERSION}"
+              echo "${DOCKERHUB_REF}:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push (multi-arch)
         uses: docker/build-push-action@v6
         with:
@@ -104,16 +148,28 @@ jobs:
             VERSION=${{ steps.meta.outputs.version }}
             COMMIT=${{ steps.meta.outputs.commit }}
             BUILD_DATE=${{ steps.meta.outputs.build_date }}
-          tags: |
-            ${{ steps.img.outputs.ref }}:${{ steps.meta.outputs.version }}
-            ${{ steps.img.outputs.ref }}:latest
+          tags: ${{ steps.tags.outputs.tags }}
 
       - name: Summary
+        env:
+          GHCR_REF: ${{ steps.img.outputs.ghcr_ref }}
+          DOCKERHUB_REF: ${{ steps.img.outputs.dockerhub_ref }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          DOCKERHUB_ENABLED: ${{ steps.dockerhub.outputs.enabled }}
         run: |
           {
             echo "## Published"
-            echo "- \`${{ steps.img.outputs.ref }}:${{ steps.meta.outputs.version }}\`"
-            echo "- \`${{ steps.img.outputs.ref }}:latest\`"
-            echo
-            echo "Pull: \`docker pull ${{ steps.img.outputs.ref }}:${{ steps.meta.outputs.version }}\`"
+            echo "- \`${GHCR_REF}:${VERSION}\`"
+            echo "- \`${GHCR_REF}:latest\`"
+            if [ "${DOCKERHUB_ENABLED}" = "true" ]; then
+              echo "- \`${DOCKERHUB_REF}:${VERSION}\`"
+              echo "- \`${DOCKERHUB_REF}:latest\`"
+              echo
+              echo "Pull: \`docker pull ${DOCKERHUB_REF}:${VERSION}\`"
+            else
+              echo
+              echo "Docker Hub skipped: configure \`DOCKERHUB_TOKEN\` to publish \`${DOCKERHUB_REF}\`. Set \`DOCKERHUB_USERNAME\` only if the login account is not \`kaitranntt\`."
+              echo
+              echo "Pull: \`docker pull ${GHCR_REF}:${VERSION}\`"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -72,17 +72,23 @@ CLIProxyAPI Guides: [https://help.router-for.me/](https://help.router-for.me/)
 
 ### Run with Docker
 
-Multi-arch images (`linux/amd64`, `linux/arm64`) are published to GitHub Container Registry on every release tag.
+Multi-arch images (`linux/amd64`, `linux/arm64`) are published to Docker Hub and GitHub Container Registry on every release tag.
 
 ```sh
 # Pull a specific version (recommended)
-docker pull ghcr.io/kaitranntt/cli-proxy-api-plus:v6.9.45-0
+docker pull kaitranntt/cli-proxy-api-plus:v6.9.45-0
 
 # Or pull the latest published release
+docker pull kaitranntt/cli-proxy-api-plus:latest
+```
+
+GHCR mirror:
+
+```sh
 docker pull ghcr.io/kaitranntt/cli-proxy-api-plus:latest
 ```
 
-Or use the included `docker-compose.yml` (defaults to the GHCR image, builds from source if `CLI_PROXY_IMAGE` is overridden):
+Or use the included `docker-compose.yml` (defaults to the Docker Hub image, builds from source if `CLI_PROXY_IMAGE` is overridden):
 
 ```sh
 git clone https://github.com/kaitranntt/CLIProxyAPIPlus.git
@@ -90,7 +96,9 @@ cd CLIProxyAPIPlus
 docker compose up -d
 ```
 
-Available tags: [`ghcr.io/kaitranntt/cli-proxy-api-plus`](https://github.com/kaitranntt/CLIProxyAPIPlus/pkgs/container/cli-proxy-api-plus).
+Available tags:
+- Docker Hub: [`kaitranntt/cli-proxy-api-plus`](https://hub.docker.com/r/kaitranntt/cli-proxy-api-plus)
+- GHCR: [`ghcr.io/kaitranntt/cli-proxy-api-plus`](https://github.com/kaitranntt/CLIProxyAPIPlus/pkgs/container/cli-proxy-api-plus)
 
 ## Management API
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -70,6 +70,36 @@ VisionCoder 还为我们的用户提供 <a href="https://coder.visioncoder.cn" t
 
 CLIProxyAPI 用户手册： [https://help.router-for.me/](https://help.router-for.me/cn/)
 
+### 使用 Docker 运行
+
+每个发布标签都会发布多架构镜像（`linux/amd64`、`linux/arm64`）到 Docker Hub 和 GitHub Container Registry。
+
+```sh
+# 拉取指定版本（推荐）
+docker pull kaitranntt/cli-proxy-api-plus:v6.9.45-0
+
+# 或拉取最新发布版本
+docker pull kaitranntt/cli-proxy-api-plus:latest
+```
+
+GHCR 镜像：
+
+```sh
+docker pull ghcr.io/kaitranntt/cli-proxy-api-plus:latest
+```
+
+也可以使用仓库内置的 `docker-compose.yml`（默认使用 Docker Hub 镜像；如需覆盖，可设置 `CLI_PROXY_IMAGE`）：
+
+```sh
+git clone https://github.com/kaitranntt/CLIProxyAPIPlus.git
+cd CLIProxyAPIPlus
+docker compose up -d
+```
+
+可用标签：
+- Docker Hub: [`kaitranntt/cli-proxy-api-plus`](https://hub.docker.com/r/kaitranntt/cli-proxy-api-plus)
+- GHCR: [`ghcr.io/kaitranntt/cli-proxy-api-plus`](https://github.com/kaitranntt/CLIProxyAPIPlus/pkgs/container/cli-proxy-api-plus)
+
 ## 管理 API 文档
 
 请参见 [MANAGEMENT_API_CN.md](https://help.router-for.me/cn/management/api)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   cli-proxy-api:
-    image: ${CLI_PROXY_IMAGE:-ghcr.io/kaitranntt/cli-proxy-api-plus:latest}
+    image: ${CLI_PROXY_IMAGE:-kaitranntt/cli-proxy-api-plus:latest}
     pull_policy: always
     build:
       context: .


### PR DESCRIPTION
## Summary

- publish the official Docker Hub image as `kaitranntt/cli-proxy-api-plus` when `DOCKERHUB_TOKEN` is configured
- keep GHCR publishing unchanged as a mirror and fallback
- make `docker-compose.yml` default to the official Docker Hub image
- document Docker Hub first in both English and Chinese READMEs

Refs #6

## Root Cause

PR #44 solved image publishing through GHCR, and PR #45 fixed the compose path to that GHCR image. The remaining user expectation is Docker Hub: the repo still had no official `kaitranntt/cli-proxy-api-plus` Docker Hub publication path, while the community-maintained `leic4u/cli-proxy-api-plus` image exists only as an external stopgap.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/docker-image.yml` | Adds optional Docker Hub login/push for `kaitranntt/cli-proxy-api-plus` while always preserving GHCR publishing. |
| `docker-compose.yml` | Defaults to `kaitranntt/cli-proxy-api-plus:latest`. |
| `README.md` / `README_CN.md` | Shows Docker Hub pull commands first and GHCR as the mirror. |
| `.gitattributes` | Updates the protected compose-file comment for the new official image path. |

## Validation

- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker-image.yml"); puts "yaml ok"'`
- [x] `git diff --check`
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "cliproxy" is unknown' .github/workflows/docker-image.yml`
- [x] `go build -o test-output ./cmd/server && rm test-output`
- [x] `go test ./...`

## Follow-up

- Add repository secret `DOCKERHUB_TOKEN` before triggering `docker-image.yml` for the first Docker Hub publish. `DOCKERHUB_USERNAME` is optional and defaults to `kaitranntt`.
