### PR TITLE
fix: harden management auth and OAuth callbacks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,11 +16,16 @@ services:
       DEPLOY: ${DEPLOY:-}
     ports:
       - "8317:8317"
-      - "8085:8085"
-      - "1455:1455"
-      - "54545:54545"
-      - "51121:51121"
-      - "11451:11451"
+      # OAuth callback ports are host-loopback only so browser-based login
+      # works from Docker Compose without exposing callbacks on the LAN.
+      - "127.0.0.1:1455:1455"
+      - "127.0.0.1:8085:8085"
+      - "127.0.0.1:9876:9876"
+      - "127.0.0.1:11451:11451"
+      - "127.0.0.1:17171:17171"
+      - "127.0.0.1:51121:51121"
+      - "127.0.0.1:54545:54545"
+      - "127.0.0.1:56121:56121"
     volumes:
       - ${CLI_PROXY_CONFIG_PATH:-./config.yaml}:/CLIProxyAPI/config.yaml
       - ${CLI_PROXY_AUTH_PATH:-./auths}:/root/.cli-proxy-api

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -152,7 +152,7 @@ func startCallbackForwarder(port int, provider, targetBase string) (*callbackFor
 		stopForwarderInstance(port, prev)
 	}
 
-	addr := fmt.Sprintf("0.0.0.0:%d", port)
+	addr := fmt.Sprintf("%s:%d", callbackForwarderListenHost(), port)
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to listen on %s: %w", addr, err)
@@ -198,6 +198,33 @@ func startCallbackForwarder(port int, provider, targetBase string) (*callbackFor
 	log.Infof("callback forwarder for %s listening on %s", provider, addr)
 
 	return forwarder, nil
+}
+
+func callbackForwarderListenHost() string {
+	return callbackForwarderListenHostForRuntime(runningInContainer())
+}
+
+func callbackForwarderListenHostForRuntime(inContainer bool) string {
+	if inContainer || isTruthyEnv(os.Getenv("CLIPROXY_CALLBACK_FORWARDER_BIND_ALL")) {
+		return "0.0.0.0"
+	}
+	return "127.0.0.1"
+}
+
+func runningInContainer() bool {
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("DEPLOY")), "docker")
+}
+
+func isTruthyEnv(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func stopCallbackForwarderInstance(port int, forwarder *callbackForwarder) {

--- a/internal/api/handlers/management/auth_files_callback_forwarder_test.go
+++ b/internal/api/handlers/management/auth_files_callback_forwarder_test.go
@@ -1,0 +1,27 @@
+package management
+
+import "testing"
+
+func TestCallbackForwarderListenHostDefaultsToLoopback(t *testing.T) {
+	t.Setenv("CLIPROXY_CALLBACK_FORWARDER_BIND_ALL", "")
+
+	if got := callbackForwarderListenHostForRuntime(false); got != "127.0.0.1" {
+		t.Fatalf("listen host = %q, want loopback", got)
+	}
+}
+
+func TestCallbackForwarderListenHostAllowsDockerReachability(t *testing.T) {
+	t.Setenv("CLIPROXY_CALLBACK_FORWARDER_BIND_ALL", "")
+
+	if got := callbackForwarderListenHostForRuntime(true); got != "0.0.0.0" {
+		t.Fatalf("listen host = %q, want all interfaces in container", got)
+	}
+}
+
+func TestCallbackForwarderListenHostSupportsExplicitBindAll(t *testing.T) {
+	t.Setenv("CLIPROXY_CALLBACK_FORWARDER_BIND_ALL", "true")
+
+	if got := callbackForwarderListenHostForRuntime(false); got != "0.0.0.0" {
+		t.Fatalf("listen host = %q, want explicit all-interface bind", got)
+	}
+}

--- a/internal/api/modules/amp/routes.go
+++ b/internal/api/modules/amp/routes.go
@@ -127,20 +127,6 @@ func (m *AmpModule) managementAvailabilityMiddleware() gin.HandlerFunc {
 	}
 }
 
-// wrapManagementAuth skips auth for selected management paths while keeping authentication elsewhere.
-func wrapManagementAuth(auth gin.HandlerFunc, prefixes ...string) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		path := c.Request.URL.Path
-		for _, prefix := range prefixes {
-			if strings.HasPrefix(path, prefix) && (len(path) == len(prefix) || path[len(prefix)] == '/') {
-				c.Next()
-				return
-			}
-		}
-		auth(c)
-	}
-}
-
 // registerManagementRoutes registers Amp management proxy routes
 // These routes proxy through to the Amp control plane for OAuth, user management, etc.
 // Uses dynamic middleware and proxy getter for hot-reload support.
@@ -155,10 +141,8 @@ func (m *AmpModule) registerManagementRoutes(engine *gin.Engine, baseHandler *ha
 	ampAPI.Use(m.localhostOnlyMiddleware())
 
 	// Apply authentication middleware - requires valid API key in Authorization header
-	var authWithBypass gin.HandlerFunc
 	if auth != nil {
 		ampAPI.Use(auth)
-		authWithBypass = wrapManagementAuth(auth, "/threads", "/auth", "/docs", "/settings")
 	}
 
 	// Inject client API key into request context for per-client upstream routing
@@ -208,8 +192,8 @@ func (m *AmpModule) registerManagementRoutes(engine *gin.Engine, baseHandler *ha
 	// Root-level routes that AMP CLI expects without /api prefix
 	// These need the same security middleware as the /api/* routes (dynamic for hot-reload)
 	rootMiddleware := []gin.HandlerFunc{m.managementAvailabilityMiddleware(), noCORSMiddleware(), m.localhostOnlyMiddleware()}
-	if authWithBypass != nil {
-		rootMiddleware = append(rootMiddleware, authWithBypass)
+	if auth != nil {
+		rootMiddleware = append(rootMiddleware, auth)
 	}
 	// Add clientAPIKeyMiddleware after auth for per-client upstream routing
 	rootMiddleware = append(rootMiddleware, clientAPIKeyMiddleware())

--- a/internal/api/modules/amp/routes_test.go
+++ b/internal/api/modules/amp/routes_test.go
@@ -86,6 +86,77 @@ func TestRegisterManagementRoutes(t *testing.T) {
 	}
 }
 
+func TestRegisterManagementRoutes_RootRoutesRequireAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	m := &AmpModule{restrictToLocalhost: false}
+	mockProxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("proxied"))
+	}))
+	defer mockProxy.Close()
+
+	proxy, errProxy := createReverseProxy(mockProxy.URL, NewStaticSecretSource(""))
+	if errProxy != nil {
+		t.Fatalf("create proxy: %v", errProxy)
+	}
+	m.setProxy(proxy)
+
+	authCalls := 0
+	authMiddleware := func(c *gin.Context) {
+		authCalls++
+		if c.GetHeader("Authorization") != "Bearer test-key" {
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+		c.Next()
+	}
+
+	m.registerManagementRoutes(r, &handlers.BaseAPIHandler{}, authMiddleware)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	for _, path := range []string{"/threads", "/settings", "/docs", "/auth/cli-login"} {
+		t.Run(path, func(t *testing.T) {
+			authCalls = 0
+			unauthReq, errReq := http.NewRequest(http.MethodGet, srv.URL+path, nil)
+			if errReq != nil {
+				t.Fatalf("build unauth request: %v", errReq)
+			}
+			unauthResp, errDo := http.DefaultClient.Do(unauthReq)
+			if errDo != nil {
+				t.Fatalf("unauth request failed: %v", errDo)
+			}
+			defer unauthResp.Body.Close()
+			if unauthResp.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("unauth status = %d, want %d", unauthResp.StatusCode, http.StatusUnauthorized)
+			}
+			if authCalls != 1 {
+				t.Fatalf("auth calls for unauth = %d, want 1", authCalls)
+			}
+
+			authCalls = 0
+			authReq, errReq := http.NewRequest(http.MethodGet, srv.URL+path, nil)
+			if errReq != nil {
+				t.Fatalf("build auth request: %v", errReq)
+			}
+			authReq.Header.Set("Authorization", "Bearer test-key")
+			authResp, errDo := http.DefaultClient.Do(authReq)
+			if errDo != nil {
+				t.Fatalf("auth request failed: %v", errDo)
+			}
+			defer authResp.Body.Close()
+			if authResp.StatusCode != http.StatusOK {
+				t.Fatalf("auth status = %d, want %d", authResp.StatusCode, http.StatusOK)
+			}
+			if authCalls != 1 {
+				t.Fatalf("auth calls for auth = %d, want 1", authCalls)
+			}
+		})
+	}
+}
+
 func TestRegisterProviderAliases_AllProvidersRegistered(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1385,6 +1385,10 @@ func (s *Server) Stop(ctx context.Context) error {
 //   - gin.HandlerFunc: The CORS middleware handler
 func corsMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if strings.HasPrefix(c.Request.URL.Path, "/v0/management") {
+			c.Next()
+			return
+		}
 		c.Header("Access-Control-Allow-Origin", "*")
 		c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 		c.Header("Access-Control-Allow-Headers", "*")

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -161,6 +161,38 @@ func TestManagementUsageEndpointsRequireManagementAuthAndServePlusContracts(t *t
 	}
 }
 
+func TestCorsMiddlewareSkipsManagementRoutes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(corsMiddleware())
+	router.OPTIONS("/v0/management/config", func(c *gin.Context) {
+		c.Status(http.StatusUnauthorized)
+	})
+	router.OPTIONS("/v1/models", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	managementReq := httptest.NewRequest(http.MethodOptions, "/v0/management/config", nil)
+	managementRR := httptest.NewRecorder()
+	router.ServeHTTP(managementRR, managementReq)
+	if managementRR.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Fatalf("management CORS origin = %q, want empty", managementRR.Header().Get("Access-Control-Allow-Origin"))
+	}
+	if managementRR.Code != http.StatusUnauthorized {
+		t.Fatalf("management status = %d, want %d", managementRR.Code, http.StatusUnauthorized)
+	}
+
+	apiReq := httptest.NewRequest(http.MethodOptions, "/v1/models", nil)
+	apiRR := httptest.NewRecorder()
+	router.ServeHTTP(apiRR, apiReq)
+	if apiRR.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Fatalf("api CORS origin = %q, want *", apiRR.Header().Get("Access-Control-Allow-Origin"))
+	}
+	if apiRR.Code != http.StatusNoContent {
+		t.Fatalf("api status = %d, want %d", apiRR.Code, http.StatusNoContent)
+	}
+}
+
 func TestHomeEnabledHidesManagementEndpointsAndControlPanel(t *testing.T) {
 	t.Setenv("MANAGEMENT_PASSWORD", "test-management-key")
 

--- a/internal/auth/claude/oauth_server.go
+++ b/internal/auth/claude/oauth_server.go
@@ -87,7 +87,7 @@ func (s *OAuthServer) Start() error {
 	mux.HandleFunc("/success", s.handleSuccess)
 
 	s.server = &http.Server{
-		Addr:         fmt.Sprintf(":%d", s.port),
+		Addr:         fmt.Sprintf("localhost:%d", s.port),
 		Handler:      mux,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
@@ -309,7 +309,7 @@ func (s *OAuthServer) sendResult(result *OAuthResult) {
 // Returns:
 //   - bool: True if the port is available, false otherwise
 func (s *OAuthServer) isPortAvailable() bool {
-	addr := fmt.Sprintf(":%d", s.port)
+	addr := fmt.Sprintf("localhost:%d", s.port)
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return false

--- a/internal/auth/codex/oauth_server.go
+++ b/internal/auth/codex/oauth_server.go
@@ -84,7 +84,7 @@ func (s *OAuthServer) Start() error {
 	mux.HandleFunc("/success", s.handleSuccess)
 
 	s.server = &http.Server{
-		Addr:         fmt.Sprintf(":%d", s.port),
+		Addr:         fmt.Sprintf("localhost:%d", s.port),
 		Handler:      mux,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
@@ -306,7 +306,7 @@ func (s *OAuthServer) sendResult(result *OAuthResult) {
 // Returns:
 //   - bool: True if the port is available, false otherwise
 func (s *OAuthServer) isPortAvailable() bool {
-	addr := fmt.Sprintf(":%d", s.port)
+	addr := fmt.Sprintf("localhost:%d", s.port)
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return false

--- a/internal/auth/gemini/gemini_auth.go
+++ b/internal/auth/gemini/gemini_auth.go
@@ -223,7 +223,7 @@ func (g *GeminiAuth) getTokenFromWeb(ctx context.Context, config *oauth2.Config,
 
 	// Create a new HTTP server with its own multiplexer.
 	mux := http.NewServeMux()
-	server := &http.Server{Addr: fmt.Sprintf(":%d", callbackPort), Handler: mux}
+	server := &http.Server{Addr: fmt.Sprintf("localhost:%d", callbackPort), Handler: mux}
 	config.RedirectURL = callbackURL
 
 	mux.HandleFunc("/oauth2callback", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/auth/gitlab/gitlab.go
+++ b/internal/auth/gitlab/gitlab.go
@@ -163,7 +163,7 @@ func (s *OAuthServer) Start() error {
 	mux.HandleFunc("/auth/callback", s.handleCallback)
 
 	s.server = &http.Server{
-		Addr:         fmt.Sprintf(":%d", s.port),
+		Addr:         fmt.Sprintf("localhost:%d", s.port),
 		Handler:      mux,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
@@ -235,7 +235,7 @@ func (s *OAuthServer) sendResult(result *OAuthResult) {
 }
 
 func (s *OAuthServer) isPortAvailable() bool {
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", s.port))
+	listener, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", s.port))
 	if err != nil {
 		return false
 	}

--- a/internal/auth/iflow/oauth_server.go
+++ b/internal/auth/iflow/oauth_server.go
@@ -55,7 +55,7 @@ func (s *OAuthServer) Start() error {
 	mux.HandleFunc("/oauth2callback", s.handleCallback)
 
 	s.server = &http.Server{
-		Addr:         fmt.Sprintf(":%d", s.port),
+		Addr:         fmt.Sprintf("localhost:%d", s.port),
 		Handler:      mux,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
@@ -133,7 +133,7 @@ func (s *OAuthServer) sendResult(res *OAuthResult) {
 }
 
 func (s *OAuthServer) isPortAvailable() bool {
-	addr := fmt.Sprintf(":%d", s.port)
+	addr := fmt.Sprintf("localhost:%d", s.port)
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return false

--- a/internal/logging/request_logger.go
+++ b/internal/logging/request_logger.go
@@ -192,6 +192,45 @@ func cloneHeaders(headers map[string][]string) map[string][]string {
 	return out
 }
 
+func sanitizeHomeHeaders(headers map[string][]string) map[string][]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(headers))
+	for key, values := range headers {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		if isHomeSensitiveHeader(key) {
+			out[key] = []string{"[REDACTED]"}
+			continue
+		}
+		if values == nil {
+			out[key] = nil
+			continue
+		}
+		copied := make([]string, len(values))
+		copy(copied, values)
+		out[key] = copied
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func isHomeSensitiveHeader(key string) bool {
+	lowerKey := strings.ToLower(strings.TrimSpace(key))
+	switch lowerKey {
+	case "authorization", "proxy-authorization", "cookie", "set-cookie", "x-api-key", "x-goog-api-key":
+		return true
+	}
+	return strings.Contains(lowerKey, "api-key") ||
+		strings.Contains(lowerKey, "apikey") ||
+		strings.Contains(lowerKey, "token") ||
+		strings.Contains(lowerKey, "secret")
+}
+
 func (l *FileRequestLogger) forwardRequestLogToHome(ctx context.Context, headers map[string][]string, logText string) error {
 	if l == nil || !l.homeEnabled {
 		return nil
@@ -201,7 +240,7 @@ func (l *FileRequestLogger) forwardRequestLogToHome(ctx context.Context, headers
 		return nil
 	}
 	payload := homeRequestLogPayload{
-		Headers:    cloneHeaders(headers),
+		Headers:    sanitizeHomeHeaders(headers),
 		RequestLog: logText,
 	}
 	raw, errMarshal := json.Marshal(&payload)
@@ -1765,7 +1804,7 @@ func (w *homeStreamingLogWriter) Close() error {
 	}
 
 	payload := homeRequestLogPayload{
-		Headers:    cloneHeaders(w.requestHeaders),
+		Headers:    sanitizeHomeHeaders(w.requestHeaders),
 		RequestLog: buf.String(),
 	}
 	raw, errMarshal := json.Marshal(&payload)

--- a/internal/logging/request_logger_home_test.go
+++ b/internal/logging/request_logger_home_test.go
@@ -38,8 +38,11 @@ func TestFileRequestLogger_HomeEnabled_ForwardsWhenRequestLogEnabled(t *testing.
 	logger.SetHomeEnabled(true)
 
 	requestHeaders := map[string][]string{
-		"Content-Type":  {"application/json"},
-		"Authorization": {"Bearer secret"},
+		"Content-Type":   {"application/json"},
+		"Authorization":  {"Bearer secret"},
+		"Cookie":         {"session=secret"},
+		"X-Goog-Api-Key": {"goog-secret"},
+		"X-Custom-Token": {"custom-secret"},
 	}
 
 	errLog := logger.LogRequest(
@@ -85,11 +88,68 @@ func TestFileRequestLogger_HomeEnabled_ForwardsWhenRequestLogEnabled(t *testing.
 	if got.Headers == nil || got.Headers["Content-Type"][0] != "application/json" {
 		t.Fatalf("headers.content-type = %+v, want application/json", got.Headers["Content-Type"])
 	}
-	if got.Headers == nil || got.Headers["Authorization"][0] != "Bearer secret" {
-		t.Fatalf("headers.authorization = %+v, want Bearer secret", got.Headers["Authorization"])
+	if got.Headers == nil || got.Headers["Authorization"][0] != "[REDACTED]" {
+		t.Fatalf("headers.authorization = %+v, want redacted", got.Headers["Authorization"])
+	}
+	for _, key := range []string{"Cookie", "X-Goog-Api-Key", "X-Custom-Token"} {
+		if got.Headers[key][0] != "[REDACTED]" {
+			t.Fatalf("headers[%s] = %+v, want redacted", key, got.Headers[key])
+		}
+	}
+	if bytes.Contains(stub.pushed[0], []byte("Bearer secret")) || bytes.Contains(stub.pushed[0], []byte("session=secret")) {
+		t.Fatalf("home payload leaked sensitive header: %s", string(stub.pushed[0]))
 	}
 	if got.RequestLog == "" {
 		t.Fatalf("request_log empty, want non-empty")
+	}
+}
+
+func TestFileRequestLogger_HomeEnabled_RedactsStreamingHeaders(t *testing.T) {
+	original := currentHomeRequestLogClient
+	defer func() {
+		currentHomeRequestLogClient = original
+	}()
+
+	stub := &stubHomeRequestLogClient{heartbeatOK: true}
+	currentHomeRequestLogClient = func() homeRequestLogClient {
+		return stub
+	}
+
+	logger := NewFileRequestLogger(true, t.TempDir(), "", 0)
+	logger.SetHomeEnabled(true)
+
+	writer := newHomeStreamingLogWriter(
+		"/v1/chat/completions",
+		http.MethodPost,
+		map[string][]string{
+			"Authorization": {"Bearer stream-secret"},
+			"Content-Type":  {"application/json"},
+		},
+		[]byte(`{"stream":true}`),
+		"req-stream",
+	)
+	if errStatus := writer.WriteStatus(http.StatusOK, map[string][]string{"Content-Type": {"text/event-stream"}}); errStatus != nil {
+		t.Fatalf("WriteStatus error: %v", errStatus)
+	}
+	writer.WriteChunkAsync([]byte(`data: {"ok":true}`))
+	if errClose := writer.Close(); errClose != nil {
+		t.Fatalf("Close error: %v", errClose)
+	}
+
+	if len(stub.pushed) != 1 {
+		t.Fatalf("home pushed records = %d, want 1", len(stub.pushed))
+	}
+	if bytes.Contains(stub.pushed[0], []byte("Bearer stream-secret")) {
+		t.Fatalf("home streaming payload leaked authorization header: %s", string(stub.pushed[0]))
+	}
+	var got struct {
+		Headers map[string][]string `json:"headers"`
+	}
+	if errUnmarshal := json.Unmarshal(stub.pushed[0], &got); errUnmarshal != nil {
+		t.Fatalf("unmarshal payload: %v", errUnmarshal)
+	}
+	if got.Headers["Authorization"][0] != "[REDACTED]" {
+		t.Fatalf("headers.authorization = %+v, want redacted", got.Headers["Authorization"])
 	}
 }
 

--- a/internal/util/provider.go
+++ b/internal/util/provider.go
@@ -202,6 +202,7 @@ func MaskAuthorizationHeader(value string) string {
 //
 // Behavior by header key (case-insensitive):
 //   - "Authorization": Preserve the auth type prefix (e.g., "Bearer ") and mask only the credential part.
+//   - "Cookie", "Set-Cookie", and "Proxy-Authorization": Mask the entire value.
 //   - Headers containing "api-key": Mask the entire value using HideAPIKey.
 //   - Others: Return the original value unchanged.
 //
@@ -214,6 +215,10 @@ func MaskAuthorizationHeader(value string) string {
 func MaskSensitiveHeaderValue(key, value string) string {
 	lowerKey := strings.ToLower(strings.TrimSpace(key))
 	switch {
+	case lowerKey == "cookie",
+		lowerKey == "set-cookie",
+		lowerKey == "proxy-authorization":
+		return HideAPIKey(value)
 	case strings.Contains(lowerKey, "authorization"):
 		return MaskAuthorizationHeader(value)
 	case strings.Contains(lowerKey, "api-key"),

--- a/sdk/auth/antigravity.go
+++ b/sdk/auth/antigravity.go
@@ -229,7 +229,7 @@ func startAntigravityCallbackServer(port int) (*http.Server, int, <-chan callbac
 	if port <= 0 {
 		port = antigravity.CallbackPort
 	}
-	addr := fmt.Sprintf(":%d", port)
+	addr := fmt.Sprintf("localhost:%d", port)
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return nil, 0, nil, err


### PR DESCRIPTION
## Summary
- redact sensitive Home forwarded request headers in structured and text log payloads
- require management auth for Amp root routes and skip wildcard CORS on management endpoints
- keep OAuth callbacks loopback-scoped while preserving Docker Compose Web UI OAuth via host-loopback port publishes

Closes #78
Closes #80
Closes #81
Closes #82

## Validation
- `go test ./...`
- `go build -o test-output ./cmd/server && rm test-output`
- `git diff --check`

## Docs impact
Docs impact: minor
Action: updated `docker-compose.yml` inline callback port comments; no separate docs page needed because callback exposure is configured there.
