### PR TITLE
docs: document maintained dashboard fork default

### DIFF
--- a/.github/workflows/agents-md-guard.yml
+++ b/.github/workflows/agents-md-guard.yml
@@ -12,6 +12,9 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   close-when-agents-md-changed:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -28,6 +28,7 @@ on:
       - 'v*'
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   APP_NAME: CLIProxyAPI
   GHCR_REGISTRY: ghcr.io
   GHCR_IMAGE_NAME: ${{ github.repository_owner }}/cli-proxy-api-plus

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -6,6 +6,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,9 @@ concurrency:
   group: goreleaser-${{ inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-release-tag.yml
+++ b/.github/workflows/sync-release-tag.yml
@@ -15,6 +15,9 @@ concurrency:
   group: sync-release-tag
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -35,6 +35,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   TRACKING_ISSUE_LABEL: upstream-sync-blocked
   PR_LABEL: upstream-sync
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ see [MANAGEMENT_API.md](https://help.router-for.me/management/api)
 
 ## Usage Statistics
 
-Since v6.10.0, CLIProxyAPI and [CPAMC](https://github.com/router-for-me/Cli-Proxy-API-Management-Center) no longer ship built-in usage statistics. If you need usage statistics, use:
+Since v6.10.0, upstream CLIProxyAPI and [CPAMC](https://github.com/router-for-me/Cli-Proxy-API-Management-Center) no longer ship built-in usage statistics. CLIProxyAPIPlus preserves this workflow with its usage logger and the maintained [CPAMC dashboard fork](https://github.com/kaitranntt/Cli-Proxy-API-Management-Center), which is the default management panel release stream.
+
+If you need a separate external usage service, use:
 
 ### [CPA Usage Keeper](https://github.com/Willxup/cpa-usage-keeper)
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -106,7 +106,9 @@ docker compose up -d
 
 ## 使用量统计
 
-自v6.10.0版本以后，CLIProxyAPI及 [CPAMC](https://github.com/router-for-me/Cli-Proxy-API-Management-Center) 项目不再预置数据统计功能，如果有数据统计需求的请使用以下项目：
+自 v6.10.0 版本以后，上游 CLIProxyAPI 及 [CPAMC](https://github.com/router-for-me/Cli-Proxy-API-Management-Center) 项目不再预置数据统计功能。CLIProxyAPIPlus 会通过自身的使用量日志和维护版 [CPAMC dashboard fork](https://github.com/kaitranntt/Cli-Proxy-API-Management-Center) 保留该工作流，并默认使用这个管理面板发布源。
+
+如果需要独立的外部使用量服务，请使用以下项目：
 
 ### [CPA Usage Keeper](https://github.com/Willxup/cpa-usage-keeper)
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -74,7 +74,9 @@ CLIProxyAPIガイド：[https://help.router-for.me/](https://help.router-for.me/
 
 ## 使用量統計
 
-v6.10.0以降、CLIProxyAPIおよび [CPAMC](https://github.com/router-for-me/Cli-Proxy-API-Management-Center) プロジェクトには使用量統計機能がプリセットされなくなりました。使用量統計が必要な場合は、次のプロジェクトをご利用ください：
+v6.10.0以降、上流のCLIProxyAPIおよび [CPAMC](https://github.com/router-for-me/Cli-Proxy-API-Management-Center) プロジェクトには使用量統計機能がプリセットされなくなりました。CLIProxyAPIPlusでは、使用量ロガーとメンテナンス版の [CPAMC dashboard fork](https://github.com/kaitranntt/Cli-Proxy-API-Management-Center) により、このワークフローを維持し、この管理パネルのリリースをデフォルトで使用します。
+
+外部の独立した使用量サービスが必要な場合は、次のプロジェクトをご利用ください：
 
 ### [CPA Usage Keeper](https://github.com/Willxup/cpa-usage-keeper)
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -30,7 +30,7 @@ remote-management:
   # disable-auto-update-panel: false
 
   # GitHub repository for the management control panel. Accepts a repository URL or releases API URL.
-  panel-github-repository: 'https://github.com/router-for-me/Cli-Proxy-API-Management-Center'
+  panel-github-repository: 'https://github.com/kaitranntt/Cli-Proxy-API-Management-Center'
 
 # Authentication directory (supports ~ for home directory)
 auth-dir: '~/.cli-proxy-api'


### PR DESCRIPTION
## Summary
- point the sample management panel repository at the maintained CPAMC dashboard fork
- document that CLIProxyAPIPlus preserves usage statistics through its usage logger and maintained dashboard fork
- keep CPA Usage Keeper documented as an external alternative

## Validation
- `go test ./internal/config ./internal/managementasset`

Closes #53
