### PR TITLE
fix(kiro): map cache tokens to Claude/OpenAI usage fields

### DIFF
--- a/internal/runtime/executor/kiro_executor.go
+++ b/internal/runtime/executor/kiro_executor.go
@@ -96,6 +96,13 @@ func enqueueTranslatedSSE(out chan<- cliproxyexecutor.StreamChunk, chunk []byte)
 	out <- cliproxyexecutor.StreamChunk{Payload: append(bytes.Clone(chunk), '\n', '\n')}
 }
 
+// hasUpstreamInputUsage reports whether the upstream supplied any input-side
+// token counts (uncached, cache-read, or cache-write). Used to decide whether
+// to fall back to local estimation.
+func hasUpstreamInputUsage(u usage.Detail) bool {
+	return u.InputTokens > 0 || u.CacheReadTokens > 0 || u.CacheCreationTokens > 0
+}
+
 // retryConfig holds configuration for socket retry logic.
 // Based on kiro2Api Python implementation patterns.
 type retryConfig struct {
@@ -980,7 +987,7 @@ func (e *KiroExecutor) executeWithRetry(ctx context.Context, auth *cliproxyauth.
 			// Fallback for usage if missing from upstream
 
 			// 1. Estimate InputTokens if missing
-			if usageInfo.InputTokens == 0 {
+			if !hasUpstreamInputUsage(usageInfo) {
 				if enc, encErr := getTokenizer(req.Model); encErr == nil {
 					if inp, countErr := countOpenAIChatTokens(enc, opts.OriginalRequest); countErr == nil {
 						usageInfo.InputTokens = inp
@@ -1006,7 +1013,7 @@ func (e *KiroExecutor) executeWithRetry(ctx context.Context, auth *cliproxyauth.
 			}
 
 			// 3. Update TotalTokens
-			usageInfo.TotalTokens = usageInfo.InputTokens + usageInfo.OutputTokens
+			usageInfo.TotalTokens = usageInfo.InputTokens + usageInfo.OutputTokens + usageInfo.CacheReadTokens + usageInfo.CacheCreationTokens
 
 			appendAPIResponseChunk(ctx, e.cfg, []byte(content))
 			reporter.publish(ctx, usageInfo)
@@ -1844,13 +1851,14 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 				}
 				// cacheReadInputTokens - tokens read from cache
 				if cacheReadTokens, ok := tokenUsage["cacheReadInputTokens"].(float64); ok {
-					// Add to input tokens if we have uncached tokens, otherwise use as input
-					if usageInfo.InputTokens > 0 {
-						usageInfo.InputTokens += int64(cacheReadTokens)
-					} else {
-						usageInfo.InputTokens = int64(cacheReadTokens)
-					}
+					usageInfo.CacheReadTokens = int64(cacheReadTokens)
+					usageInfo.CachedTokens = int64(cacheReadTokens)
 					log.Debugf("kiro: parseEventStream found cacheReadInputTokens in tokenUsage: %d", int64(cacheReadTokens))
+				}
+				// cacheWriteInputTokens - tokens written to cache
+				if cacheWriteTokens, ok := tokenUsage["cacheWriteInputTokens"].(float64); ok {
+					usageInfo.CacheCreationTokens = int64(cacheWriteTokens)
+					log.Debugf("kiro: parseEventStream found cacheWriteInputTokens in tokenUsage: %d", int64(cacheWriteTokens))
 				}
 				// contextUsagePercentage - can be used as fallback for input token estimation
 				if ctxPct, ok := tokenUsage["contextUsagePercentage"].(float64); ok {
@@ -2103,7 +2111,7 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 	// Use contextUsagePercentage to calculate more accurate input tokens
 	// Kiro model has 200k max context, contextUsagePercentage represents the percentage used
 	// Formula: input_tokens = contextUsagePercentage * 200000 / 100
-	if upstreamContextPercentage > 0 {
+	if upstreamContextPercentage > 0 && !hasUpstreamInputUsage(usageInfo) {
 		calculatedInputTokens := int64(upstreamContextPercentage * 200000 / 100)
 		if calculatedInputTokens > 0 {
 			localEstimate := usageInfo.InputTokens
@@ -2114,6 +2122,10 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 		}
 	}
 
+	if usageInfo.CachedTokens == 0 {
+		usageInfo.CachedTokens = usageInfo.CacheCreationTokens
+	}
+	usageInfo.TotalTokens = usageInfo.InputTokens + usageInfo.OutputTokens + usageInfo.CacheReadTokens + usageInfo.CacheCreationTokens
 	return cleanedContent, toolUses, usageInfo, stopReason, nil
 }
 
@@ -2364,6 +2376,7 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 
 	// Pre-calculate input tokens from request if possible
 	// Kiro uses Claude format, so try Claude format first, then OpenAI format, then fallback
+	var estimatedInputTokens int64
 	if enc, err := getTokenizer(model); err == nil {
 		var inputTokens int64
 		var countMethod string
@@ -2385,9 +2398,9 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 			countMethod = "estimate"
 		}
 
-		totalUsage.InputTokens = inputTokens
+		estimatedInputTokens = inputTokens
 		log.Debugf("kiro: streamToChannel pre-calculated input tokens: %d (method: %s, claude body: %d bytes, original req: %d bytes)",
-			totalUsage.InputTokens, countMethod, len(claudeBody), len(originalReq))
+			estimatedInputTokens, countMethod, len(claudeBody), len(originalReq))
 	}
 
 	contentBlockIndex := -1
@@ -2514,7 +2527,7 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 
 		// Send message_start on first event
 		if !messageStartSent {
-			msgStart := kiroclaude.BuildClaudeMessageStartEvent(model, totalUsage.InputTokens)
+			msgStart := kiroclaude.BuildClaudeMessageStartEvent(model, estimatedInputTokens)
 			sseData := sdktranslator.TranslateStream(ctx, sdktranslator.FromString("kiro"), targetFormat, model, originalReq, claudeBody, msgStart, &translatorParam)
 			for _, chunk := range sseData {
 				enqueueTranslatedSSE(out, chunk)
@@ -3184,14 +3197,16 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 				}
 				// cacheReadInputTokens - tokens read from cache
 				if cacheReadTokens, ok := tokenUsage["cacheReadInputTokens"].(float64); ok {
-					// Add to input tokens if we have uncached tokens, otherwise use as input
-					if totalUsage.InputTokens > 0 {
-						totalUsage.InputTokens += int64(cacheReadTokens)
-					} else {
-						totalUsage.InputTokens = int64(cacheReadTokens)
-					}
+					totalUsage.CacheReadTokens = int64(cacheReadTokens)
+					totalUsage.CachedTokens = int64(cacheReadTokens)
 					hasUpstreamUsage = true
 					log.Debugf("kiro: streamToChannel found cacheReadInputTokens in tokenUsage: %d", int64(cacheReadTokens))
+				}
+				// cacheWriteInputTokens - tokens written to cache
+				if cacheWriteTokens, ok := tokenUsage["cacheWriteInputTokens"].(float64); ok {
+					totalUsage.CacheCreationTokens = int64(cacheWriteTokens)
+					hasUpstreamUsage = true
+					log.Debugf("kiro: streamToChannel found cacheWriteInputTokens in tokenUsage: %d", int64(cacheWriteTokens))
 				}
 				// contextUsagePercentage - can be used as fallback for input token estimation
 				if ctxPct, ok := tokenUsage["contextUsagePercentage"].(float64); ok {
@@ -3407,7 +3422,7 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 	// Kiro model has 200k max context, contextUsagePercentage represents the percentage used
 	// Formula: input_tokens = contextUsagePercentage * 200000 / 100
 	// Note: The effective input context is ~170k (200k - 30k reserved for output)
-	if upstreamContextPercentage > 0 {
+	if upstreamContextPercentage > 0 && !hasUpstreamInputUsage(totalUsage) {
 		// Calculate input tokens from context percentage
 		// Using 200k as the base since that's what Kiro reports against
 		calculatedInputTokens := int64(upstreamContextPercentage * 200000 / 100)
@@ -3421,8 +3436,14 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 				upstreamContextPercentage, calculatedInputTokens, localEstimate)
 		}
 	}
+	if !hasUpstreamInputUsage(totalUsage) && estimatedInputTokens > 0 {
+		totalUsage.InputTokens = estimatedInputTokens
+	}
 
-	totalUsage.TotalTokens = totalUsage.InputTokens + totalUsage.OutputTokens
+	if totalUsage.CachedTokens == 0 {
+		totalUsage.CachedTokens = totalUsage.CacheCreationTokens
+	}
+	totalUsage.TotalTokens = totalUsage.InputTokens + totalUsage.OutputTokens + totalUsage.CacheReadTokens + totalUsage.CacheCreationTokens
 
 	// Log upstream usage information if received
 	if hasUpstreamUsage {

--- a/internal/runtime/executor/kiro_executor.go
+++ b/internal/runtime/executor/kiro_executor.go
@@ -1852,7 +1852,6 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 				// cacheReadInputTokens - tokens read from cache
 				if cacheReadTokens, ok := tokenUsage["cacheReadInputTokens"].(float64); ok {
 					usageInfo.CacheReadTokens = int64(cacheReadTokens)
-					usageInfo.CachedTokens = int64(cacheReadTokens)
 					log.Debugf("kiro: parseEventStream found cacheReadInputTokens in tokenUsage: %d", int64(cacheReadTokens))
 				}
 				// cacheWriteInputTokens - tokens written to cache
@@ -2122,9 +2121,7 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 		}
 	}
 
-	if usageInfo.CachedTokens == 0 {
-		usageInfo.CachedTokens = usageInfo.CacheCreationTokens
-	}
+	usageInfo.CachedTokens = usageInfo.CacheReadTokens + usageInfo.CacheCreationTokens
 	usageInfo.TotalTokens = usageInfo.InputTokens + usageInfo.OutputTokens + usageInfo.CacheReadTokens + usageInfo.CacheCreationTokens
 	return cleanedContent, toolUses, usageInfo, stopReason, nil
 }
@@ -3198,7 +3195,6 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 				// cacheReadInputTokens - tokens read from cache
 				if cacheReadTokens, ok := tokenUsage["cacheReadInputTokens"].(float64); ok {
 					totalUsage.CacheReadTokens = int64(cacheReadTokens)
-					totalUsage.CachedTokens = int64(cacheReadTokens)
 					hasUpstreamUsage = true
 					log.Debugf("kiro: streamToChannel found cacheReadInputTokens in tokenUsage: %d", int64(cacheReadTokens))
 				}
@@ -3440,9 +3436,7 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 		totalUsage.InputTokens = estimatedInputTokens
 	}
 
-	if totalUsage.CachedTokens == 0 {
-		totalUsage.CachedTokens = totalUsage.CacheCreationTokens
-	}
+	totalUsage.CachedTokens = totalUsage.CacheReadTokens + totalUsage.CacheCreationTokens
 	totalUsage.TotalTokens = totalUsage.InputTokens + totalUsage.OutputTokens + totalUsage.CacheReadTokens + totalUsage.CacheCreationTokens
 
 	// Log upstream usage information if received

--- a/internal/runtime/executor/kiro_executor_test.go
+++ b/internal/runtime/executor/kiro_executor_test.go
@@ -1,12 +1,65 @@
 package executor
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
 	"testing"
 
 	kiroauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/kiro"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
+
+func TestKiroParseEventStreamMapsCacheUsageToClaudeSemantics(t *testing.T) {
+	executor := &KiroExecutor{}
+	body := bytes.NewReader(buildKiroEventStreamMessage(t, "messageMetadataEvent", []byte(`{"messageMetadataEvent":{"tokenUsage":{"outputTokens":4,"totalTokens":22048,"uncachedInputTokens":13,"cacheReadInputTokens":22000,"cacheWriteInputTokens":31,"contextUsagePercentage":99}}}`)))
+
+	_, _, gotUsage, _, err := executor.parseEventStream(body)
+	if err != nil {
+		t.Fatalf("parseEventStream() error = %v", err)
+	}
+
+	if gotUsage.InputTokens != 13 {
+		t.Fatalf("InputTokens = %d, want %d", gotUsage.InputTokens, 13)
+	}
+	if gotUsage.OutputTokens != 4 {
+		t.Fatalf("OutputTokens = %d, want %d", gotUsage.OutputTokens, 4)
+	}
+	if gotUsage.CacheReadTokens != 22000 {
+		t.Fatalf("CacheReadTokens = %d, want %d", gotUsage.CacheReadTokens, 22000)
+	}
+	if gotUsage.CacheCreationTokens != 31 {
+		t.Fatalf("CacheCreationTokens = %d, want %d", gotUsage.CacheCreationTokens, 31)
+	}
+	if gotUsage.TotalTokens != 22048 {
+		t.Fatalf("TotalTokens = %d, want %d", gotUsage.TotalTokens, 22048)
+	}
+}
+
+func buildKiroEventStreamMessage(t *testing.T, eventType string, payload []byte) []byte {
+	t.Helper()
+
+	var headers bytes.Buffer
+	headers.WriteByte(byte(len(":event-type")))
+	headers.WriteString(":event-type")
+	headers.WriteByte(7)
+	if err := binary.Write(&headers, binary.BigEndian, uint16(len(eventType))); err != nil {
+		t.Fatalf("write event type length: %v", err)
+	}
+	headers.WriteString(eventType)
+
+	headersBytes := headers.Bytes()
+	totalLength := uint32(12 + len(headersBytes) + len(payload) + 4)
+	message := make([]byte, 0, totalLength)
+	prelude := make([]byte, 12)
+	binary.BigEndian.PutUint32(prelude[0:4], totalLength)
+	binary.BigEndian.PutUint32(prelude[4:8], uint32(len(headersBytes)))
+	message = append(message, prelude...)
+	message = append(message, headersBytes...)
+	message = append(message, payload...)
+	message = append(message, 0, 0, 0, 0)
+	return message
+}
 
 func TestBuildKiroEndpointConfigs(t *testing.T) {
 	tests := []struct {

--- a/internal/translator/kiro/claude/kiro_claude_response.go
+++ b/internal/translator/kiro/claude/kiro_claude_response.go
@@ -107,8 +107,10 @@ func BuildClaudeResponse(content string, toolUses []KiroToolUse, model string, u
 		"content":     contentBlocks,
 		"stop_reason": stopReason,
 		"usage": map[string]interface{}{
-			"input_tokens":  usageInfo.InputTokens,
-			"output_tokens": usageInfo.OutputTokens,
+			"input_tokens":                usageInfo.InputTokens,
+			"output_tokens":               usageInfo.OutputTokens,
+			"cache_read_input_tokens":     usageInfo.CacheReadTokens,
+			"cache_creation_input_tokens": usageInfo.CacheCreationTokens,
 		},
 	}
 	result, _ := json.Marshal(response)

--- a/internal/translator/kiro/claude/kiro_claude_response_test.go
+++ b/internal/translator/kiro/claude/kiro_claude_response_test.go
@@ -1,0 +1,54 @@
+package claude
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+	"github.com/tidwall/gjson"
+)
+
+func TestBuildClaudeResponseIncludesCacheUsage(t *testing.T) {
+	response := BuildClaudeResponse("ok", nil, "kiro-claude", usage.Detail{
+		InputTokens:         13,
+		OutputTokens:        4,
+		CacheReadTokens:     22000,
+		CacheCreationTokens: 31,
+	}, "end_turn")
+
+	if got := gjson.GetBytes(response, "usage.input_tokens").Int(); got != 13 {
+		t.Fatalf("input_tokens = %d, want %d", got, 13)
+	}
+	if got := gjson.GetBytes(response, "usage.output_tokens").Int(); got != 4 {
+		t.Fatalf("output_tokens = %d, want %d", got, 4)
+	}
+	if got := gjson.GetBytes(response, "usage.cache_read_input_tokens").Int(); got != 22000 {
+		t.Fatalf("cache_read_input_tokens = %d, want %d", got, 22000)
+	}
+	if got := gjson.GetBytes(response, "usage.cache_creation_input_tokens").Int(); got != 31 {
+		t.Fatalf("cache_creation_input_tokens = %d, want %d", got, 31)
+	}
+}
+
+func TestBuildClaudeMessageDeltaEventIncludesCacheUsage(t *testing.T) {
+	event := BuildClaudeMessageDeltaEvent("end_turn", usage.Detail{
+		InputTokens:         13,
+		OutputTokens:        4,
+		CacheReadTokens:     22000,
+		CacheCreationTokens: 31,
+	})
+	data := []byte(strings.TrimSpace(strings.SplitN(string(event), "\ndata:", 2)[1]))
+
+	if got := gjson.GetBytes(data, "usage.input_tokens").Int(); got != 13 {
+		t.Fatalf("input_tokens = %d, want %d", got, 13)
+	}
+	if got := gjson.GetBytes(data, "usage.output_tokens").Int(); got != 4 {
+		t.Fatalf("output_tokens = %d, want %d", got, 4)
+	}
+	if got := gjson.GetBytes(data, "usage.cache_read_input_tokens").Int(); got != 22000 {
+		t.Fatalf("cache_read_input_tokens = %d, want %d", got, 22000)
+	}
+	if got := gjson.GetBytes(data, "usage.cache_creation_input_tokens").Int(); got != 31 {
+		t.Fatalf("cache_creation_input_tokens = %d, want %d", got, 31)
+	}
+}

--- a/internal/translator/kiro/claude/kiro_claude_stream.go
+++ b/internal/translator/kiro/claude/kiro_claude_stream.go
@@ -118,8 +118,10 @@ func BuildClaudeMessageDeltaEvent(stopReason string, usageInfo usage.Detail) []b
 			"stop_sequence": nil,
 		},
 		"usage": map[string]interface{}{
-			"input_tokens":  usageInfo.InputTokens,
-			"output_tokens": usageInfo.OutputTokens,
+			"input_tokens":                usageInfo.InputTokens,
+			"output_tokens":               usageInfo.OutputTokens,
+			"cache_read_input_tokens":     usageInfo.CacheReadTokens,
+			"cache_creation_input_tokens": usageInfo.CacheCreationTokens,
 		},
 	}
 	deltaResult, _ := json.Marshal(deltaEvent)

--- a/internal/translator/kiro/openai/kiro_openai.go
+++ b/internal/translator/kiro/openai/kiro_openai.go
@@ -144,12 +144,11 @@ func ConvertKiroStreamToOpenAI(ctx context.Context, model string, originalReques
 
 		// Extract usage if present
 		if eventJSON.Get("usage").Exists() {
-			inputTokens := eventJSON.Get("usage.input_tokens").Int()
-			outputTokens := eventJSON.Get("usage.output_tokens").Int()
 			usageInfo := usage.Detail{
-				InputTokens:  inputTokens,
-				OutputTokens: outputTokens,
-				TotalTokens:  inputTokens + outputTokens,
+				InputTokens:         eventJSON.Get("usage.input_tokens").Int(),
+				OutputTokens:        eventJSON.Get("usage.output_tokens").Int(),
+				CachedTokens:        eventJSON.Get("usage.cache_read_input_tokens").Int(),
+				CacheCreationTokens: eventJSON.Get("usage.cache_creation_input_tokens").Int(),
 			}
 			chunk := BuildOpenAISSEUsage(state, usageInfo)
 			results = append(results, []byte(chunk))
@@ -163,12 +162,11 @@ func ConvertKiroStreamToOpenAI(ctx context.Context, model string, originalReques
 	case "ping":
 		// Ping event with usage - optionally emit usage chunk
 		if eventJSON.Get("usage").Exists() {
-			inputTokens := eventJSON.Get("usage.input_tokens").Int()
-			outputTokens := eventJSON.Get("usage.output_tokens").Int()
 			usageInfo := usage.Detail{
-				InputTokens:  inputTokens,
-				OutputTokens: outputTokens,
-				TotalTokens:  inputTokens + outputTokens,
+				InputTokens:         eventJSON.Get("usage.input_tokens").Int(),
+				OutputTokens:        eventJSON.Get("usage.output_tokens").Int(),
+				CachedTokens:        eventJSON.Get("usage.cache_read_input_tokens").Int(),
+				CacheCreationTokens: eventJSON.Get("usage.cache_creation_input_tokens").Int(),
 			}
 			chunk := BuildOpenAISSEUsage(state, usageInfo)
 			results = append(results, []byte(chunk))
@@ -230,10 +228,12 @@ func ConvertKiroNonStreamToOpenAI(ctx context.Context, model string, originalReq
 
 	// Extract usage
 	usageInfo := usage.Detail{
-		InputTokens:  response.Get("usage.input_tokens").Int(),
-		OutputTokens: response.Get("usage.output_tokens").Int(),
+		InputTokens:         response.Get("usage.input_tokens").Int(),
+		OutputTokens:        response.Get("usage.output_tokens").Int(),
+		CachedTokens:        response.Get("usage.cache_read_input_tokens").Int(),
+		CacheCreationTokens: response.Get("usage.cache_creation_input_tokens").Int(),
 	}
-	usageInfo.TotalTokens = usageInfo.InputTokens + usageInfo.OutputTokens
+	usageInfo.TotalTokens = usageInfo.InputTokens + usageInfo.OutputTokens + usageInfo.CachedTokens + usageInfo.CacheCreationTokens
 
 	// Build OpenAI response with reasoning_content support
 	openaiResponse := BuildOpenAIResponseWithReasoning(content, reasoningContent, toolUses, model, usageInfo, stopReason)

--- a/internal/translator/kiro/openai/kiro_openai.go
+++ b/internal/translator/kiro/openai/kiro_openai.go
@@ -145,12 +145,13 @@ func ConvertKiroStreamToOpenAI(ctx context.Context, model string, originalReques
 		// Extract usage if present
 		if eventJSON.Get("usage").Exists() {
 			cacheReadTokens := eventJSON.Get("usage.cache_read_input_tokens").Int()
+			cacheCreationTokens := eventJSON.Get("usage.cache_creation_input_tokens").Int()
 			usageInfo := usage.Detail{
 				InputTokens:         eventJSON.Get("usage.input_tokens").Int(),
 				OutputTokens:        eventJSON.Get("usage.output_tokens").Int(),
-				CachedTokens:        cacheReadTokens,
+				CachedTokens:        cacheReadTokens + cacheCreationTokens,
 				CacheReadTokens:     cacheReadTokens,
-				CacheCreationTokens: eventJSON.Get("usage.cache_creation_input_tokens").Int(),
+				CacheCreationTokens: cacheCreationTokens,
 			}
 			chunk := BuildOpenAISSEUsage(state, usageInfo)
 			results = append(results, []byte(chunk))
@@ -165,12 +166,13 @@ func ConvertKiroStreamToOpenAI(ctx context.Context, model string, originalReques
 		// Ping event with usage - optionally emit usage chunk
 		if eventJSON.Get("usage").Exists() {
 			cacheReadTokens := eventJSON.Get("usage.cache_read_input_tokens").Int()
+			cacheCreationTokens := eventJSON.Get("usage.cache_creation_input_tokens").Int()
 			usageInfo := usage.Detail{
 				InputTokens:         eventJSON.Get("usage.input_tokens").Int(),
 				OutputTokens:        eventJSON.Get("usage.output_tokens").Int(),
-				CachedTokens:        cacheReadTokens,
+				CachedTokens:        cacheReadTokens + cacheCreationTokens,
 				CacheReadTokens:     cacheReadTokens,
-				CacheCreationTokens: eventJSON.Get("usage.cache_creation_input_tokens").Int(),
+				CacheCreationTokens: cacheCreationTokens,
 			}
 			chunk := BuildOpenAISSEUsage(state, usageInfo)
 			results = append(results, []byte(chunk))
@@ -232,14 +234,15 @@ func ConvertKiroNonStreamToOpenAI(ctx context.Context, model string, originalReq
 
 	// Extract usage
 	cacheReadTokens := response.Get("usage.cache_read_input_tokens").Int()
+	cacheCreationTokens := response.Get("usage.cache_creation_input_tokens").Int()
 	usageInfo := usage.Detail{
 		InputTokens:         response.Get("usage.input_tokens").Int(),
 		OutputTokens:        response.Get("usage.output_tokens").Int(),
-		CachedTokens:        cacheReadTokens,
+		CachedTokens:        cacheReadTokens + cacheCreationTokens,
 		CacheReadTokens:     cacheReadTokens,
-		CacheCreationTokens: response.Get("usage.cache_creation_input_tokens").Int(),
+		CacheCreationTokens: cacheCreationTokens,
 	}
-	usageInfo.TotalTokens = usageInfo.InputTokens + usageInfo.OutputTokens + usageInfo.CachedTokens + usageInfo.CacheCreationTokens
+	usageInfo.TotalTokens = usageInfo.InputTokens + usageInfo.OutputTokens + usageInfo.CacheReadTokens + usageInfo.CacheCreationTokens
 
 	// Build OpenAI response with reasoning_content support
 	openaiResponse := BuildOpenAIResponseWithReasoning(content, reasoningContent, toolUses, model, usageInfo, stopReason)

--- a/internal/translator/kiro/openai/kiro_openai.go
+++ b/internal/translator/kiro/openai/kiro_openai.go
@@ -144,10 +144,12 @@ func ConvertKiroStreamToOpenAI(ctx context.Context, model string, originalReques
 
 		// Extract usage if present
 		if eventJSON.Get("usage").Exists() {
+			cacheReadTokens := eventJSON.Get("usage.cache_read_input_tokens").Int()
 			usageInfo := usage.Detail{
 				InputTokens:         eventJSON.Get("usage.input_tokens").Int(),
 				OutputTokens:        eventJSON.Get("usage.output_tokens").Int(),
-				CachedTokens:        eventJSON.Get("usage.cache_read_input_tokens").Int(),
+				CachedTokens:        cacheReadTokens,
+				CacheReadTokens:     cacheReadTokens,
 				CacheCreationTokens: eventJSON.Get("usage.cache_creation_input_tokens").Int(),
 			}
 			chunk := BuildOpenAISSEUsage(state, usageInfo)
@@ -162,10 +164,12 @@ func ConvertKiroStreamToOpenAI(ctx context.Context, model string, originalReques
 	case "ping":
 		// Ping event with usage - optionally emit usage chunk
 		if eventJSON.Get("usage").Exists() {
+			cacheReadTokens := eventJSON.Get("usage.cache_read_input_tokens").Int()
 			usageInfo := usage.Detail{
 				InputTokens:         eventJSON.Get("usage.input_tokens").Int(),
 				OutputTokens:        eventJSON.Get("usage.output_tokens").Int(),
-				CachedTokens:        eventJSON.Get("usage.cache_read_input_tokens").Int(),
+				CachedTokens:        cacheReadTokens,
+				CacheReadTokens:     cacheReadTokens,
 				CacheCreationTokens: eventJSON.Get("usage.cache_creation_input_tokens").Int(),
 			}
 			chunk := BuildOpenAISSEUsage(state, usageInfo)
@@ -227,10 +231,12 @@ func ConvertKiroNonStreamToOpenAI(ctx context.Context, model string, originalReq
 	}
 
 	// Extract usage
+	cacheReadTokens := response.Get("usage.cache_read_input_tokens").Int()
 	usageInfo := usage.Detail{
 		InputTokens:         response.Get("usage.input_tokens").Int(),
 		OutputTokens:        response.Get("usage.output_tokens").Int(),
-		CachedTokens:        response.Get("usage.cache_read_input_tokens").Int(),
+		CachedTokens:        cacheReadTokens,
+		CacheReadTokens:     cacheReadTokens,
 		CacheCreationTokens: response.Get("usage.cache_creation_input_tokens").Int(),
 	}
 	usageInfo.TotalTokens = usageInfo.InputTokens + usageInfo.OutputTokens + usageInfo.CachedTokens + usageInfo.CacheCreationTokens

--- a/internal/translator/kiro/openai/kiro_openai_response.go
+++ b/internal/translator/kiro/openai/kiro_openai_response.go
@@ -91,7 +91,9 @@ func BuildOpenAIResponseWithReasoning(content, reasoningContent string, toolUses
 			"completion_tokens": usageInfo.OutputTokens,
 			"total_tokens":      promptTokens + usageInfo.OutputTokens,
 			"prompt_tokens_details": map[string]interface{}{
-				"cached_tokens": usageInfo.CachedTokens,
+				"cached_tokens":               usageInfo.CachedTokens,
+				"cache_read_input_tokens":     usageInfo.CacheReadTokens,
+				"cache_creation_input_tokens": usageInfo.CacheCreationTokens,
 			},
 		},
 	}
@@ -264,7 +266,9 @@ func BuildOpenAIStreamUsageChunk(model string, usageInfo usage.Detail) []byte {
 			"completion_tokens": usageInfo.OutputTokens,
 			"total_tokens":      promptTokens + usageInfo.OutputTokens,
 			"prompt_tokens_details": map[string]interface{}{
-				"cached_tokens": usageInfo.CachedTokens,
+				"cached_tokens":               usageInfo.CachedTokens,
+				"cache_read_input_tokens":     usageInfo.CacheReadTokens,
+				"cache_creation_input_tokens": usageInfo.CacheCreationTokens,
 			},
 		},
 	}

--- a/internal/translator/kiro/openai/kiro_openai_response.go
+++ b/internal/translator/kiro/openai/kiro_openai_response.go
@@ -29,7 +29,7 @@ func BuildOpenAIResponse(content string, toolUses []KiroToolUse, model string, u
 // reasoningContent is included as reasoning_content field in the message when present.
 // stopReason is passed from upstream; fallback logic applied if empty.
 func BuildOpenAIResponseWithReasoning(content, reasoningContent string, toolUses []KiroToolUse, model string, usageInfo usage.Detail, stopReason string) []byte {
-	promptTokens := usageInfo.InputTokens + usageInfo.CachedTokens + usageInfo.CacheCreationTokens
+	promptTokens := usageInfo.InputTokens + usageInfo.CacheReadTokens + usageInfo.CacheCreationTokens
 
 	// Build the message object
 	message := map[string]interface{}{
@@ -253,7 +253,7 @@ func BuildOpenAIStreamFinishChunk(model string, finishReason string) []byte {
 
 // BuildOpenAIStreamUsageChunk creates a chunk with usage information (optional, for stream_options.include_usage)
 func BuildOpenAIStreamUsageChunk(model string, usageInfo usage.Detail) []byte {
-	promptTokens := usageInfo.InputTokens + usageInfo.CachedTokens + usageInfo.CacheCreationTokens
+	promptTokens := usageInfo.InputTokens + usageInfo.CacheReadTokens + usageInfo.CacheCreationTokens
 
 	chunk := map[string]interface{}{
 		"id":      "chatcmpl-" + uuid.New().String()[:12],

--- a/internal/translator/kiro/openai/kiro_openai_response.go
+++ b/internal/translator/kiro/openai/kiro_openai_response.go
@@ -29,6 +29,8 @@ func BuildOpenAIResponse(content string, toolUses []KiroToolUse, model string, u
 // reasoningContent is included as reasoning_content field in the message when present.
 // stopReason is passed from upstream; fallback logic applied if empty.
 func BuildOpenAIResponseWithReasoning(content, reasoningContent string, toolUses []KiroToolUse, model string, usageInfo usage.Detail, stopReason string) []byte {
+	promptTokens := usageInfo.InputTokens + usageInfo.CachedTokens + usageInfo.CacheCreationTokens
+
 	// Build the message object
 	message := map[string]interface{}{
 		"role":    "assistant",
@@ -85,9 +87,12 @@ func BuildOpenAIResponseWithReasoning(content, reasoningContent string, toolUses
 			},
 		},
 		"usage": map[string]interface{}{
-			"prompt_tokens":     usageInfo.InputTokens,
+			"prompt_tokens":     promptTokens,
 			"completion_tokens": usageInfo.OutputTokens,
-			"total_tokens":      usageInfo.InputTokens + usageInfo.OutputTokens,
+			"total_tokens":      promptTokens + usageInfo.OutputTokens,
+			"prompt_tokens_details": map[string]interface{}{
+				"cached_tokens": usageInfo.CachedTokens,
+			},
 		},
 	}
 
@@ -246,6 +251,8 @@ func BuildOpenAIStreamFinishChunk(model string, finishReason string) []byte {
 
 // BuildOpenAIStreamUsageChunk creates a chunk with usage information (optional, for stream_options.include_usage)
 func BuildOpenAIStreamUsageChunk(model string, usageInfo usage.Detail) []byte {
+	promptTokens := usageInfo.InputTokens + usageInfo.CachedTokens + usageInfo.CacheCreationTokens
+
 	chunk := map[string]interface{}{
 		"id":      "chatcmpl-" + uuid.New().String()[:12],
 		"object":  "chat.completion.chunk",
@@ -253,9 +260,12 @@ func BuildOpenAIStreamUsageChunk(model string, usageInfo usage.Detail) []byte {
 		"model":   model,
 		"choices": []map[string]interface{}{},
 		"usage": map[string]interface{}{
-			"prompt_tokens":     usageInfo.InputTokens,
+			"prompt_tokens":     promptTokens,
 			"completion_tokens": usageInfo.OutputTokens,
-			"total_tokens":      usageInfo.InputTokens + usageInfo.OutputTokens,
+			"total_tokens":      promptTokens + usageInfo.OutputTokens,
+			"prompt_tokens_details": map[string]interface{}{
+				"cached_tokens": usageInfo.CachedTokens,
+			},
 		},
 	}
 

--- a/internal/translator/kiro/openai/kiro_openai_response_test.go
+++ b/internal/translator/kiro/openai/kiro_openai_response_test.go
@@ -1,0 +1,57 @@
+package openai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertKiroNonStreamToOpenAIIncludesCacheUsage(t *testing.T) {
+	rawResponse := []byte(`{"id":"msg_1","type":"message","role":"assistant","model":"kiro-claude","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":13,"output_tokens":4,"cache_read_input_tokens":22000,"cache_creation_input_tokens":31}}`)
+
+	out := ConvertKiroNonStreamToOpenAI(context.Background(), "kiro-claude", nil, nil, rawResponse, nil)
+
+	if got := gjson.GetBytes(out, "usage.prompt_tokens").Int(); got != 22044 {
+		t.Fatalf("prompt_tokens = %d, want %d", got, 22044)
+	}
+	if got := gjson.GetBytes(out, "usage.completion_tokens").Int(); got != 4 {
+		t.Fatalf("completion_tokens = %d, want %d", got, 4)
+	}
+	if got := gjson.GetBytes(out, "usage.total_tokens").Int(); got != 22048 {
+		t.Fatalf("total_tokens = %d, want %d", got, 22048)
+	}
+	if got := gjson.GetBytes(out, "usage.prompt_tokens_details.cached_tokens").Int(); got != 22000 {
+		t.Fatalf("cached_tokens = %d, want %d", got, 22000)
+	}
+}
+
+func TestConvertKiroStreamToOpenAIIncludesCacheUsage(t *testing.T) {
+	var param any
+	out := ConvertKiroStreamToOpenAI(
+		context.Background(),
+		"kiro-claude",
+		nil,
+		nil,
+		[]byte(`event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":13,"output_tokens":4,"cache_read_input_tokens":22000,"cache_creation_input_tokens":31}}`),
+		&param,
+	)
+
+	if len(out) != 2 {
+		t.Fatalf("len(out) = %d, want %d", len(out), 2)
+	}
+	usageChunk := out[1]
+	if got := gjson.GetBytes(usageChunk, "usage.prompt_tokens").Int(); got != 22044 {
+		t.Fatalf("prompt_tokens = %d, want %d", got, 22044)
+	}
+	if got := gjson.GetBytes(usageChunk, "usage.completion_tokens").Int(); got != 4 {
+		t.Fatalf("completion_tokens = %d, want %d", got, 4)
+	}
+	if got := gjson.GetBytes(usageChunk, "usage.total_tokens").Int(); got != 22048 {
+		t.Fatalf("total_tokens = %d, want %d", got, 22048)
+	}
+	if got := gjson.GetBytes(usageChunk, "usage.prompt_tokens_details.cached_tokens").Int(); got != 22000 {
+		t.Fatalf("cached_tokens = %d, want %d", got, 22000)
+	}
+}

--- a/internal/translator/kiro/openai/kiro_openai_response_test.go
+++ b/internal/translator/kiro/openai/kiro_openai_response_test.go
@@ -21,8 +21,8 @@ func TestConvertKiroNonStreamToOpenAIIncludesCacheUsage(t *testing.T) {
 	if got := gjson.GetBytes(out, "usage.total_tokens").Int(); got != 22048 {
 		t.Fatalf("total_tokens = %d, want %d", got, 22048)
 	}
-	if got := gjson.GetBytes(out, "usage.prompt_tokens_details.cached_tokens").Int(); got != 22000 {
-		t.Fatalf("cached_tokens = %d, want %d", got, 22000)
+	if got := gjson.GetBytes(out, "usage.prompt_tokens_details.cached_tokens").Int(); got != 22031 {
+		t.Fatalf("cached_tokens = %d, want %d", got, 22031)
 	}
 	if got := gjson.GetBytes(out, "usage.prompt_tokens_details.cache_read_input_tokens").Int(); got != 22000 {
 		t.Fatalf("cache_read_input_tokens = %d, want %d", got, 22000)
@@ -57,8 +57,8 @@ data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":
 	if got := gjson.GetBytes(usageChunk, "usage.total_tokens").Int(); got != 22048 {
 		t.Fatalf("total_tokens = %d, want %d", got, 22048)
 	}
-	if got := gjson.GetBytes(usageChunk, "usage.prompt_tokens_details.cached_tokens").Int(); got != 22000 {
-		t.Fatalf("cached_tokens = %d, want %d", got, 22000)
+	if got := gjson.GetBytes(usageChunk, "usage.prompt_tokens_details.cached_tokens").Int(); got != 22031 {
+		t.Fatalf("cached_tokens = %d, want %d", got, 22031)
 	}
 	if got := gjson.GetBytes(usageChunk, "usage.prompt_tokens_details.cache_read_input_tokens").Int(); got != 22000 {
 		t.Fatalf("cache_read_input_tokens = %d, want %d", got, 22000)

--- a/internal/translator/kiro/openai/kiro_openai_response_test.go
+++ b/internal/translator/kiro/openai/kiro_openai_response_test.go
@@ -24,6 +24,12 @@ func TestConvertKiroNonStreamToOpenAIIncludesCacheUsage(t *testing.T) {
 	if got := gjson.GetBytes(out, "usage.prompt_tokens_details.cached_tokens").Int(); got != 22000 {
 		t.Fatalf("cached_tokens = %d, want %d", got, 22000)
 	}
+	if got := gjson.GetBytes(out, "usage.prompt_tokens_details.cache_read_input_tokens").Int(); got != 22000 {
+		t.Fatalf("cache_read_input_tokens = %d, want %d", got, 22000)
+	}
+	if got := gjson.GetBytes(out, "usage.prompt_tokens_details.cache_creation_input_tokens").Int(); got != 31 {
+		t.Fatalf("cache_creation_input_tokens = %d, want %d", got, 31)
+	}
 }
 
 func TestConvertKiroStreamToOpenAIIncludesCacheUsage(t *testing.T) {
@@ -53,5 +59,11 @@ data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":
 	}
 	if got := gjson.GetBytes(usageChunk, "usage.prompt_tokens_details.cached_tokens").Int(); got != 22000 {
 		t.Fatalf("cached_tokens = %d, want %d", got, 22000)
+	}
+	if got := gjson.GetBytes(usageChunk, "usage.prompt_tokens_details.cache_read_input_tokens").Int(); got != 22000 {
+		t.Fatalf("cache_read_input_tokens = %d, want %d", got, 22000)
+	}
+	if got := gjson.GetBytes(usageChunk, "usage.prompt_tokens_details.cache_creation_input_tokens").Int(); got != 31 {
+		t.Fatalf("cache_creation_input_tokens = %d, want %d", got, 31)
 	}
 }

--- a/internal/translator/kiro/openai/kiro_openai_stream.go
+++ b/internal/translator/kiro/openai/kiro_openai_stream.go
@@ -116,6 +116,8 @@ func BuildOpenAISSEFinish(state *OpenAIStreamState, finishReason string) string 
 
 // BuildOpenAISSEUsage creates an SSE event with usage information
 func BuildOpenAISSEUsage(state *OpenAIStreamState, usageInfo usage.Detail) string {
+	promptTokens := usageInfo.InputTokens + usageInfo.CachedTokens + usageInfo.CacheCreationTokens
+
 	chunk := map[string]interface{}{
 		"id":      state.ResponseID,
 		"object":  "chat.completion.chunk",
@@ -123,9 +125,12 @@ func BuildOpenAISSEUsage(state *OpenAIStreamState, usageInfo usage.Detail) strin
 		"model":   state.Model,
 		"choices": []map[string]interface{}{},
 		"usage": map[string]interface{}{
-			"prompt_tokens":     usageInfo.InputTokens,
+			"prompt_tokens":     promptTokens,
 			"completion_tokens": usageInfo.OutputTokens,
-			"total_tokens":      usageInfo.InputTokens + usageInfo.OutputTokens,
+			"total_tokens":      promptTokens + usageInfo.OutputTokens,
+			"prompt_tokens_details": map[string]interface{}{
+				"cached_tokens": usageInfo.CachedTokens,
+			},
 		},
 	}
 	result, _ := json.Marshal(chunk)

--- a/internal/translator/kiro/openai/kiro_openai_stream.go
+++ b/internal/translator/kiro/openai/kiro_openai_stream.go
@@ -116,7 +116,7 @@ func BuildOpenAISSEFinish(state *OpenAIStreamState, finishReason string) string 
 
 // BuildOpenAISSEUsage creates an SSE event with usage information
 func BuildOpenAISSEUsage(state *OpenAIStreamState, usageInfo usage.Detail) string {
-	promptTokens := usageInfo.InputTokens + usageInfo.CachedTokens + usageInfo.CacheCreationTokens
+	promptTokens := usageInfo.InputTokens + usageInfo.CacheReadTokens + usageInfo.CacheCreationTokens
 
 	chunk := map[string]interface{}{
 		"id":      state.ResponseID,

--- a/internal/translator/kiro/openai/kiro_openai_stream.go
+++ b/internal/translator/kiro/openai/kiro_openai_stream.go
@@ -129,7 +129,9 @@ func BuildOpenAISSEUsage(state *OpenAIStreamState, usageInfo usage.Detail) strin
 			"completion_tokens": usageInfo.OutputTokens,
 			"total_tokens":      promptTokens + usageInfo.OutputTokens,
 			"prompt_tokens_details": map[string]interface{}{
-				"cached_tokens": usageInfo.CachedTokens,
+				"cached_tokens":               usageInfo.CachedTokens,
+				"cache_read_input_tokens":     usageInfo.CacheReadTokens,
+				"cache_creation_input_tokens": usageInfo.CacheCreationTokens,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Kiro upstream reports `cacheReadInputTokens` and `cacheWriteInputTokens` inside `tokenUsage`. Previously the executor folded the read tokens into `InputTokens` (double-counting prompt usage) and ignored the write tokens entirely, so downstream Claude/OpenAI clients never saw cache breakdowns.

This change maps them onto `usage.Detail.CacheReadTokens` / `CacheCreationTokens` (plus `CachedTokens` for OpenAI's `cached_tokens`) and surfaces the values in both translators.

## Changes

- **`internal/runtime/executor/kiro_executor.go`**
  - Parse `cacheReadInputTokens` and `cacheWriteInputTokens` into the dedicated `usage.Detail` fields in both `parseEventStream` and `streamToChannel`.
  - Local-estimation fallback now only runs when the upstream supplied no input-side tokens at all, via a new `hasUpstreamInputUsage` helper that replaces four copies of the same three-field zero check.
  - Pre-computed estimate is kept in a local `estimatedInputTokens` so it doesn't pollute the final usage when upstream values arrive.
  - `TotalTokens` consistently sums Input + Output + CacheRead + CacheCreation across all paths.
- **`internal/translator/kiro/claude/*`** — emit `cache_read_input_tokens` and `cache_creation_input_tokens` in the non-stream response and `message_delta` event.
- **`internal/translator/kiro/openai/*`** — read the Claude cache fields and emit `prompt_tokens_details.cached_tokens` plus a corrected `prompt_tokens` / `total_tokens` that include cache reads and writes.

## Tests

- `TestKiroParseEventStreamMapsCacheUsageToClaudeSemantics` — verifies upstream `tokenUsage` is mapped to the Claude-shaped fields without double counting.
- `TestBuildClaudeResponseIncludesCacheUsage` / `TestBuildClaudeMessageDeltaEventIncludesCacheUsage` — verify the Claude translator emits the cache fields.
- `TestConvertKiroNonStreamToOpenAIIncludesCacheUsage` / `TestConvertKiroStreamToOpenAIIncludesCacheUsage` — verify the OpenAI translator emits `prompt_tokens_details.cached_tokens` and the corrected aggregate counts.

## Verification

- `gofmt -w .`
- `go build -o cli-proxy-api ./cmd/server`
- `go test ./internal/runtime/executor/ ./internal/translator/kiro/...`