### PR TITLE
fix(qoder): allow models from dynamic cache to bypass static ModelMap…

### DIFF
--- a/internal/auth/qoder/api.go
+++ b/internal/auth/qoder/api.go
@@ -40,12 +40,13 @@ var ModelMap = map[string]string{
 	"efficient":   "efficient",
 	"lite":        "lite",
 	// Frontier models — pin a specific backing model
-	"qmodel":    "qmodel",    // Qwen 3.6 Plus
-	"dmodel":    "dmodel",    // DeepSeek V4 Pro
-	"dfmodel":   "dfmodel",   // DeepSeek V4 Flash
-	"gm51model": "gm51model", // GLM 5.1
-	"kmodel":    "kmodel",    // Kimi K2.6
-	"mmodel":    "mmodel",    // MiniMax M2.7
+	"qmodel":        "qmodel",        // Qwen3.7 Plus
+	"qmodel_latest": "qmodel_latest", // Qwen3.7 Max (latest)
+	"dmodel":        "dmodel",        // DeepSeek V4 Pro
+	"dfmodel":       "dfmodel",       // DeepSeek V4 Flash
+	"gm51model":     "gm51model",     // GLM 5.1
+	"kmodel":        "kmodel",        // Kimi K2.6
+	"mmodel":        "mmodel",        // MiniMax M3
 }
 
 // doRefreshToken performs a token refresh and persists the result to authFilePath.

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2010,7 +2010,6 @@
         ]
       }
     }
-
   ],
   "xai": [
     {
@@ -2165,8 +2164,12 @@
       "type": "qoder",
       "display_name": "Qoder Auto",
       "description": "Qoder Auto — automatically selects the best model for your prompt",
-      "context_length": 131072,
-      "max_completion_tokens": 65536
+      "context_length": 180000,
+      "max_completion_tokens": 65536,
+      "supported_input_modalities": [
+        "TEXT",
+        "IMAGE"
+      ]
     },
     {
       "id": "qoder/ultimate",
@@ -2176,13 +2179,24 @@
       "type": "qoder",
       "display_name": "Qoder Ultimate",
       "description": "Qoder Ultimate — highest quality tier",
-      "context_length": 131072,
+      "context_length": 180000,
       "max_completion_tokens": 65536,
+      "supported_input_modalities": [
+        "TEXT",
+        "IMAGE"
+      ],
       "thinking": {
         "min": 1024,
         "max": 32000,
         "zero_allowed": true,
-        "dynamic_allowed": true
+        "dynamic_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "max",
+          "xhigh"
+        ]
       }
     },
     {
@@ -2193,13 +2207,24 @@
       "type": "qoder",
       "display_name": "Qoder Performance",
       "description": "Qoder Performance — balanced quality and speed",
-      "context_length": 131072,
+      "context_length": 272000,
       "max_completion_tokens": 32768,
+      "supported_input_modalities": [
+        "TEXT",
+        "IMAGE"
+      ],
       "thinking": {
         "min": 1024,
         "max": 32000,
         "zero_allowed": true,
-        "dynamic_allowed": true
+        "dynamic_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "max",
+          "xhigh"
+        ]
       }
     },
     {
@@ -2210,8 +2235,12 @@
       "type": "qoder",
       "display_name": "Qoder Efficient",
       "description": "Qoder Efficient — cost-efficient tier",
-      "context_length": 131072,
-      "max_completion_tokens": 16384
+      "context_length": 180000,
+      "max_completion_tokens": 16384,
+      "supported_input_modalities": [
+        "TEXT",
+        "IMAGE"
+      ]
     },
     {
       "id": "qoder/lite",
@@ -2221,7 +2250,7 @@
       "type": "qoder",
       "display_name": "Qoder Lite",
       "description": "Qoder Lite — fastest and most affordable tier",
-      "context_length": 131072,
+      "context_length": 180000,
       "max_completion_tokens": 16384
     },
     {
@@ -2230,10 +2259,29 @@
       "created": 1767196800,
       "owned_by": "qoder",
       "type": "qoder",
-      "display_name": "Qwen 3.6 Plus (Qoder)",
-      "description": "Qoder frontier — Qwen 3.6 Plus",
-      "context_length": 131072,
-      "max_completion_tokens": 32768
+      "display_name": "Qwen3.7 Plus (Qoder)",
+      "description": "Qoder frontier — Qwen3.7 Plus",
+      "context_length": 180000,
+      "max_completion_tokens": 32768,
+      "supported_input_modalities": [
+        "TEXT",
+        "IMAGE"
+      ]
+    },
+    {
+      "id": "qoder/qmodel_latest",
+      "object": "model",
+      "created": 1767196800,
+      "owned_by": "qoder",
+      "type": "qoder",
+      "display_name": "Qwen3.7 Max (Qoder)",
+      "description": "Qoder frontier — Qwen3.7 Max (latest Qwen)",
+      "context_length": 180000,
+      "max_completion_tokens": 32768,
+      "supported_input_modalities": [
+        "TEXT",
+        "IMAGE"
+      ]
     },
     {
       "id": "qoder/dmodel",
@@ -2243,13 +2291,21 @@
       "type": "qoder",
       "display_name": "DeepSeek V4 Pro (Qoder)",
       "description": "Qoder frontier — DeepSeek V4 Pro",
-      "context_length": 131072,
+      "context_length": 180000,
       "max_completion_tokens": 65536,
+      "supported_input_modalities": [
+        "TEXT",
+        "IMAGE"
+      ],
       "thinking": {
         "min": 1024,
         "max": 32000,
         "zero_allowed": true,
-        "dynamic_allowed": true
+        "dynamic_allowed": true,
+        "levels": [
+          "high",
+          "max"
+        ]
       }
     },
     {
@@ -2260,8 +2316,22 @@
       "type": "qoder",
       "display_name": "DeepSeek V4 Flash (Qoder)",
       "description": "Qoder frontier — DeepSeek V4 Flash",
-      "context_length": 131072,
-      "max_completion_tokens": 16384
+      "context_length": 180000,
+      "max_completion_tokens": 16384,
+      "supported_input_modalities": [
+        "TEXT",
+        "IMAGE"
+      ],
+      "thinking": {
+        "min": 1024,
+        "max": 32000,
+        "zero_allowed": true,
+        "dynamic_allowed": true,
+        "levels": [
+          "high",
+          "max"
+        ]
+      }
     },
     {
       "id": "qoder/gm51model",
@@ -2271,13 +2341,21 @@
       "type": "qoder",
       "display_name": "GLM 5.1 (Qoder)",
       "description": "Qoder frontier — GLM 5.1",
-      "context_length": 131072,
+      "context_length": 180000,
       "max_completion_tokens": 32768,
+      "supported_input_modalities": [
+        "TEXT",
+        "IMAGE"
+      ],
       "thinking": {
         "min": 1024,
         "max": 32000,
         "zero_allowed": true,
-        "dynamic_allowed": true
+        "dynamic_allowed": true,
+        "levels": [
+          "high",
+          "max"
+        ]
       }
     },
     {
@@ -2288,14 +2366,12 @@
       "type": "qoder",
       "display_name": "Kimi K2.6 (Qoder)",
       "description": "Qoder frontier — Kimi K2.6",
-      "context_length": 131072,
+      "context_length": 256000,
       "max_completion_tokens": 32768,
-      "thinking": {
-        "min": 1024,
-        "max": 32000,
-        "zero_allowed": true,
-        "dynamic_allowed": true
-      }
+      "supported_input_modalities": [
+        "TEXT",
+        "IMAGE"
+      ]
     },
     {
       "id": "qoder/mmodel",
@@ -2303,10 +2379,14 @@
       "created": 1767196800,
       "owned_by": "qoder",
       "type": "qoder",
-      "display_name": "MiniMax M2.7 (Qoder)",
-      "description": "Qoder frontier — MiniMax M2.7",
-      "context_length": 131072,
-      "max_completion_tokens": 65536
+      "display_name": "MiniMax M3 (Qoder)",
+      "description": "Qoder frontier — MiniMax M3",
+      "context_length": 180000,
+      "max_completion_tokens": 65536,
+      "supported_input_modalities": [
+        "TEXT",
+        "IMAGE"
+      ]
     }
   ]
 }

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2165,7 +2165,6 @@
       "display_name": "Qoder Auto",
       "description": "Qoder Auto — automatically selects the best model for your prompt",
       "context_length": 180000,
-      "max_completion_tokens": 65536,
       "supported_input_modalities": [
         "TEXT",
         "IMAGE"
@@ -2180,7 +2179,6 @@
       "display_name": "Qoder Ultimate",
       "description": "Qoder Ultimate — highest quality tier",
       "context_length": 180000,
-      "max_completion_tokens": 65536,
       "supported_input_modalities": [
         "TEXT",
         "IMAGE"
@@ -2208,7 +2206,6 @@
       "display_name": "Qoder Performance",
       "description": "Qoder Performance — balanced quality and speed",
       "context_length": 272000,
-      "max_completion_tokens": 32768,
       "supported_input_modalities": [
         "TEXT",
         "IMAGE"
@@ -2236,7 +2233,6 @@
       "display_name": "Qoder Efficient",
       "description": "Qoder Efficient — cost-efficient tier",
       "context_length": 180000,
-      "max_completion_tokens": 16384,
       "supported_input_modalities": [
         "TEXT",
         "IMAGE"
@@ -2250,8 +2246,7 @@
       "type": "qoder",
       "display_name": "Qoder Lite",
       "description": "Qoder Lite — fastest and most affordable tier",
-      "context_length": 180000,
-      "max_completion_tokens": 16384
+      "context_length": 180000
     },
     {
       "id": "qoder/qmodel",
@@ -2262,7 +2257,6 @@
       "display_name": "Qwen3.7 Plus (Qoder)",
       "description": "Qoder frontier — Qwen3.7 Plus",
       "context_length": 180000,
-      "max_completion_tokens": 32768,
       "supported_input_modalities": [
         "TEXT",
         "IMAGE"
@@ -2277,7 +2271,6 @@
       "display_name": "Qwen3.7 Max (Qoder)",
       "description": "Qoder frontier — Qwen3.7 Max (latest Qwen)",
       "context_length": 180000,
-      "max_completion_tokens": 32768,
       "supported_input_modalities": [
         "TEXT",
         "IMAGE"
@@ -2292,7 +2285,6 @@
       "display_name": "DeepSeek V4 Pro (Qoder)",
       "description": "Qoder frontier — DeepSeek V4 Pro",
       "context_length": 180000,
-      "max_completion_tokens": 65536,
       "supported_input_modalities": [
         "TEXT",
         "IMAGE"
@@ -2317,7 +2309,6 @@
       "display_name": "DeepSeek V4 Flash (Qoder)",
       "description": "Qoder frontier — DeepSeek V4 Flash",
       "context_length": 180000,
-      "max_completion_tokens": 16384,
       "supported_input_modalities": [
         "TEXT",
         "IMAGE"
@@ -2342,7 +2333,6 @@
       "display_name": "GLM 5.1 (Qoder)",
       "description": "Qoder frontier — GLM 5.1",
       "context_length": 180000,
-      "max_completion_tokens": 32768,
       "supported_input_modalities": [
         "TEXT",
         "IMAGE"
@@ -2367,7 +2357,6 @@
       "display_name": "Kimi K2.6 (Qoder)",
       "description": "Qoder frontier — Kimi K2.6",
       "context_length": 256000,
-      "max_completion_tokens": 32768,
       "supported_input_modalities": [
         "TEXT",
         "IMAGE"
@@ -2382,7 +2371,6 @@
       "display_name": "MiniMax M3 (Qoder)",
       "description": "Qoder frontier — MiniMax M3",
       "context_length": 180000,
-      "max_completion_tokens": 65536,
       "supported_input_modalities": [
         "TEXT",
         "IMAGE"

--- a/internal/runtime/executor/qoder_executor.go
+++ b/internal/runtime/executor/qoder_executor.go
@@ -76,7 +76,8 @@ func (e *QoderExecutor) ExecuteStream(ctx context.Context, authRecord *cliproxya
 	qoderModel := strings.TrimPrefix(model, "qoder/")
 	if mapped, ok := qoderauth.ModelMap[qoderModel]; ok {
 		qoderModel = mapped
-	} else {
+	} else if _, cached := storage.GetModelConfig(qoderModel); !cached {
+		// Not in static map and not in dynamic model cache — reject early.
 		return nil, fmt.Errorf("unsupported qoder model: %q (received %q)", qoderModel, model)
 	}
 


### PR DESCRIPTION
… check

Models fetched from /algo/api/v2/model/list (e.g. qmodel_latest) were rejected at request time because they were not in the static ModelMap. Fall back to the dynamic model config cache before failing, so any model returned by the live API is automatically accepted without manual updates to ModelMap.