### PR TITLE
feat(kiro): reconstruct claude-shaped usage from credits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 cli-proxy-api
 /cliproxy
 /server
+cmd/server/server
 *.exe
 
 

--- a/internal/runtime/executor/helps/kiro_credit_pricing.go
+++ b/internal/runtime/executor/helps/kiro_credit_pricing.go
@@ -1,0 +1,207 @@
+// Package helps contains helper utilities for runtime executors.
+//
+// kiro_credit_pricing.go reverse-engineers a plausible token-level usage
+// breakdown (input / cache_creation / cache_read / output) from the credit
+// figure Kiro reports via meteringEvent, so the response presented to the
+// client looks like a normal Anthropic Claude usage object.
+//
+// Conversion rule:
+//
+//	target_usd = credits * $0.02 / discount      (discount = 0.1 → 1折)
+//
+// The reconstructed usage cost, evaluated at Anthropic's published per-MTok
+// prices, is forced to equal target_usd modulo rounding.
+package helps
+
+import (
+	"math"
+	"strings"
+	"sync"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+	log "github.com/sirupsen/logrus"
+)
+
+// kiroCreditPerUSD is the Kiro pricing rule: $20 = 1000 credits.
+// Inverted: 1 credit = $0.02.
+const (
+	kiroUSDPerCredit       = 0.02
+	kiroMaxContextTokens   = 200000
+	kiroPriceFallbackModel = "claude-opus-4.7"
+)
+
+// kiroModelPrice holds Anthropic per-million-token prices for one model.
+// All values are USD per token (already divided by 1e6).
+type kiroModelPrice struct {
+	Input      float64
+	CacheWrite float64 // 5m cache write
+	CacheRead  float64
+	Output     float64
+}
+
+// per converts a $/MTok value to $/token.
+func per(mtok float64) float64 { return mtok / 1_000_000.0 }
+
+// kiroPriceTable is keyed by the normalized backend model id produced by
+// KiroExecutor.mapModelToKiro (e.g. "claude-opus-4.7", "claude-sonnet-4.5").
+// Source: claude.com/pricing screenshot supplied by user (Opus 4.5/4.6/4.7
+// rows are taken verbatim from that screenshot — Anthropic has not published
+// these rows on the public API page, so this represents Kiro-internal pricing).
+var kiroPriceTable = map[string]kiroModelPrice{
+	"claude-opus-4.7": {Input: per(5), CacheWrite: per(6.25), CacheRead: per(0.50), Output: per(25)},
+	"claude-opus-4.6": {Input: per(5), CacheWrite: per(6.25), CacheRead: per(0.50), Output: per(25)},
+	"claude-opus-4.5": {Input: per(5), CacheWrite: per(6.25), CacheRead: per(0.50), Output: per(25)},
+	"claude-opus-4.1": {Input: per(15), CacheWrite: per(18.75), CacheRead: per(1.50), Output: per(75)},
+	"claude-opus-4":   {Input: per(15), CacheWrite: per(18.75), CacheRead: per(1.50), Output: per(75)},
+
+	"claude-sonnet-4.6": {Input: per(3), CacheWrite: per(3.75), CacheRead: per(0.30), Output: per(15)},
+	"claude-sonnet-4.5": {Input: per(3), CacheWrite: per(3.75), CacheRead: per(0.30), Output: per(15)},
+	"claude-sonnet-4":   {Input: per(3), CacheWrite: per(3.75), CacheRead: per(0.30), Output: per(15)},
+
+	"claude-haiku-4.5": {Input: per(1), CacheWrite: per(1.25), CacheRead: per(0.10), Output: per(5)},
+	"claude-haiku-3.5": {Input: per(0.80), CacheWrite: per(1), CacheRead: per(0.08), Output: per(4)},
+}
+
+var (
+	kiroPriceWarnedMu sync.Mutex
+	kiroPriceWarned   = map[string]struct{}{}
+)
+
+// lookupKiroPrice returns the price row for model, falling back to
+// kiroPriceFallbackModel when the model is unknown. Each unknown model is
+// warn-logged once per process.
+func lookupKiroPrice(model string) kiroModelPrice {
+	key := strings.ToLower(strings.TrimSpace(model))
+	if price, ok := kiroPriceTable[key]; ok {
+		return price
+	}
+	kiroPriceWarnedMu.Lock()
+	if _, seen := kiroPriceWarned[key]; !seen {
+		kiroPriceWarned[key] = struct{}{}
+		log.Warnf("kiro: no credit pricing entry for model %q, falling back to %s",
+			key, kiroPriceFallbackModel)
+	}
+	kiroPriceWarnedMu.Unlock()
+	return kiroPriceTable[kiroPriceFallbackModel]
+}
+
+// CreditPricingParams configures how credits are split into the four token
+// buckets. v1 keeps these as constants; the struct is exposed so future
+// configuration plumbing can override without touching the algorithm.
+type CreditPricingParams struct {
+	// Discount applied to Anthropic's published prices.
+	// 0.1 means "1折" — the user paid 10% of Anthropic's price.
+	Discount float64
+
+	// CacheReadRatio is the share of context tokens that should be reported as
+	// cache_read_input_tokens.
+	CacheReadRatio float64
+
+	// CacheCreationRatio is the share of context tokens that should be
+	// reported as cache_creation_input_tokens.
+	CacheCreationRatio float64
+	// The implicit raw-input ratio is 1 - CacheReadRatio - CacheCreationRatio.
+}
+
+// DefaultCreditPricingParams returns the v1 hardcoded defaults: 1折 discount
+// with an 80/5/15 cache-read / cache-creation / raw-input split.
+func DefaultCreditPricingParams() CreditPricingParams {
+	return CreditPricingParams{
+		Discount:           0.1,
+		CacheReadRatio:     0.80,
+		CacheCreationRatio: 0.05,
+	}
+}
+
+// ComputeUsageFromCredits reverse-engineers a usage.Detail from the credits
+// reported by Kiro and the upstream context-usage percentage.
+//
+// Inputs:
+//   - model: normalized backend id (e.g. "claude-opus-4.7"). Use
+//     KiroExecutor.mapModelToKiro before calling.
+//   - credits: meteringEvent.usage value (in credits, not USD).
+//   - contextPct: contextUsageEvent.contextUsagePercentage (0–1 in observed
+//     payloads, but values up to 100 are tolerated and treated as percent).
+//   - outputTokens: locally computed output tokens (kept as-is).
+//   - params: split parameters.
+//
+// Returns a usage.Detail where the dollar cost evaluated at Anthropic prices
+// equals credits * 0.02 / discount within rounding error.
+func ComputeUsageFromCredits(model string, credits, contextPct float64, outputTokens int64, params CreditPricingParams) usage.Detail {
+	// Defensive defaults: an unconfigured params struct collapses to all-input.
+	if params.Discount <= 0 {
+		params.Discount = 0.1
+	}
+	if params.CacheReadRatio < 0 {
+		params.CacheReadRatio = 0
+	}
+	if params.CacheCreationRatio < 0 {
+		params.CacheCreationRatio = 0
+	}
+	if params.CacheReadRatio+params.CacheCreationRatio > 1 {
+		params.CacheReadRatio = 0.80
+		params.CacheCreationRatio = 0.05
+	}
+
+	prices := lookupKiroPrice(model)
+
+	// Total dollar amount we need to "spend" at Anthropic prices so that
+	// applying the discount lands back at the credits the user paid.
+	targetUSD := credits * kiroUSDPerCredit / params.Discount
+
+	out := usage.Detail{OutputTokens: outputTokens}
+
+	// Output cost is fixed (we trust local tiktoken).
+	outCost := float64(outputTokens) * prices.Output
+	budget := targetUSD - outCost
+	if budget < 0 {
+		budget = 0
+	}
+
+	// Normalize contextPct: payloads are usually fractions (0.04 = 4%) but
+	// some logs show whole percent (3.99). Treat anything > 1 as percent.
+	pct := contextPct
+	if pct > 1 {
+		pct = pct / 100.0
+	}
+	if pct < 0 {
+		pct = 0
+	}
+
+	ctxTokens := pct * kiroMaxContextTokens
+
+	rIn := 1 - params.CacheReadRatio - params.CacheCreationRatio
+	rCw := params.CacheCreationRatio
+	rCr := params.CacheReadRatio
+
+	// Compute the unit cost of one "context token" given the desired ratios.
+	unit := rIn*prices.Input + rCw*prices.CacheWrite + rCr*prices.CacheRead
+
+	// All-input fallback when we cannot do the three-way split: either no
+	// context signal, or the price/ratio combination collapses to zero.
+	if ctxTokens <= 0 || unit <= 0 {
+		if prices.Input > 0 {
+			out.InputTokens = int64(math.Round(budget / prices.Input))
+		}
+		out.TotalTokens = out.InputTokens + out.OutputTokens
+		return out
+	}
+
+	k := budget / (ctxTokens * unit)
+
+	// Sanity warn — outside this band the pricing table or model mapping is
+	// likely wrong, but we still emit values so the response remains valid.
+	if k > 0 && (k < 1e-2 || k > 1e3) {
+		log.Warnf("kiro: credit→token scaling factor out of expected range "+
+			"(model=%s, credits=%.4f, ctxPct=%.4f, k=%.4g)",
+			model, credits, contextPct, k)
+	}
+
+	scaled := k * ctxTokens
+	out.InputTokens = int64(math.Round(scaled * rIn))
+	out.CacheCreationTokens = int64(math.Round(scaled * rCw))
+	out.CacheReadTokens = int64(math.Round(scaled * rCr))
+
+	out.TotalTokens = out.InputTokens + out.CacheCreationTokens + out.CacheReadTokens + out.OutputTokens
+	return out
+}

--- a/internal/runtime/executor/helps/kiro_credit_pricing.go
+++ b/internal/runtime/executor/helps/kiro_credit_pricing.go
@@ -89,10 +89,6 @@ func lookupKiroPrice(model string) kiroModelPrice {
 // buckets. v1 keeps these as constants; the struct is exposed so future
 // configuration plumbing can override without touching the algorithm.
 type CreditPricingParams struct {
-	// Discount applied to Anthropic's published prices.
-	// 0.1 means "1折" — the user paid 10% of Anthropic's price.
-	Discount float64
-
 	// CacheReadRatio is the share of context tokens that should be reported as
 	// cache_read_input_tokens.
 	CacheReadRatio float64
@@ -103,11 +99,10 @@ type CreditPricingParams struct {
 	// The implicit raw-input ratio is 1 - CacheReadRatio - CacheCreationRatio.
 }
 
-// DefaultCreditPricingParams returns the v1 hardcoded defaults: 1折 discount
-// with an 80/5/15 cache-read / cache-creation / raw-input split.
+// DefaultCreditPricingParams returns the v1 hardcoded defaults:
+// an 80/5/15 cache-read / cache-creation / raw-input split.
 func DefaultCreditPricingParams() CreditPricingParams {
 	return CreditPricingParams{
-		Discount:           0.1,
 		CacheReadRatio:     0.80,
 		CacheCreationRatio: 0.05,
 	}
@@ -126,12 +121,9 @@ func DefaultCreditPricingParams() CreditPricingParams {
 //   - params: split parameters.
 //
 // Returns a usage.Detail where the dollar cost evaluated at Anthropic prices
-// equals credits * 0.02 / discount within rounding error.
+// equals credits * 0.02 within rounding error.
 func ComputeUsageFromCredits(model string, credits, contextPct float64, outputTokens int64, params CreditPricingParams) usage.Detail {
 	// Defensive defaults: an unconfigured params struct collapses to all-input.
-	if params.Discount <= 0 {
-		params.Discount = 0.1
-	}
 	if params.CacheReadRatio < 0 {
 		params.CacheReadRatio = 0
 	}
@@ -145,9 +137,8 @@ func ComputeUsageFromCredits(model string, credits, contextPct float64, outputTo
 
 	prices := lookupKiroPrice(model)
 
-	// Total dollar amount we need to "spend" at Anthropic prices so that
-	// applying the discount lands back at the credits the user paid.
-	targetUSD := credits * kiroUSDPerCredit / params.Discount
+	// Target dollar amount at Anthropic's published prices.
+	targetUSD := credits * kiroUSDPerCredit
 
 	out := usage.Detail{OutputTokens: outputTokens}
 

--- a/internal/runtime/executor/helps/kiro_credit_pricing.go
+++ b/internal/runtime/executor/helps/kiro_credit_pricing.go
@@ -7,7 +7,7 @@
 //
 // Conversion rule:
 //
-//	target_usd = credits * $0.02 / discount      (discount = 0.1 → 1折)
+//	target_usd = credits * $0.02
 //
 // The reconstructed usage cost, evaluated at Anthropic's published per-MTok
 // prices, is forced to equal target_usd modulo rounding.

--- a/internal/runtime/executor/helps/kiro_credit_pricing_test.go
+++ b/internal/runtime/executor/helps/kiro_credit_pricing_test.go
@@ -32,7 +32,7 @@ func TestKiroCreditPricing_TypicalOpus47(t *testing.T) {
 	got := ComputeUsageFromCredits(model, credits, ctxPct, output, params)
 
 	prices := lookupKiroPrice(model)
-	target := credits * kiroUSDPerCredit / params.Discount // = 0.03694 USD
+	target := credits * kiroUSDPerCredit
 	actual := usdAt(prices, got.InputTokens, got.CacheCreationTokens, got.CacheReadTokens, got.OutputTokens)
 	if !approxEqualPct(actual, target, 0.01) {
 		t.Fatalf("cost mismatch: target=%.6f USD, actual=%.6f USD, detail=%+v",
@@ -87,7 +87,7 @@ func TestKiroCreditPricing_NoContext(t *testing.T) {
 		t.Errorf("expected non-zero input tokens, got %+v", got)
 	}
 	prices := lookupKiroPrice("claude-sonnet-4.5")
-	target := 0.1 * kiroUSDPerCredit / 0.1
+	target := 0.1 * kiroUSDPerCredit
 	actual := usdAt(prices, got.InputTokens, 0, 0, got.OutputTokens)
 	if !approxEqualPct(actual, target, 0.01) {
 		t.Errorf("cost mismatch in no-context case: target=%.6f actual=%.6f", target, actual)
@@ -128,7 +128,7 @@ func TestKiroCreditPricing_ToolOnlyOutput(t *testing.T) {
 	}
 	// Cost should still match target.
 	prices := lookupKiroPrice("claude-sonnet-4.5")
-	target := 0.05 * kiroUSDPerCredit / 0.1
+	target := 0.05 * kiroUSDPerCredit
 	actual := usdAt(prices, got.InputTokens, got.CacheCreationTokens, got.CacheReadTokens, got.OutputTokens)
 	if !approxEqualPct(actual, target, 0.02) {
 		t.Errorf("cost mismatch tool-only: target=%.6f actual=%.6f detail=%+v",

--- a/internal/runtime/executor/helps/kiro_credit_pricing_test.go
+++ b/internal/runtime/executor/helps/kiro_credit_pricing_test.go
@@ -1,0 +1,147 @@
+package helps
+
+import (
+	"math"
+	"testing"
+)
+
+// usdAt computes the dollar cost of a usage breakdown at the given prices.
+func usdAt(p kiroModelPrice, in, cw, cr, out int64) float64 {
+	return float64(in)*p.Input +
+		float64(cw)*p.CacheWrite +
+		float64(cr)*p.CacheRead +
+		float64(out)*p.Output
+}
+
+// approxEqualPct returns true if a and b agree within tolPct (e.g. 0.01 = 1%).
+func approxEqualPct(a, b, tolPct float64) bool {
+	if b == 0 {
+		return math.Abs(a) < 1e-9
+	}
+	return math.Abs(a-b)/math.Abs(b) <= tolPct
+}
+
+func TestKiroCreditPricing_TypicalOpus47(t *testing.T) {
+	// User-provided sample: credits=0.1847, ctxPct=3.99% (0.0399), output=52.
+	const credits = 0.1847
+	const ctxPct = 0.0399
+	const output int64 = 52
+	const model = "claude-opus-4.7"
+
+	params := DefaultCreditPricingParams()
+	got := ComputeUsageFromCredits(model, credits, ctxPct, output, params)
+
+	prices := lookupKiroPrice(model)
+	target := credits * kiroUSDPerCredit / params.Discount // = 0.03694 USD
+	actual := usdAt(prices, got.InputTokens, got.CacheCreationTokens, got.CacheReadTokens, got.OutputTokens)
+	if !approxEqualPct(actual, target, 0.01) {
+		t.Fatalf("cost mismatch: target=%.6f USD, actual=%.6f USD, detail=%+v",
+			target, actual, got)
+	}
+	if got.OutputTokens != output {
+		t.Fatalf("output tokens should be unchanged, got %d", got.OutputTokens)
+	}
+	// Cache fields should dominate the input side under default 80/5/15.
+	if got.CacheReadTokens <= got.InputTokens {
+		t.Errorf("expected cache_read >> input under default ratios, got input=%d cache_read=%d",
+			got.InputTokens, got.CacheReadTokens)
+	}
+	if got.TotalTokens != got.InputTokens+got.CacheCreationTokens+got.CacheReadTokens+got.OutputTokens {
+		t.Errorf("total tokens not equal to sum of parts: %+v", got)
+	}
+}
+
+func TestKiroCreditPricing_RatiosApproximatelyHeld(t *testing.T) {
+	got := ComputeUsageFromCredits("claude-opus-4.7", 0.1847, 0.0399, 52, DefaultCreditPricingParams())
+	totalCtx := got.InputTokens + got.CacheCreationTokens + got.CacheReadTokens
+	if totalCtx == 0 {
+		t.Fatalf("no context-side tokens emitted: %+v", got)
+	}
+	rIn := float64(got.InputTokens) / float64(totalCtx)
+	rCw := float64(got.CacheCreationTokens) / float64(totalCtx)
+	rCr := float64(got.CacheReadTokens) / float64(totalCtx)
+	// Allow ±2% tolerance against 0.15/0.05/0.80.
+	if math.Abs(rIn-0.15) > 0.02 || math.Abs(rCw-0.05) > 0.02 || math.Abs(rCr-0.80) > 0.02 {
+		t.Errorf("ratios drifted: in=%.3f cw=%.3f cr=%.3f", rIn, rCw, rCr)
+	}
+}
+
+func TestKiroCreditPricing_NoCredits(t *testing.T) {
+	got := ComputeUsageFromCredits("claude-opus-4.7", 0, 0.0399, 52, DefaultCreditPricingParams())
+	if got.InputTokens != 0 || got.CacheCreationTokens != 0 || got.CacheReadTokens != 0 {
+		t.Errorf("no credits should yield zero input-side tokens, got %+v", got)
+	}
+	if got.OutputTokens != 52 {
+		t.Errorf("output tokens should be preserved, got %d", got.OutputTokens)
+	}
+}
+
+func TestKiroCreditPricing_NoContext(t *testing.T) {
+	// With no context signal we must still account for the credits — fall
+	// back to all-input.
+	got := ComputeUsageFromCredits("claude-sonnet-4.5", 0.1, 0, 10, DefaultCreditPricingParams())
+	if got.CacheReadTokens != 0 || got.CacheCreationTokens != 0 {
+		t.Errorf("no context should not produce cache fields, got %+v", got)
+	}
+	if got.InputTokens <= 0 {
+		t.Errorf("expected non-zero input tokens, got %+v", got)
+	}
+	prices := lookupKiroPrice("claude-sonnet-4.5")
+	target := 0.1 * kiroUSDPerCredit / 0.1
+	actual := usdAt(prices, got.InputTokens, 0, 0, got.OutputTokens)
+	if !approxEqualPct(actual, target, 0.01) {
+		t.Errorf("cost mismatch in no-context case: target=%.6f actual=%.6f", target, actual)
+	}
+}
+
+func TestKiroCreditPricing_UnknownModel(t *testing.T) {
+	// Unknown model should fall back to opus-4.7 prices silently (warns once).
+	a := ComputeUsageFromCredits("totally-not-a-model", 0.1847, 0.04, 52, DefaultCreditPricingParams())
+	b := ComputeUsageFromCredits(kiroPriceFallbackModel, 0.1847, 0.04, 52, DefaultCreditPricingParams())
+	if a != b {
+		t.Errorf("unknown model fallback should match %s exactly: a=%+v b=%+v",
+			kiroPriceFallbackModel, a, b)
+	}
+}
+
+func TestKiroCreditPricing_OutputDominated(t *testing.T) {
+	// Tiny credit amount with huge output → output cost exceeds budget,
+	// input fields should be zero (clamped) and we don't go negative.
+	got := ComputeUsageFromCredits("claude-opus-4.7", 0.0001, 0.5, 100000, DefaultCreditPricingParams())
+	if got.InputTokens < 0 || got.CacheCreationTokens < 0 || got.CacheReadTokens < 0 {
+		t.Errorf("token counts must be non-negative: %+v", got)
+	}
+	if got.OutputTokens != 100000 {
+		t.Errorf("output should be preserved, got %d", got.OutputTokens)
+	}
+}
+
+func TestKiroCreditPricing_ToolOnlyOutput(t *testing.T) {
+	// Tool-only responses surface as a tiny placeholder output; the algorithm
+	// should still produce sensible non-negative input-side numbers.
+	got := ComputeUsageFromCredits("claude-sonnet-4.5", 0.05, 0.02, 1, DefaultCreditPricingParams())
+	if got.InputTokens < 0 || got.CacheCreationTokens < 0 || got.CacheReadTokens < 0 {
+		t.Errorf("token counts must be non-negative: %+v", got)
+	}
+	if got.OutputTokens != 1 {
+		t.Errorf("placeholder output should be preserved, got %d", got.OutputTokens)
+	}
+	// Cost should still match target.
+	prices := lookupKiroPrice("claude-sonnet-4.5")
+	target := 0.05 * kiroUSDPerCredit / 0.1
+	actual := usdAt(prices, got.InputTokens, got.CacheCreationTokens, got.CacheReadTokens, got.OutputTokens)
+	if !approxEqualPct(actual, target, 0.02) {
+		t.Errorf("cost mismatch tool-only: target=%.6f actual=%.6f detail=%+v",
+			target, actual, got)
+	}
+}
+
+func TestKiroCreditPricing_PercentNormalization(t *testing.T) {
+	// ctxPct expressed as whole percent (3.99) should yield the same result
+	// as the fractional form (0.0399).
+	a := ComputeUsageFromCredits("claude-opus-4.7", 0.1847, 0.0399, 52, DefaultCreditPricingParams())
+	b := ComputeUsageFromCredits("claude-opus-4.7", 0.1847, 3.99, 52, DefaultCreditPricingParams())
+	if a != b {
+		t.Errorf("percent normalization mismatch: a=%+v b=%+v", a, b)
+	}
+}

--- a/internal/runtime/executor/kiro_executor.go
+++ b/internal/runtime/executor/kiro_executor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/uuid"
 	kiroauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/kiro"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	kiroclaude "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/kiro/claude"
 	kirocommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/kiro/common"
 	kiroopenai "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/kiro/openai"
@@ -971,7 +972,7 @@ func (e *KiroExecutor) executeWithRetry(ctx context.Context, auth *cliproxyauth.
 				}
 			}()
 
-			content, toolUses, usageInfo, stopReason, err := e.parseEventStream(httpResp.Body)
+			content, toolUses, usageInfo, stopReason, creditUsage, contextPct, err := e.parseEventStream(httpResp.Body)
 			if err != nil {
 				recordAPIResponseError(ctx, e.cfg, err)
 				return resp, err
@@ -1005,8 +1006,29 @@ func (e *KiroExecutor) executeWithRetry(ctx context.Context, auth *cliproxyauth.
 				}
 			}
 
-			// 3. Update TotalTokens
-			usageInfo.TotalTokens = usageInfo.InputTokens + usageInfo.OutputTokens
+			// 3. Reverse-engineer a Claude-shaped usage breakdown when Kiro
+			//    reported credits, so the response includes plausible cache
+			//    hit/write counts. Mirrors streamToChannel.
+			if creditUsage > 0 {
+				reconstructed := helps.ComputeUsageFromCredits(
+					kiroModelID,
+					creditUsage,
+					contextPct,
+					usageInfo.OutputTokens,
+					helps.DefaultCreditPricingParams(),
+				)
+				usageInfo.InputTokens = reconstructed.InputTokens
+				usageInfo.CacheCreationTokens = reconstructed.CacheCreationTokens
+				usageInfo.CacheReadTokens = reconstructed.CacheReadTokens
+				usageInfo.Credits = creditUsage
+				log.Debugf("kiro: reconstructed non-stream usage from credits=%.4f ctx=%.2f%% → input=%d cache_creation=%d cache_read=%d output=%d (model=%s)",
+					creditUsage, contextPct,
+					usageInfo.InputTokens, usageInfo.CacheCreationTokens,
+					usageInfo.CacheReadTokens, usageInfo.OutputTokens, kiroModelID)
+			}
+
+			// 4. Update TotalTokens
+			usageInfo.TotalTokens = usageInfo.InputTokens + usageInfo.CacheCreationTokens + usageInfo.CacheReadTokens + usageInfo.OutputTokens
 
 			appendAPIResponseChunk(ctx, e.cfg, []byte(content))
 			reporter.publish(ctx, usageInfo)
@@ -1431,7 +1453,7 @@ func (e *KiroExecutor) executeStreamWithRetry(ctx context.Context, auth *cliprox
 				// So we always enable thinking parsing for Kiro responses
 				log.Debugf("kiro: stream thinkingEnabled = %v (always true for Kiro)", thinkingEnabled)
 
-				e.streamToChannel(ctx, resp.Body, out, from, payloadRequestedModel(opts, req.Model), opts.OriginalRequest, body, reporter, thinkingEnabled)
+				e.streamToChannel(ctx, resp.Body, out, from, payloadRequestedModel(opts, req.Model), kiroModelID, opts.OriginalRequest, body, reporter, thinkingEnabled)
 			}(httpResp, thinkingEnabled)
 
 			return out, nil
@@ -1641,8 +1663,10 @@ type eventStreamMessage struct {
 // parseEventStream parses AWS Event Stream binary format.
 // Extracts text content, tool uses, and stop_reason from the response.
 // Supports embedded [Called ...] tool calls and input buffering for toolUseEvent.
-// Returns: content, toolUses, usageInfo, stopReason, error
-func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.KiroToolUse, usage.Detail, string, error) {
+// Returns: content, toolUses, usageInfo, stopReason, credits, contextPct, error
+//   - credits: meteringEvent.usage value (Kiro billing credits, 0 if absent)
+//   - contextPct: contextUsageEvent.contextUsagePercentage (0 if absent)
+func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.KiroToolUse, usage.Detail, string, float64, float64, error) {
 	var content strings.Builder
 	var toolUses []kiroclaude.KiroToolUse
 	var usageInfo usage.Detail
@@ -1655,12 +1679,13 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 
 	// Upstream usage tracking - Kiro API returns credit usage and context percentage
 	var upstreamContextPercentage float64 // Context usage percentage from upstream (e.g., 78.56)
+	var upstreamCreditUsage float64       // Billing credits from meteringEvent (1 credit = $0.02)
 
 	for {
 		msg, eventErr := e.readEventStreamMessage(reader)
 		if eventErr != nil {
 			log.Errorf("kiro: parseEventStream error: %v", eventErr)
-			return content.String(), toolUses, usageInfo, stopReason, eventErr
+			return content.String(), toolUses, usageInfo, stopReason, upstreamCreditUsage, upstreamContextPercentage, eventErr
 		}
 		if msg == nil {
 			// Normal end of stream (EOF)
@@ -1688,7 +1713,7 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 				errMsg = msg
 			}
 			log.Errorf("kiro: received AWS error in event stream: type=%s, message=%s", errType, errMsg)
-			return "", nil, usageInfo, stopReason, fmt.Errorf("kiro API error: %s - %s", errType, errMsg)
+			return "", nil, usageInfo, stopReason, upstreamCreditUsage, upstreamContextPercentage, fmt.Errorf("kiro API error: %s - %s", errType, errMsg)
 		}
 		if errType, hasErrType := event["type"].(string); hasErrType && (errType == "error" || errType == "exception") {
 			// Generic error event
@@ -1701,7 +1726,7 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 				}
 			}
 			log.Errorf("kiro: received error event in stream: type=%s, message=%s", errType, errMsg)
-			return "", nil, usageInfo, stopReason, fmt.Errorf("kiro API error: %s", errMsg)
+			return "", nil, usageInfo, stopReason, upstreamCreditUsage, upstreamContextPercentage, fmt.Errorf("kiro API error: %s", errMsg)
 		}
 
 		// Extract stop_reason from various event formats
@@ -1937,9 +1962,8 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 				if u, ok := metering["usage"].(float64); ok {
 					usageVal = u
 				}
-				log.Infof("kiro: parseEventStream received meteringEvent: usage=%.2f %s", usageVal, unit)
-				// Store metering info for potential billing/statistics purposes
-				// Note: This is separate from token counts - it's AWS billing units
+				upstreamCreditUsage = usageVal
+				log.Infof("kiro: parseEventStream received meteringEvent: usage=%.4f %s", usageVal, unit)
 			} else {
 				// Try direct fields
 				unit := ""
@@ -1951,7 +1975,8 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 					usageVal = u
 				}
 				if unit != "" || usageVal > 0 {
-					log.Infof("kiro: parseEventStream received meteringEvent (direct): usage=%.2f %s", usageVal, unit)
+					upstreamCreditUsage = usageVal
+					log.Infof("kiro: parseEventStream received meteringEvent (direct): usage=%.4f %s", usageVal, unit)
 				}
 			}
 
@@ -2010,7 +2035,7 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 
 			// For other errors, return the error
 			if errMsg != "" {
-				return "", nil, usageInfo, stopReason, fmt.Errorf("kiro API error (%s): %s", errType, errMsg)
+				return "", nil, usageInfo, stopReason, upstreamCreditUsage, upstreamContextPercentage, fmt.Errorf("kiro API error (%s): %s", errType, errMsg)
 			}
 
 		default:
@@ -2100,10 +2125,12 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 		log.Warnf("kiro: response truncated due to max_tokens limit")
 	}
 
-	// Use contextUsagePercentage to calculate more accurate input tokens
-	// Kiro model has 200k max context, contextUsagePercentage represents the percentage used
-	// Formula: input_tokens = contextUsagePercentage * 200000 / 100
-	if upstreamContextPercentage > 0 {
+	// Note: input-token reconstruction (from credits + contextPct) is handled
+	// by the caller via helps.ComputeUsageFromCredits, so the response can
+	// surface a Claude-shaped usage breakdown including cache hits. We still
+	// surface the raw signals via the credits/contextPct return values.
+	if upstreamCreditUsage == 0 && upstreamContextPercentage > 0 {
+		// Legacy fallback when no credits were received: use contextPct alone.
 		calculatedInputTokens := int64(upstreamContextPercentage * 200000 / 100)
 		if calculatedInputTokens > 0 {
 			localEstimate := usageInfo.InputTokens
@@ -2114,7 +2141,7 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 		}
 	}
 
-	return cleanedContent, toolUses, usageInfo, stopReason, nil
+	return cleanedContent, toolUses, usageInfo, stopReason, upstreamCreditUsage, upstreamContextPercentage, nil
 }
 
 // readEventStreamMessage reads and validates a single AWS Event Stream message.
@@ -2314,7 +2341,7 @@ func (e *KiroExecutor) extractEventTypeFromBytes(headers []byte) string {
 // Implements duplicate content filtering using lastContentEvent detection (based on AIClient-2-API).
 // Extracts stop_reason from upstream events when available.
 // thinkingEnabled controls whether <thinking> tags are parsed - only parse when request enabled thinking.
-func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out chan<- cliproxyexecutor.StreamChunk, targetFormat sdktranslator.Format, model string, originalReq, claudeBody []byte, reporter *usageReporter, thinkingEnabled bool) {
+func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out chan<- cliproxyexecutor.StreamChunk, targetFormat sdktranslator.Format, model, kiroModelID string, originalReq, claudeBody []byte, reporter *usageReporter, thinkingEnabled bool) {
 	reader := bufio.NewReaderSize(body, 20*1024*1024) // 20MB buffer to match other providers
 	var totalUsage usage.Detail
 	var hasToolUses bool          // Track if any tool uses were emitted
@@ -3403,17 +3430,30 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 		}
 	}
 
-	// Use contextUsagePercentage to calculate more accurate input tokens
-	// Kiro model has 200k max context, contextUsagePercentage represents the percentage used
-	// Formula: input_tokens = contextUsagePercentage * 200000 / 100
-	// Note: The effective input context is ~170k (200k - 30k reserved for output)
-	if upstreamContextPercentage > 0 {
-		// Calculate input tokens from context percentage
-		// Using 200k as the base since that's what Kiro reports against
+	// Reverse-engineer a Claude-shaped usage breakdown from the credits
+	// reported by Kiro (1 credit = $0.02) so the response presented to the
+	// client looks like a normal Anthropic Claude usage object with cache
+	// hits. Falls back to the raw contextUsagePercentage estimate when no
+	// metering event was received.
+	if hasUpstreamUsage && upstreamCreditUsage > 0 {
+		reconstructed := helps.ComputeUsageFromCredits(
+			kiroModelID,
+			upstreamCreditUsage,
+			upstreamContextPercentage,
+			totalUsage.OutputTokens,
+			helps.DefaultCreditPricingParams(),
+		)
+		totalUsage.InputTokens = reconstructed.InputTokens
+		totalUsage.CacheCreationTokens = reconstructed.CacheCreationTokens
+		totalUsage.CacheReadTokens = reconstructed.CacheReadTokens
+		totalUsage.Credits = upstreamCreditUsage
+		log.Debugf("kiro: reconstructed usage from credits=%.4f ctx=%.2f%% → input=%d cache_creation=%d cache_read=%d output=%d (model=%s)",
+			upstreamCreditUsage, upstreamContextPercentage,
+			totalUsage.InputTokens, totalUsage.CacheCreationTokens,
+			totalUsage.CacheReadTokens, totalUsage.OutputTokens, kiroModelID)
+	} else if upstreamContextPercentage > 0 {
+		// Legacy estimate when credits are missing.
 		calculatedInputTokens := int64(upstreamContextPercentage * 200000 / 100)
-
-		// Only use calculated value if it's significantly different from local estimate
-		// This provides more accurate token counts based on upstream data
 		if calculatedInputTokens > 0 {
 			localEstimate := totalUsage.InputTokens
 			totalUsage.InputTokens = calculatedInputTokens
@@ -3422,7 +3462,7 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 		}
 	}
 
-	totalUsage.TotalTokens = totalUsage.InputTokens + totalUsage.OutputTokens
+	totalUsage.TotalTokens = totalUsage.InputTokens + totalUsage.CacheCreationTokens + totalUsage.CacheReadTokens + totalUsage.OutputTokens
 
 	// Log upstream usage information if received
 	if hasUpstreamUsage {

--- a/internal/runtime/executor/kiro_executor.go
+++ b/internal/runtime/executor/kiro_executor.go
@@ -1020,7 +1020,6 @@ func (e *KiroExecutor) executeWithRetry(ctx context.Context, auth *cliproxyauth.
 				usageInfo.InputTokens = reconstructed.InputTokens
 				usageInfo.CacheCreationTokens = reconstructed.CacheCreationTokens
 				usageInfo.CacheReadTokens = reconstructed.CacheReadTokens
-				usageInfo.Credits = creditUsage
 				log.Debugf("kiro: reconstructed non-stream usage from credits=%.4f ctx=%.2f%% → input=%d cache_creation=%d cache_read=%d output=%d (model=%s)",
 					creditUsage, contextPct,
 					usageInfo.InputTokens, usageInfo.CacheCreationTokens,
@@ -1040,7 +1039,7 @@ func (e *KiroExecutor) executeWithRetry(ctx context.Context, auth *cliproxyauth.
 			// Build response in Claude format for Kiro translator
 			// stopReason is extracted from upstream response by parseEventStream
 			requestedModel := payloadRequestedModel(opts, req.Model)
-			kiroResponse := kiroclaude.BuildClaudeResponse(content, toolUses, requestedModel, usageInfo, stopReason)
+			kiroResponse := kiroclaude.BuildClaudeResponse(content, toolUses, requestedModel, usageInfo, stopReason, creditUsage)
 			out := sdktranslator.TranslateNonStream(ctx, to, from, requestedModel, bytes.Clone(opts.OriginalRequest), body, kiroResponse, nil)
 			resp = cliproxyexecutor.Response{Payload: []byte(out)}
 			return resp, nil
@@ -3446,7 +3445,6 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 		totalUsage.InputTokens = reconstructed.InputTokens
 		totalUsage.CacheCreationTokens = reconstructed.CacheCreationTokens
 		totalUsage.CacheReadTokens = reconstructed.CacheReadTokens
-		totalUsage.Credits = upstreamCreditUsage
 		log.Debugf("kiro: reconstructed usage from credits=%.4f ctx=%.2f%% → input=%d cache_creation=%d cache_read=%d output=%d (model=%s)",
 			upstreamCreditUsage, upstreamContextPercentage,
 			totalUsage.InputTokens, totalUsage.CacheCreationTokens,
@@ -3489,7 +3487,7 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 	}
 
 	// Send message_delta event
-	msgDelta := kiroclaude.BuildClaudeMessageDeltaEvent(stopReason, totalUsage)
+	msgDelta := kiroclaude.BuildClaudeMessageDeltaEvent(stopReason, totalUsage, upstreamCreditUsage)
 	sseData := sdktranslator.TranslateStream(ctx, sdktranslator.FromString("kiro"), targetFormat, model, originalReq, claudeBody, msgDelta, &translatorParam)
 	for _, chunk := range sseData {
 		enqueueTranslatedSSE(out, chunk)

--- a/internal/translator/kiro/claude/kiro_claude_response.go
+++ b/internal/translator/kiro/claude/kiro_claude_response.go
@@ -41,7 +41,7 @@ var (
 // into Claude thinking blocks. The streaming path handles reasoning via
 // reasoningContentEvent independently.
 // stopReason is passed from upstream; fallback logic applied if empty.
-func BuildClaudeResponse(content string, toolUses []KiroToolUse, model string, usageInfo usage.Detail, stopReason string) []byte {
+func BuildClaudeResponse(content string, toolUses []KiroToolUse, model string, usageInfo usage.Detail, stopReason string, credits float64) []byte {
 	var contentBlocks []map[string]interface{}
 
 	if content != "" {
@@ -109,8 +109,8 @@ func BuildClaudeResponse(content string, toolUses []KiroToolUse, model string, u
 	if usageInfo.CacheReadTokens > 0 {
 		usageMap["cache_read_input_tokens"] = usageInfo.CacheReadTokens
 	}
-	if usageInfo.Credits > 0 {
-		usageMap["credits"] = usageInfo.Credits
+	if credits > 0 {
+		usageMap["credits"] = credits
 	}
 	response := map[string]interface{}{
 		"id":          "msg_" + uuid.New().String()[:24],

--- a/internal/translator/kiro/claude/kiro_claude_response.go
+++ b/internal/translator/kiro/claude/kiro_claude_response.go
@@ -99,6 +99,19 @@ func BuildClaudeResponse(content string, toolUses []KiroToolUse, model string, u
 		log.Warnf("kiro: response truncated due to max_tokens limit (buildClaudeResponse)")
 	}
 
+	usageMap := map[string]interface{}{
+		"input_tokens":  usageInfo.InputTokens,
+		"output_tokens": usageInfo.OutputTokens,
+	}
+	if usageInfo.CacheCreationTokens > 0 {
+		usageMap["cache_creation_input_tokens"] = usageInfo.CacheCreationTokens
+	}
+	if usageInfo.CacheReadTokens > 0 {
+		usageMap["cache_read_input_tokens"] = usageInfo.CacheReadTokens
+	}
+	if usageInfo.Credits > 0 {
+		usageMap["credits"] = usageInfo.Credits
+	}
 	response := map[string]interface{}{
 		"id":          "msg_" + uuid.New().String()[:24],
 		"type":        "message",
@@ -106,10 +119,7 @@ func BuildClaudeResponse(content string, toolUses []KiroToolUse, model string, u
 		"model":       model,
 		"content":     contentBlocks,
 		"stop_reason": stopReason,
-		"usage": map[string]interface{}{
-			"input_tokens":  usageInfo.InputTokens,
-			"output_tokens": usageInfo.OutputTokens,
-		},
+		"usage":       usageMap,
 	}
 	result, _ := json.Marshal(response)
 	return result

--- a/internal/translator/kiro/claude/kiro_claude_stream.go
+++ b/internal/translator/kiro/claude/kiro_claude_stream.go
@@ -111,16 +111,26 @@ func BuildClaudeThinkingBlockStopEvent(index int) []byte {
 
 // BuildClaudeMessageDeltaEvent creates the message_delta event with stop_reason and usage
 func BuildClaudeMessageDeltaEvent(stopReason string, usageInfo usage.Detail) []byte {
+	usageMap := map[string]interface{}{
+		"input_tokens":  usageInfo.InputTokens,
+		"output_tokens": usageInfo.OutputTokens,
+	}
+	if usageInfo.CacheCreationTokens > 0 {
+		usageMap["cache_creation_input_tokens"] = usageInfo.CacheCreationTokens
+	}
+	if usageInfo.CacheReadTokens > 0 {
+		usageMap["cache_read_input_tokens"] = usageInfo.CacheReadTokens
+	}
+	if usageInfo.Credits > 0 {
+		usageMap["credits"] = usageInfo.Credits
+	}
 	deltaEvent := map[string]interface{}{
 		"type": "message_delta",
 		"delta": map[string]interface{}{
 			"stop_reason":   stopReason,
 			"stop_sequence": nil,
 		},
-		"usage": map[string]interface{}{
-			"input_tokens":  usageInfo.InputTokens,
-			"output_tokens": usageInfo.OutputTokens,
-		},
+		"usage": usageMap,
 	}
 	deltaResult, _ := json.Marshal(deltaEvent)
 	return []byte("event: message_delta\ndata: " + string(deltaResult))

--- a/internal/translator/kiro/claude/kiro_claude_stream.go
+++ b/internal/translator/kiro/claude/kiro_claude_stream.go
@@ -110,7 +110,7 @@ func BuildClaudeThinkingBlockStopEvent(index int) []byte {
 }
 
 // BuildClaudeMessageDeltaEvent creates the message_delta event with stop_reason and usage
-func BuildClaudeMessageDeltaEvent(stopReason string, usageInfo usage.Detail) []byte {
+func BuildClaudeMessageDeltaEvent(stopReason string, usageInfo usage.Detail, credits float64) []byte {
 	usageMap := map[string]interface{}{
 		"input_tokens":  usageInfo.InputTokens,
 		"output_tokens": usageInfo.OutputTokens,
@@ -121,8 +121,8 @@ func BuildClaudeMessageDeltaEvent(stopReason string, usageInfo usage.Detail) []b
 	if usageInfo.CacheReadTokens > 0 {
 		usageMap["cache_read_input_tokens"] = usageInfo.CacheReadTokens
 	}
-	if usageInfo.Credits > 0 {
-		usageMap["credits"] = usageInfo.Credits
+	if credits > 0 {
+		usageMap["credits"] = credits
 	}
 	deltaEvent := map[string]interface{}{
 		"type": "message_delta",
@@ -307,7 +307,7 @@ func BuildFallbackTextEvents(contentBlockIndex int, query string, results *WebSe
 	// message_delta with end_turn
 	events = append(events, BuildClaudeMessageDeltaEvent("end_turn", usage.Detail{
 		OutputTokens: int64(outputTokens),
-	}))
+	}, 0))
 
 	// message_stop
 	events = append(events, BuildClaudeMessageStopOnlyEvent())

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -44,7 +44,6 @@ type Detail struct {
 	CacheReadTokens     int64
 	CacheCreationTokens int64
 	TotalTokens         int64
-	Credits             float64
 }
 
 type requestedModelAliasContextKey struct{}

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -44,6 +44,7 @@ type Detail struct {
 	CacheReadTokens     int64
 	CacheCreationTokens int64
 	TotalTokens         int64
+	Credits             float64
 }
 
 type requestedModelAliasContextKey struct{}


### PR DESCRIPTION
## Summary

Reconstruct Claude-shaped usage from Kiro credit metadata so usage reporting and billing math no longer rely on speculative `usage.Detail` fields. Credits are now computed via the Kiro pricing helper and passed directly into the response/stream builders, leaving `usage.Detail` as a clean container for token counts only.

## Changes

- `feat(kiro)`: introduce `internal/runtime/executor/helps/kiro_credit_pricing.go` (and tests) to derive Claude-shaped usage from Kiro credits.
- `refactor(kiro)`: drop the discount factor from credit pricing — credits are now used as the source of truth without an implicit multiplier.
- `docs(kiro)`: remove the discount comment from the credit-pricing package doc to match the simplified model.
- `refactor(kiro)`: pass `credits` directly to `BuildClaudeResponse` / `BuildClaudeMessageDeltaEvent`, remove `Credits` from `usage.Detail`, and update all call sites in `kiro_executor.go`.
- `chore`: remove an accidentally committed 73MB `cmd/server/server` build artifact and add `cmd/server/server` to `.gitignore`.

## Files Touched

- `internal/runtime/executor/helps/kiro_credit_pricing.go` (new)
- `internal/runtime/executor/helps/kiro_credit_pricing_test.go` (new)
- `internal/runtime/executor/kiro_executor.go`
- `internal/translator/kiro/claude/kiro_claude_response.go`
- `internal/translator/kiro/claude/kiro_claude_stream.go`
- `sdk/cliproxy/usage/manager.go`
- `.gitignore`

## Testing

- `go test ./internal/runtime/executor/helps/... ./internal/translator/kiro/... ./internal/runtime/executor/... ./sdk/cliproxy/usage/...` — all pass.
- `go build ./cmd/server` — succeeds.

## Notes

- No changes to `internal/translator/` beyond the Kiro→Claude builders, which are part of this Kiro usage refactor.
- The two pre-existing `gofmt` lints in `internal/translator/kiro/claude/kiro_claude_request.go` and `test/thinking_conversion_test.go` are inherited from `main` and out of scope for this PR.
