### PR TITLE
fix: route codex hyphen thinking aliases

### DIFF
--- a/internal/thinking/suffix.go
+++ b/internal/thinking/suffix.go
@@ -43,6 +43,42 @@ func ParseSuffix(model string) SuffixResult {
 	}
 }
 
+// ParseHyphenSuffixAlias extracts legacy shorthand thinking suffixes from model names.
+//
+// The shorthand format is: model-name-value, where value is a valid thinking
+// level or special suffix. It is intentionally separate from ParseSuffix so
+// callers can first prove the base model is routable before treating the tail as
+// configuration instead of part of a custom model ID.
+func ParseHyphenSuffixAlias(model string) SuffixResult {
+	trimmed := strings.TrimSpace(model)
+	if trimmed == "" || ParseSuffix(trimmed).HasSuffix {
+		return SuffixResult{ModelName: model, HasSuffix: false}
+	}
+
+	lastDash := strings.LastIndex(trimmed, "-")
+	if lastDash <= 0 || lastDash >= len(trimmed)-1 {
+		return SuffixResult{ModelName: model, HasSuffix: false}
+	}
+
+	baseModel := strings.TrimSpace(trimmed[:lastDash])
+	rawSuffix := strings.ToLower(strings.TrimSpace(trimmed[lastDash+1:]))
+	if baseModel == "" || rawSuffix == "" {
+		return SuffixResult{ModelName: model, HasSuffix: false}
+	}
+
+	if _, ok := ParseSpecialSuffix(rawSuffix); !ok {
+		if _, ok := ParseLevelSuffix(rawSuffix); !ok {
+			return SuffixResult{ModelName: model, HasSuffix: false}
+		}
+	}
+
+	return SuffixResult{
+		ModelName: baseModel,
+		HasSuffix: true,
+		RawSuffix: rawSuffix,
+	}
+}
+
 // ParseNumericSuffix attempts to parse a raw suffix as a numeric budget value.
 //
 // This function parses the raw suffix content (from ParseSuffix.RawSuffix) as an integer.

--- a/internal/util/provider.go
+++ b/internal/util/provider.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -63,6 +64,24 @@ func GetProviderName(modelName string) []string {
 	}
 
 	return providers
+}
+
+// NormalizeRoutableThinkingAlias rewrites a known hyphen thinking alias such as
+// "gpt-5.5-high" to the canonical suffix form "gpt-5.5(high)".
+func NormalizeRoutableThinkingAlias(modelName string) string {
+	parsed := thinking.ParseHyphenSuffixAlias(modelName)
+	if !parsed.HasSuffix {
+		return modelName
+	}
+
+	baseModel := strings.TrimSpace(parsed.ModelName)
+	if baseModel == "" {
+		return modelName
+	}
+	if !strings.EqualFold(baseModel, "auto") && len(registry.GetGlobalRegistry().GetModelProviders(baseModel)) == 0 {
+		return modelName
+	}
+	return baseModel + "(" + parsed.RawSuffix + ")"
 }
 
 // ResolveAutoModel resolves the "auto" model name to an actual available model.

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -848,6 +848,7 @@ func statusFromError(err error) int {
 }
 
 func (h *BaseAPIHandler) getRequestDetails(modelName string) (providers []string, normalizedModel string, err *interfaces.ErrorMessage) {
+	modelName = util.NormalizeRoutableThinkingAlias(modelName)
 	resolvedModelName := modelName
 	initialSuffix := thinking.ParseSuffix(modelName)
 	if initialSuffix.ModelName == "auto" {

--- a/sdk/api/handlers/handlers_request_details_test.go
+++ b/sdk/api/handlers/handlers_request_details_test.go
@@ -22,9 +22,13 @@ func TestGetRequestDetails_PreservesSuffix(t *testing.T) {
 	})
 	modelRegistry.RegisterClient("test-request-details-openai", "openai", []*registry.ModelInfo{
 		{ID: "gpt-5.2", Created: now + 20},
+		{ID: "literal-high", Created: now + 15},
 	})
 	modelRegistry.RegisterClient("test-request-details-claude", "claude", []*registry.ModelInfo{
 		{ID: "claude-sonnet-4-5", Created: now + 5},
+	})
+	modelRegistry.RegisterClient("test-request-details-codex", "codex", []*registry.ModelInfo{
+		{ID: "gpt-5.5", Created: now + 10},
 	})
 
 	// Ensure cleanup of all test registrations.
@@ -32,6 +36,7 @@ func TestGetRequestDetails_PreservesSuffix(t *testing.T) {
 		"test-request-details-gemini",
 		"test-request-details-openai",
 		"test-request-details-claude",
+		"test-request-details-codex",
 	}
 	for _, clientID := range clientIDs {
 		id := clientID
@@ -64,10 +69,31 @@ func TestGetRequestDetails_PreservesSuffix(t *testing.T) {
 			wantErr:       false,
 		},
 		{
+			name:          "hyphen level alias canonicalized",
+			inputModel:    "gpt-5.5-high",
+			wantProviders: []string{"codex"},
+			wantModel:     "gpt-5.5(high)",
+			wantErr:       false,
+		},
+		{
+			name:          "hyphen xhigh alias lowercased",
+			inputModel:    "gpt-5.5-XHIGH",
+			wantProviders: []string{"codex"},
+			wantModel:     "gpt-5.5(xhigh)",
+			wantErr:       false,
+		},
+		{
 			name:          "no suffix unchanged",
 			inputModel:    "claude-sonnet-4-5",
 			wantProviders: []string{"claude"},
 			wantModel:     "claude-sonnet-4-5",
+			wantErr:       false,
+		},
+		{
+			name:          "registered model ending in high unchanged",
+			inputModel:    "literal-high",
+			wantProviders: []string{"openai"},
+			wantModel:     "literal-high",
 			wantErr:       false,
 		},
 		{

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -608,6 +608,7 @@ func (h *OpenAIResponsesAPIHandler) responsesWebsocketAvailableAuthsForModel(mod
 }
 
 func responsesWebsocketResolvedModelName(modelName string) string {
+	modelName = util.NormalizeRoutableThinkingAlias(modelName)
 	initialSuffix := thinking.ParseSuffix(modelName)
 	if initialSuffix.ModelName == "auto" {
 		resolvedBase := util.ResolveAutoModel(initialSuffix.ModelName)

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -81,6 +81,21 @@ type websocketPinnedFailoverStatusError struct {
 	msg    string
 }
 
+func TestResponsesWebsocketResolvedModelName_CanonicalizesHyphenThinkingAlias(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient("test-websocket-codex-alias", "codex", []*registry.ModelInfo{
+		{ID: "gpt-5.5", Created: time.Now().Unix()},
+	})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient("test-websocket-codex-alias")
+	})
+
+	got := responsesWebsocketResolvedModelName("gpt-5.5-high")
+	if got != "gpt-5.5(high)" {
+		t.Fatalf("responsesWebsocketResolvedModelName() = %q, want %q", got, "gpt-5.5(high)")
+	}
+}
+
 func (e websocketPinnedFailoverStatusError) Error() string { return e.msg }
 
 func (e websocketPinnedFailoverStatusError) StatusCode() int { return e.status }


### PR DESCRIPTION
## Summary

- canonicalize registered hyphen thinking aliases like `gpt-5.5-high` to `gpt-5.5(high)` before provider lookup
- keep existing parenthesized suffix behavior and avoid rewriting unknown/custom `-high` names without a registered base model
- apply the same canonicalization to Responses websocket model availability checks

Closes #70

## Tests

- `go test ./internal/thinking ./internal/util ./sdk/api/handlers ./sdk/api/handlers/openai`
- `go test ./...`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `git diff --check`
