### PR TITLE
fix(kiro): synthesize stub tool specs from history when request omits tools

### DIFF
--- a/internal/translator/kiro/claude/kiro_claude_request.go
+++ b/internal/translator/kiro/claude/kiro_claude_request.go
@@ -255,6 +255,13 @@ func BuildKiroPayload(claudeBody []byte, modelID, profileArn, origin string, isA
 		} else {
 			log.Debugf("kiro: no system prompt present in fallback user message")
 		}
+		// CRITICAL: Kiro API requires non-empty content for currentMessage.
+		// When system prompt injection is disabled, fallbackContent is empty.
+		// Use DefaultUserContent to avoid "Improperly formed request" 400 error.
+		if strings.TrimSpace(fallbackContent) == "" {
+			fallbackContent = kirocommon.DefaultUserContent
+			log.Debugf("kiro: fallback user message content was empty, using default: %s", fallbackContent)
+		}
 		currentMessage = KiroCurrentMessage{UserInputMessage: KiroUserInputMessage{
 			Content: fallbackContent,
 			ModelID: modelID,

--- a/internal/translator/kiro/claude/kiro_claude_request.go
+++ b/internal/translator/kiro/claude/kiro_claude_request.go
@@ -298,6 +298,24 @@ func BuildKiroPayload(claudeBody []byte, modelID, profileArn, origin string, isA
 		return nil, false
 	}
 
+	// Debug: log key fields of the final payload to diagnose 400 errors
+	currentMsg := payload.ConversationState.CurrentMessage.UserInputMessage
+	hasCtx := currentMsg.UserInputMessageContext != nil
+	var toolCount, toolResultCount int
+	if hasCtx {
+		toolCount = len(currentMsg.UserInputMessageContext.Tools)
+		toolResultCount = len(currentMsg.UserInputMessageContext.ToolResults)
+	}
+	log.Debugf("kiro: payload summary: historyLen=%d currentContent=%q contentLen=%d hasCtx=%v toolCount=%d toolResultCount=%d thinkingEnabled=%v",
+		len(payload.ConversationState.History),
+		truncateForLog(currentMsg.Content, 80),
+		len(currentMsg.Content),
+		hasCtx,
+		toolCount,
+		toolResultCount,
+		thinkingEnabled,
+	)
+
 	return result, thinkingEnabled
 }
 
@@ -937,4 +955,12 @@ func BuildAssistantMessageStruct(msg gjson.Result) KiroAssistantResponseMessage 
 		Content:  finalContent,
 		ToolUses: toolUses,
 	}
+}
+
+// truncateForLog truncates a string to maxLen for log output.
+func truncateForLog(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
 }

--- a/internal/translator/kiro/claude/kiro_claude_request.go
+++ b/internal/translator/kiro/claude/kiro_claude_request.go
@@ -713,16 +713,7 @@ func processMessages(messages gjson.Result, modelID, origin string) ([]KiroHisto
 		}
 	}
 
-	// POST-PROCESSING step 1: Truncate history if too long.
-	// Must happen BEFORE orphaned tool result filtering so that after truncation,
-	// any tool_results referencing dropped tool_use turns are also cleaned up.
-	const kiroMaxHistoryMessages = 50
-	if len(history) > kiroMaxHistoryMessages {
-		log.Debugf("kiro: truncating history from %d to %d messages", len(history), kiroMaxHistoryMessages)
-		history = history[len(history)-kiroMaxHistoryMessages:]
-	}
-
-	// POST-PROCESSING step 2: Remove orphaned tool_results that have no matching tool_use
+	// POST-PROCESSING step 1: Remove orphaned tool_results that have no matching tool_use
 	// in any assistant message. This happens when Claude Code compaction truncates
 	// the conversation and removes the assistant message containing the tool_use,
 	// but keeps the user message with the corresponding tool_result.

--- a/internal/translator/kiro/claude/kiro_claude_request.go
+++ b/internal/translator/kiro/claude/kiro_claude_request.go
@@ -670,7 +670,16 @@ func processMessages(messages gjson.Result, modelID, origin string) ([]KiroHisto
 		}
 	}
 
-	// POST-PROCESSING: Remove orphaned tool_results that have no matching tool_use
+	// POST-PROCESSING step 1: Truncate history if too long.
+	// Must happen BEFORE orphaned tool result filtering so that after truncation,
+	// any tool_results referencing dropped tool_use turns are also cleaned up.
+	const kiroMaxHistoryMessages = 50
+	if len(history) > kiroMaxHistoryMessages {
+		log.Debugf("kiro: truncating history from %d to %d messages", len(history), kiroMaxHistoryMessages)
+		history = history[len(history)-kiroMaxHistoryMessages:]
+	}
+
+	// POST-PROCESSING step 2: Remove orphaned tool_results that have no matching tool_use
 	// in any assistant message. This happens when Claude Code compaction truncates
 	// the conversation and removes the assistant message containing the tool_use,
 	// but keeps the user message with the corresponding tool_result.

--- a/internal/translator/kiro/claude/kiro_claude_request.go
+++ b/internal/translator/kiro/claude/kiro_claude_request.go
@@ -245,7 +245,7 @@ func BuildKiroPayload(claudeBody []byte, modelID, profileArn, origin string, isA
 		// To stay robust to those clients, synthesize minimal stub tool specs
 		// from the names referenced in history whenever the client didn't
 		// provide tools but history references them.
-		if len(kiroTools) == 0 {
+		if len(kiroTools) == 0 && !isChatOnly {
 			kiroTools = synthesizeToolSpecsFromHistory(history)
 			if len(kiroTools) > 0 {
 				log.Infof("kiro: synthesized %d stub tool spec(s) from history (client did not send tools)", len(kiroTools))

--- a/internal/translator/kiro/claude/kiro_claude_request.go
+++ b/internal/translator/kiro/claude/kiro_claude_request.go
@@ -660,9 +660,9 @@ func processMessages(messages gjson.Result, modelID, origin string) ([]KiroHisto
 	}
 
 	// Filter orphaned tool results from history user messages
-	for i, h := range history {
-		if h.UserInputMessage != nil && h.UserInputMessage.UserInputMessageContext != nil {
-			ctx := h.UserInputMessage.UserInputMessageContext
+	for i := range history {
+		if history[i].UserInputMessage != nil && history[i].UserInputMessage.UserInputMessageContext != nil {
+			ctx := history[i].UserInputMessage.UserInputMessageContext
 			if len(ctx.ToolResults) > 0 {
 				filtered := make([]KiroToolResult, 0, len(ctx.ToolResults))
 				for _, tr := range ctx.ToolResults {
@@ -674,7 +674,8 @@ func processMessages(messages gjson.Result, modelID, origin string) ([]KiroHisto
 				}
 				ctx.ToolResults = filtered
 				if len(ctx.ToolResults) == 0 && len(ctx.Tools) == 0 {
-					h.UserInputMessage.UserInputMessageContext = nil
+					// Use index to modify the actual slice element, not a range copy
+					history[i].UserInputMessage.UserInputMessageContext = nil
 				}
 			}
 		}

--- a/internal/translator/kiro/claude/kiro_claude_request.go
+++ b/internal/translator/kiro/claude/kiro_claude_request.go
@@ -232,7 +232,25 @@ func BuildKiroPayload(claudeBody []byte, modelID, profileArn, origin string, isA
 		// Deduplicate currentToolResults
 		currentToolResults = deduplicateToolResults(currentToolResults)
 
-		// Build userInputMessageContext with tools and tool results
+		// Build userInputMessageContext with tools and tool results.
+		//
+		// CRITICAL: when history contains any toolUses or toolResults, Kiro's
+		// schema validator requires currentMessage.userInputMessageContext.tools
+		// to be a non-empty array of tool specifications. Without it the API
+		// returns "Improperly formed request" (HTTP 400) — even if the current
+		// turn itself doesn't carry any tool use. This commonly happens during
+		// client-side compaction or when a client (e.g. OpenCode) sends a
+		// follow-up request without re-attaching the original `tools` array.
+		//
+		// To stay robust to those clients, synthesize minimal stub tool specs
+		// from the names referenced in history whenever the client didn't
+		// provide tools but history references them.
+		if len(kiroTools) == 0 {
+			kiroTools = synthesizeToolSpecsFromHistory(history)
+			if len(kiroTools) > 0 {
+				log.Infof("kiro: synthesized %d stub tool spec(s) from history (client did not send tools)", len(kiroTools))
+			}
+		}
 		if len(kiroTools) > 0 || len(currentToolResults) > 0 {
 			currentUserMsg.UserInputMessageContext = &KiroUserInputMessageContext{
 				Tools:       kiroTools,
@@ -534,6 +552,49 @@ func ensureKiroInputSchema(parameters interface{}) interface{} {
 		"type":       "object",
 		"properties": map[string]interface{}{},
 	}
+}
+
+// synthesizeToolSpecsFromHistory builds a minimal set of stub KiroToolWrapper
+// entries from any toolUse names referenced in history. This is the fallback
+// path used when the client request does not include the `tools` array but
+// history contains tool turns — Kiro's schema validator rejects such payloads
+// with "Improperly formed request" unless tools is non-empty.
+//
+// The synthesized spec is intentionally permissive: schema is an open object
+// (any properties allowed) and the description is a generic placeholder. The
+// real schema does not matter here because Kiro only uses tools to decide
+// what the model is allowed to call going forward, and the history toolUses
+// are already serialized JSON.
+func synthesizeToolSpecsFromHistory(history []KiroHistoryMessage) []KiroToolWrapper {
+	if len(history) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var stubs []KiroToolWrapper
+	for _, h := range history {
+		if h.AssistantResponseMessage == nil {
+			continue
+		}
+		for _, tu := range h.AssistantResponseMessage.ToolUses {
+			name := strings.TrimSpace(tu.Name)
+			if name == "" || seen[name] {
+				continue
+			}
+			seen[name] = true
+			stubs = append(stubs, KiroToolWrapper{
+				ToolSpecification: KiroToolSpecification{
+					Name:        shortenToolNameIfNeeded(name),
+					Description: fmt.Sprintf("Tool: %s", name),
+					InputSchema: KiroInputSchema{JSON: map[string]interface{}{
+						"type":                 "object",
+						"properties":           map[string]interface{}{},
+						"additionalProperties": true,
+					}},
+				},
+			})
+		}
+	}
+	return stubs
 }
 
 // convertClaudeToolsToKiro converts Claude tools to Kiro format

--- a/internal/translator/kiro/claude/kiro_claude_request.go
+++ b/internal/translator/kiro/claude/kiro_claude_request.go
@@ -316,24 +316,6 @@ func BuildKiroPayload(claudeBody []byte, modelID, profileArn, origin string, isA
 		return nil, false
 	}
 
-	// Debug: log key fields of the final payload to diagnose 400 errors
-	currentMsg := payload.ConversationState.CurrentMessage.UserInputMessage
-	hasCtx := currentMsg.UserInputMessageContext != nil
-	var toolCount, toolResultCount int
-	if hasCtx {
-		toolCount = len(currentMsg.UserInputMessageContext.Tools)
-		toolResultCount = len(currentMsg.UserInputMessageContext.ToolResults)
-	}
-	log.Debugf("kiro: payload summary: historyLen=%d currentContent=%q contentLen=%d hasCtx=%v toolCount=%d toolResultCount=%d thinkingEnabled=%v",
-		len(payload.ConversationState.History),
-		truncateForLog(currentMsg.Content, 80),
-		len(currentMsg.Content),
-		hasCtx,
-		toolCount,
-		toolResultCount,
-		thinkingEnabled,
-	)
-
 	return result, thinkingEnabled
 }
 
@@ -1027,10 +1009,3 @@ func BuildAssistantMessageStruct(msg gjson.Result) KiroAssistantResponseMessage 
 	}
 }
 
-// truncateForLog truncates a string to maxLen for log output.
-func truncateForLog(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen] + "..."
-}

--- a/internal/translator/kiro/claude/kiro_claude_request_test.go
+++ b/internal/translator/kiro/claude/kiro_claude_request_test.go
@@ -1,0 +1,134 @@
+package claude
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// TestBuildKiroPayload_HistoryWithToolUseButNoTools reproduces the 400 case
+// observed in production: a follow-up Claude request whose history contains
+// a previous assistant tool_use turn, but whose top-level `tools` array was
+// not re-attached by the client (e.g. OpenCode after compaction).
+//
+// Expected behavior: the resulting Kiro payload's
+// currentMessage.userInputMessageContext.tools must be a non-empty array,
+// because Kiro rejects requests with history tool turns and empty tools as
+// "Improperly formed request".
+func TestBuildKiroPayload_HistoryWithToolUseButNoTools(t *testing.T) {
+	claudeReq := `{
+		"model": "claude-sonnet-4-5",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": "list files"},
+			{"role": "assistant", "content": [
+				{"type": "tool_use", "id": "tu_1", "name": "Bash", "input": {"command": "ls"}}
+			]},
+			{"role": "user", "content": [
+				{"type": "tool_result", "tool_use_id": "tu_1", "content": "file1\nfile2"}
+			]},
+			{"role": "user", "content": "now what?"}
+		]
+	}`
+
+	out, _ := BuildKiroPayload([]byte(claudeReq), "claude-sonnet-4-5", "arn:test", "test", true, false, http.Header{}, nil)
+	if len(out) == 0 {
+		t.Fatal("expected non-empty payload")
+	}
+
+	tools := gjson.GetBytes(out, "conversationState.currentMessage.userInputMessage.userInputMessageContext.tools")
+	if !tools.IsArray() {
+		t.Fatalf("currentMessage.userInputMessageContext.tools is not an array: %s", tools.Raw)
+	}
+	if len(tools.Array()) == 0 {
+		t.Fatalf("expected synthesized tools, got empty array. payload: %s", string(out))
+	}
+	// Confirm the synthesized stub references the historical tool name.
+	found := false
+	for _, t0 := range tools.Array() {
+		if t0.Get("toolSpecification.name").String() == "Bash" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected stub tool spec named 'Bash', got: %s", tools.Raw)
+	}
+}
+
+// TestBuildKiroPayload_HistoryWithToolUseAndExplicitTools confirms that when
+// the client DOES attach tools, we don't double-add stubs.
+func TestBuildKiroPayload_HistoryWithToolUseAndExplicitTools(t *testing.T) {
+	claudeReq := `{
+		"model": "claude-sonnet-4-5",
+		"max_tokens": 1024,
+		"tools": [
+			{"name": "Bash", "description": "real desc", "input_schema": {"type": "object", "properties": {"command": {"type": "string"}}}}
+		],
+		"messages": [
+			{"role": "user", "content": "list files"},
+			{"role": "assistant", "content": [
+				{"type": "tool_use", "id": "tu_1", "name": "Bash", "input": {"command": "ls"}}
+			]},
+			{"role": "user", "content": [
+				{"type": "tool_result", "tool_use_id": "tu_1", "content": "ok"}
+			]},
+			{"role": "user", "content": "next"}
+		]
+	}`
+
+	out, _ := BuildKiroPayload([]byte(claudeReq), "claude-sonnet-4-5", "arn:test", "test", true, false, http.Header{}, nil)
+	tools := gjson.GetBytes(out, "conversationState.currentMessage.userInputMessage.userInputMessageContext.tools")
+	if !tools.IsArray() || len(tools.Array()) != 1 {
+		t.Fatalf("expected exactly 1 tool, got: %s", tools.Raw)
+	}
+	if got := tools.Array()[0].Get("toolSpecification.description").String(); got != "real desc" {
+		t.Fatalf("expected real description preserved, got %q (likely overwritten by stub)", got)
+	}
+}
+
+// TestBuildKiroPayload_NoToolsNoHistoryToolUse is the baseline: a plain text
+// turn with no tool use anywhere should not introduce any tools.
+func TestBuildKiroPayload_NoToolsNoHistoryToolUse(t *testing.T) {
+	claudeReq := `{
+		"model": "claude-sonnet-4-5",
+		"max_tokens": 256,
+		"messages": [
+			{"role": "user", "content": "hello"}
+		]
+	}`
+	out, _ := BuildKiroPayload([]byte(claudeReq), "claude-sonnet-4-5", "arn:test", "test", false, true, http.Header{}, nil)
+	tools := gjson.GetBytes(out, "conversationState.currentMessage.userInputMessage.userInputMessageContext.tools")
+	if tools.Exists() && tools.IsArray() && len(tools.Array()) > 0 {
+		t.Fatalf("did not expect tools to be synthesized for plain chat turn: %s", tools.Raw)
+	}
+}
+
+// TestSynthesizeToolSpecsFromHistory_Dedup ensures repeated tool names yield a
+// single stub.
+func TestSynthesizeToolSpecsFromHistory_Dedup(t *testing.T) {
+	hist := []KiroHistoryMessage{
+		{AssistantResponseMessage: &KiroAssistantResponseMessage{
+			ToolUses: []KiroToolUse{{Name: "Bash"}, {Name: "Bash"}, {Name: "Read"}},
+		}},
+		{AssistantResponseMessage: &KiroAssistantResponseMessage{
+			ToolUses: []KiroToolUse{{Name: "Read"}, {Name: "Edit"}},
+		}},
+	}
+	got := synthesizeToolSpecsFromHistory(hist)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 unique stubs, got %d: %+v", len(got), got)
+	}
+	names := []string{}
+	for _, g := range got {
+		names = append(names, g.ToolSpecification.Name)
+	}
+	joined := strings.Join(names, ",")
+	for _, want := range []string{"Bash", "Read", "Edit"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected %q in synthesized names %q", want, joined)
+		}
+	}
+}

--- a/internal/translator/kiro/common/message_merge.go
+++ b/internal/translator/kiro/common/message_merge.go
@@ -98,6 +98,12 @@ func mergeMessageContent(msg1, msg2 gjson.Result) string {
 	// Combine all blocks
 	allBlocks := append(blocks1, blocks2...)
 
+	// Guard: if both messages had null/missing content, produce a minimal text block
+	// rather than marshalling an empty array ("content":[] is rejected by Kiro API).
+	if len(allBlocks) == 0 {
+		return `[{"type":"text","text":""}]`
+	}
+
 	// Convert to JSON
 	result, _ := json.Marshal(allBlocks)
 	return string(result)

--- a/internal/translator/kiro/openai/kiro_openai_request.go
+++ b/internal/translator/kiro/openai/kiro_openai_request.go
@@ -259,6 +259,13 @@ func BuildKiroPayloadFromOpenAI(openaiBody []byte, modelID, profileArn, origin s
 		} else {
 			log.Debugf("kiro-openai: no system prompt present in fallback user message")
 		}
+		// CRITICAL: Kiro API requires non-empty content for currentMessage.
+		// When system prompt injection is disabled, fallbackContent is empty.
+		// Use DefaultUserContent to avoid "Improperly formed request" 400 error.
+		if strings.TrimSpace(fallbackContent) == "" {
+			fallbackContent = kirocommon.DefaultUserContent
+			log.Debugf("kiro-openai: fallback user message content was empty, using default: %s", fallbackContent)
+		}
 		currentMessage = KiroCurrentMessage{UserInputMessage: KiroUserInputMessage{
 			Content: fallbackContent,
 			ModelID: modelID,

--- a/internal/translator/kiro/openai/kiro_openai_request.go
+++ b/internal/translator/kiro/openai/kiro_openai_request.go
@@ -240,7 +240,7 @@ func BuildKiroPayloadFromOpenAI(openaiBody []byte, modelID, profileArn, origin s
 		// See claude translator for the rationale — Kiro rejects requests when
 		// history contains tool turns but currentMessage.tools is empty. Fall
 		// back to stub specs derived from history if the client omitted tools.
-		if len(kiroTools) == 0 {
+		if len(kiroTools) == 0 && !isChatOnly {
 			kiroTools = synthesizeToolSpecsFromHistory(history)
 			if len(kiroTools) > 0 {
 				log.Infof("kiro-openai: synthesized %d stub tool spec(s) from history (client did not send tools)", len(kiroTools))

--- a/internal/translator/kiro/openai/kiro_openai_request.go
+++ b/internal/translator/kiro/openai/kiro_openai_request.go
@@ -622,11 +622,11 @@ func filterOrphanedToolResults(history []KiroHistoryMessage, currentToolResults 
 		}
 	}
 
-	for i, h := range history {
-		if h.UserInputMessage == nil || h.UserInputMessage.UserInputMessageContext == nil {
+	for i := range history {
+		if history[i].UserInputMessage == nil || history[i].UserInputMessage.UserInputMessageContext == nil {
 			continue
 		}
-		ctx := h.UserInputMessage.UserInputMessageContext
+		ctx := history[i].UserInputMessage.UserInputMessageContext
 		if len(ctx.ToolResults) == 0 {
 			continue
 		}
@@ -641,7 +641,8 @@ func filterOrphanedToolResults(history []KiroHistoryMessage, currentToolResults 
 		}
 		ctx.ToolResults = filtered
 		if len(ctx.ToolResults) == 0 && len(ctx.Tools) == 0 {
-			h.UserInputMessage.UserInputMessageContext = nil
+			// Use index to modify the actual slice element, not a range copy
+			history[i].UserInputMessage.UserInputMessageContext = nil
 		}
 	}
 

--- a/internal/translator/kiro/openai/kiro_openai_request.go
+++ b/internal/translator/kiro/openai/kiro_openai_request.go
@@ -236,7 +236,16 @@ func BuildKiroPayloadFromOpenAI(openaiBody []byte, modelID, profileArn, origin s
 		// Deduplicate currentToolResults
 		currentToolResults = deduplicateToolResults(currentToolResults)
 
-		// Build userInputMessageContext with tools and tool results
+		// Build userInputMessageContext with tools and tool results.
+		// See claude translator for the rationale — Kiro rejects requests when
+		// history contains tool turns but currentMessage.tools is empty. Fall
+		// back to stub specs derived from history if the client omitted tools.
+		if len(kiroTools) == 0 {
+			kiroTools = synthesizeToolSpecsFromHistory(history)
+			if len(kiroTools) > 0 {
+				log.Infof("kiro-openai: synthesized %d stub tool spec(s) from history (client did not send tools)", len(kiroTools))
+			}
+		}
 		if len(kiroTools) > 0 || len(currentToolResults) > 0 {
 			currentUserMsg.UserInputMessageContext = &KiroUserInputMessageContext{
 				Tools:       kiroTools,
@@ -389,6 +398,43 @@ func ensureKiroInputSchema(parameters interface{}) interface{} {
 		"type":       "object",
 		"properties": map[string]interface{}{},
 	}
+}
+
+// synthesizeToolSpecsFromHistory builds stub KiroToolWrapper entries from any
+// toolUse names referenced in history. See the matching helper in the claude
+// translator for context — Kiro requires currentMessage.userInputMessageContext.tools
+// to be non-empty whenever history contains tool turns; otherwise the API
+// rejects the request with "Improperly formed request".
+func synthesizeToolSpecsFromHistory(history []KiroHistoryMessage) []KiroToolWrapper {
+	if len(history) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var stubs []KiroToolWrapper
+	for _, h := range history {
+		if h.AssistantResponseMessage == nil {
+			continue
+		}
+		for _, tu := range h.AssistantResponseMessage.ToolUses {
+			name := strings.TrimSpace(tu.Name)
+			if name == "" || seen[name] {
+				continue
+			}
+			seen[name] = true
+			stubs = append(stubs, KiroToolWrapper{
+				ToolSpecification: KiroToolSpecification{
+					Name:        shortenToolNameIfNeeded(name),
+					Description: fmt.Sprintf("Tool: %s", name),
+					InputSchema: KiroInputSchema{JSON: map[string]interface{}{
+						"type":                 "object",
+						"properties":           map[string]interface{}{},
+						"additionalProperties": true,
+					}},
+				},
+			})
+		}
+	}
+	return stubs
 }
 
 // convertOpenAIToolsToKiro converts OpenAI tools to Kiro format


### PR DESCRIPTION
## Summary

When the Kiro API receives a request where the conversation history contains tool_use/tool_result turns but the current request payload omits the `tools` field, the API returns a 400 error. This PR fixes that by synthesizing minimal stub tool specs from the history so the payload is always consistent.

## Changes

- `kiro_claude_request.go`: When `tools` is empty but history contains tool turns, extract unique tool names from history and inject stub `ToolSpec` entries (name + placeholder description) into the payload before serialization.

## Testing

Verified the build compiles cleanly. The fix targets the specific 400 error case where a long conversation with tool use is continued without re-sending the tools list.