### PR TITLE
fix(codex): preserve fast service tier requests

### DIFF
--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -321,11 +321,27 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 	}
 	template, _ = sjson.SetBytes(template, "reasoning.effort", reasoningEffort)
 	template, _ = sjson.SetBytes(template, "reasoning.summary", "auto")
+	if serviceTier := normalizeCodexServiceTier(rootResult.Get("service_tier")); serviceTier != "" {
+		template, _ = sjson.SetBytes(template, "service_tier", serviceTier)
+	}
 	template, _ = sjson.SetBytes(template, "stream", true)
 	template, _ = sjson.SetBytes(template, "store", false)
 	template, _ = sjson.SetBytes(template, "include", []string{"reasoning.encrypted_content"})
 
 	return template
+}
+
+func normalizeCodexServiceTier(result gjson.Result) string {
+	if !result.Exists() || result.Type != gjson.String {
+		return ""
+	}
+
+	switch strings.ToLower(strings.TrimSpace(result.String())) {
+	case "fast", "priority":
+		return "priority"
+	default:
+		return ""
+	}
 }
 
 // isFernetLikeReasoningSignature checks only the encrypted_content envelope shape

--- a/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_test.go
@@ -136,6 +136,40 @@ func TestConvertClaudeRequestToCodex_ParallelToolCalls(t *testing.T) {
 	}
 }
 
+func TestConvertClaudeRequestToCodex_ServiceTier(t *testing.T) {
+	tests := []struct {
+		name        string
+		serviceTier string
+		want        string
+	}{
+		{name: "priority passes through", serviceTier: "priority", want: "priority"},
+		{name: "fast normalizes to priority", serviceTier: "fast", want: "priority"},
+		{name: "invalid tier is omitted", serviceTier: "default", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ConvertClaudeRequestToCodex("test-model", []byte(`{
+				"model": "claude-3-opus",
+				"service_tier": "`+tt.serviceTier+`",
+				"messages": [{"role": "user", "content": "hello"}]
+			}`), false)
+			resultJSON := gjson.ParseBytes(result)
+
+			if tt.want == "" {
+				if resultJSON.Get("service_tier").Exists() {
+					t.Fatalf("service_tier should be omitted. Output: %s", string(result))
+				}
+				return
+			}
+
+			if got := resultJSON.Get("service_tier").String(); got != tt.want {
+				t.Fatalf("service_tier = %q, want %q. Output: %s", got, tt.want, string(result))
+			}
+		})
+	}
+}
+
 func TestConvertClaudeRequestToCodex_ToolChoiceModeMapping(t *testing.T) {
 	tests := []struct {
 		name                string

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request.go
@@ -2,6 +2,7 @@ package responses
 
 import (
 	"fmt"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
@@ -27,7 +28,9 @@ func ConvertOpenAIResponsesRequestToCodex(modelName string, inputRawJSON []byte,
 	rawJSON, _ = sjson.DeleteBytes(rawJSON, "temperature")
 	rawJSON, _ = sjson.DeleteBytes(rawJSON, "top_p")
 	if v := gjson.GetBytes(rawJSON, "service_tier"); v.Exists() {
-		if v.String() != "priority" {
+		if serviceTier := normalizeCodexServiceTier(v); serviceTier != "" {
+			rawJSON, _ = sjson.SetBytes(rawJSON, "service_tier", serviceTier)
+		} else {
 			rawJSON, _ = sjson.DeleteBytes(rawJSON, "service_tier")
 		}
 	}
@@ -43,6 +46,19 @@ func ConvertOpenAIResponsesRequestToCodex(modelName string, inputRawJSON []byte,
 	rawJSON = normalizeCodexBuiltinTools(rawJSON)
 
 	return rawJSON
+}
+
+func normalizeCodexServiceTier(result gjson.Result) string {
+	if !result.Exists() || result.Type != gjson.String {
+		return ""
+	}
+
+	switch strings.ToLower(strings.TrimSpace(result.String())) {
+	case "fast", "priority":
+		return "priority"
+	default:
+		return ""
+	}
 }
 
 // applyResponsesCompactionCompatibility handles OpenAI Responses context_management.compaction

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
@@ -219,6 +219,41 @@ func TestConvertOpenAIResponsesRequestToCodex_OriginalIssue(t *testing.T) {
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToCodex_ServiceTier(t *testing.T) {
+	tests := []struct {
+		name        string
+		serviceTier string
+		want        string
+	}{
+		{name: "priority passes through", serviceTier: "priority", want: "priority"},
+		{name: "fast normalizes to priority", serviceTier: "fast", want: "priority"},
+		{name: "invalid tier is stripped", serviceTier: "default", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputJSON := []byte(`{
+				"model": "gpt-5.4",
+				"service_tier": "` + tt.serviceTier + `",
+				"input": "hello"
+			}`)
+
+			output := ConvertOpenAIResponsesRequestToCodex("gpt-5.4", inputJSON, false)
+
+			if tt.want == "" {
+				if gjson.GetBytes(output, "service_tier").Exists() {
+					t.Fatalf("service_tier should be stripped. Output: %s", string(output))
+				}
+				return
+			}
+
+			if got := gjson.GetBytes(output, "service_tier").String(); got != tt.want {
+				t.Fatalf("service_tier = %q, want %q. Output: %s", got, tt.want, string(output))
+			}
+		})
+	}
+}
+
 // TestConvertSystemRoleToDeveloper_AssistantRole tests that assistant role is preserved
 func TestConvertSystemRoleToDeveloper_AssistantRole(t *testing.T) {
 	inputJSON := []byte(`{


### PR DESCRIPTION
## Summary
- preserve Codex Claude-compatible `service_tier` requests through the translator
- normalize legacy `fast` service tier values to Codex's request value `priority`
- keep unsupported tiers omitted on Codex Responses compatibility

## Validation
- `go test ./internal/translator/codex/claude ./internal/translator/codex/openai/responses`
- `go build -o test-output ./cmd/server && rm test-output`

Related upstream issue: router-for-me/CLIProxyAPI#3276
Related CCS issue: kaitranntt/ccs#760
