### PR TITLE
fix: remove duplicate home discovery flag

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -148,7 +148,6 @@ func main() {
 	flag.StringVar(&password, "password", "", "")
 	flag.StringVar(&homeJWT, "home-jwt", "", "Home control plane JWT for mTLS certificate bootstrap and connection")
 	flag.BoolVar(&homeDisableClusterDiscovery, "home-disable-cluster-discovery", false, "Disable Home CLUSTER NODES discovery and keep using the configured Home address")
-	flag.BoolVar(&homeDisableClusterDiscovery, "home-disable-cluster-discovery", false, "Disable Home CLUSTER NODES discovery and keep using the configured -home-jwt address")
 	flag.BoolVar(&tuiMode, "tui", false, "Start with terminal management UI")
 	flag.BoolVar(&standalone, "standalone", false, "In TUI mode, start an embedded local server")
 	flag.BoolVar(&localModel, "local-model", false, "Use embedded model catalog only, skip remote model fetching")

--- a/cmd/server/main_flags_test.go
+++ b/cmd/server/main_flags_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"testing"
+)
+
+func TestServerFlagsAreRegisteredOnce(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse main.go: %v", err)
+	}
+
+	seen := make(map[string]token.Pos)
+	duplicates := make(map[string][2]token.Pos)
+
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok || len(call.Args) < 2 {
+			return true
+		}
+
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || !isFlagRegistration(selector) {
+			return true
+		}
+
+		name, ok := stringLiteral(call.Args[1])
+		if !ok {
+			return true
+		}
+
+		if first, exists := seen[name]; exists {
+			duplicates[name] = [2]token.Pos{first, call.Args[1].Pos()}
+			return true
+		}
+		seen[name] = call.Args[1].Pos()
+		return true
+	})
+
+	if len(duplicates) == 0 {
+		return
+	}
+
+	for name, positions := range duplicates {
+		t.Errorf(
+			"flag %q registered more than once at %s and %s",
+			name,
+			fset.Position(positions[0]),
+			fset.Position(positions[1]),
+		)
+	}
+}
+
+func isFlagRegistration(selector *ast.SelectorExpr) bool {
+	ident, ok := selector.X.(*ast.Ident)
+	if !ok || ident.Name != "flag" {
+		return false
+	}
+
+	switch selector.Sel.Name {
+	case "BoolVar", "DurationVar", "Float64Var", "Func", "Int64Var", "IntVar",
+		"StringVar", "TextVar", "Uint64Var", "UintVar", "Var":
+		return true
+	default:
+		return false
+	}
+}
+
+func stringLiteral(expr ast.Expr) (string, bool) {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+
+	value, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return value, true
+}


### PR DESCRIPTION
## Summary

- Remove the duplicate `home-disable-cluster-discovery` flag registration that panics during startup.
- Add a parser-based regression test to catch duplicate server flag names before release.

Closes #97

## Test plan

- [x] `go test ./cmd/server`
- [x] `go build -o /tmp/cli-proxy-api-plus-fix-97 ./cmd/server`
- [x] `/tmp/cli-proxy-api-plus-fix-97 --help`
- [x] `go test ./...`
- [x] `go build -o test-output ./cmd/server && rm test-output`
