### PR TITLE
feat(kiro): report credit-based claude usage

### DIFF
--- a/internal/runtime/executor/helps/kiro_credit_rates.go
+++ b/internal/runtime/executor/helps/kiro_credit_rates.go
@@ -1,0 +1,161 @@
+// Package helps provides supporting helpers for runtime executors.
+package helps
+
+import (
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+	log "github.com/sirupsen/logrus"
+)
+
+// modelPricing holds Anthropic per-bucket prices ($/MTok) for a model. All
+// buckets are needed to map a Kiro credit total onto token counts under
+// official pricing. The 5m cache-write tier is used for cacheCreation (the
+// default Anthropic cache TTL); the 1h tier is not modeled.
+type modelPricing struct {
+	input         float64 // base input tokens ($/MTok)
+	cacheRead     float64 // cache hits & refreshes ($/MTok)
+	cacheCreation float64 // 5m cache writes ($/MTok)
+	output        float64 // output tokens ($/MTok)
+}
+
+// officialBasePrices holds Anthropic prices used to derive per-token credit
+// rates. Models absent from this table fall back to fallbackPricing.
+var officialBasePrices = map[string]modelPricing{
+	"claude-opus-4.8":   {input: 5, cacheRead: 0.5, cacheCreation: 6.25, output: 25},
+	"claude-opus-4.7":   {input: 5, cacheRead: 0.5, cacheCreation: 6.25, output: 25},
+	"claude-opus-4.6":   {input: 5, cacheRead: 0.5, cacheCreation: 6.25, output: 25},
+	"claude-opus-4.5":   {input: 5, cacheRead: 0.5, cacheCreation: 6.25, output: 25},
+	"claude-opus-4.1":   {input: 15, cacheRead: 1.5, cacheCreation: 18.75, output: 75},
+	"claude-sonnet-4.6": {input: 3, cacheRead: 0.3, cacheCreation: 3.75, output: 15},
+	"claude-sonnet-4.5": {input: 3, cacheRead: 0.3, cacheCreation: 3.75, output: 15},
+	"claude-haiku-4.5":  {input: 1, cacheRead: 0.1, cacheCreation: 1.25, output: 5},
+}
+
+// Kiro credit pricing basis.
+//   - creditToUSD: 20$ = 1000 credits => 1 credit = $0.02.
+//
+// Derived credit rate per base-input token: c = (input/1e6) / creditToUSD.
+//
+//	Opus 4.7   ($5/MTok): (5/1e6)/0.02 = 0.000250 credits/token
+//	Sonnet 4.6 ($3/MTok): (3/1e6)/0.02 = 0.000150 credits/token
+const (
+	creditToUSD = 20.0 / 1000.0 // 0.02 USD per credit
+)
+
+// fallbackPricing is used when a model is absent from officialBasePrices.
+// It mirrors the Opus tier (the most common Claude family on Kiro).
+var fallbackPricing = modelPricing{input: 5, cacheRead: 0.5, cacheCreation: 6.25, output: 25}
+
+// ApplyKiroCreditCacheSplit derives a cache token split from credits using a
+// price heuristic and mutates detail in place. It sets CacheReadTokens,
+// CachedTokens, CacheCreationTokens, and the uncached InputTokens.
+//
+// Per-token credit rates come from the model's official Anthropic prices
+// (modelPricing) divided by creditToUSD. Let T be the original input total and
+// O the output. With the invariant uncached + cache_read == T, the billed
+// credits from the input+output base range over:
+//
+//	min = cRead*T  + cOut*O   (all input billed as cache_read)
+//	max = cIn*T    + cOut*O   (all input billed as uncached)
+//
+// The split is chosen to match the upstream credit value:
+//
+//   - credits within [min, max]: back-solve cache_read R from
+//     credits = cIn*(T-R) + cRead*R + cOut*O  =>  R = (cIn*T + cOut*O - credits)
+//     / (cIn - cRead), clamped to [0, T]; cache_creation stays 0.
+//   - credits below min: cache_read clamps to T (cheapest base), overflow
+//     discarded, cache_creation stays 0. Billing will exceed credits, but token
+//     splits cannot go lower while preserving the context base.
+//   - credits above max (even all-uncached input cannot reach credits): bill all
+//     input as uncached and make up the remaining credits with cache_creation
+//     tokens: cc = round((credits - max) / cCre). This is the only case where
+//     cache_creation is non-zero.
+//
+// Invariant: input_tokens + cache_read_input_tokens always equals the original
+// input total T, so downstream context-size accounting covers the full prompt.
+// cache_creation_input_tokens, when present, is reported in addition to T as a
+// pure billing make-up and never reduces the context base.
+func ApplyKiroCreditCacheSplit(model string, detail *usage.Detail) {
+	if detail == nil {
+		return
+	}
+	// model is kiroModelID (mapModelToKiro's output) — already the canonical
+	// backend ID, so it can be used directly as the rate-table key.
+	pricing, ok := officialBasePrices[model]
+	totalInput, output, credits := detail.InputTokens, detail.OutputTokens, detail.Credits
+
+	detail.CacheCreationTokens = 0
+
+	if !ok {
+		log.Warnf("kiro: model %q absent from credit rate table, using fallback Opus pricing", model)
+		pricing = fallbackPricing
+	}
+	if credits <= 0 || totalInput <= 0 {
+		return
+	}
+
+	// Per-token credit rates for each bucket (credits per token).
+	cIn := (pricing.input / 1e6) / creditToUSD
+	cRead := (pricing.cacheRead / 1e6) / creditToUSD
+	cCre := (pricing.cacheCreation / 1e6) / creditToUSD
+	cOut := (pricing.output / 1e6) / creditToUSD
+	if cIn <= cRead {
+		// Degenerate pricing (no spread between uncached and cache_read); cannot
+		// back-solve a meaningful split. Leave the upstream input total untouched
+		// (no cache split), matching the credits<=0 / totalInput<=0 early returns.
+		return
+	}
+
+	outputCredits := cOut * float64(output)
+	maxNoCacheCreation := cIn*float64(totalInput) + outputCredits
+
+	if credits > maxNoCacheCreation && cCre > 0 {
+		// Even billing all input as uncached cannot reach credits; make up the
+		// shortfall with cache_creation tokens.
+		cacheCreation := int64((credits-maxNoCacheCreation)/cCre + 0.5)
+		cacheCreation = max(cacheCreation, 0)
+		detail.InputTokens = totalInput
+		detail.CacheReadTokens = 0
+		detail.CachedTokens = 0
+		detail.CacheCreationTokens = cacheCreation
+		detail.TotalTokens = totalInput + output
+		return
+	}
+
+	// Back-solve cache_read R from credits = cIn*(T-R) + cRead*R + cOut*O.
+	solvedCacheRead := int64((maxNoCacheCreation - credits) / (cIn - cRead))
+	uncachedInput, cacheRead := fitKiroCacheSplit(totalInput, solvedCacheRead)
+
+	detail.CacheReadTokens = cacheRead
+	detail.CachedTokens = cacheRead
+	detail.InputTokens = uncachedInput
+	// input_tokens + cache_read_input_tokens stays equal to the original input
+	// total, so context-size accounting is unchanged. Restate the token count for
+	// callers that pass an unset total.
+	detail.TotalTokens = totalInput + output
+}
+
+// fitKiroCacheSplit distributes the back-solved cache_read across the input
+// buckets while guaranteeing input_tokens + cache_read_input_tokens == totalInput.
+// The solved cache_read is clamped to [0, totalInput]; any overflow beyond
+// totalInput is discarded (cache_creation stays 0) rather than billed as the
+// expensive cache-creation bucket.
+func fitKiroCacheSplit(totalInput, solvedCacheRead int64) (uncachedInput, cacheRead int64) {
+	switch {
+	case solvedCacheRead <= 0:
+		uncachedInput, cacheRead = totalInput, 0
+	case solvedCacheRead >= totalInput:
+		// Clamp to T: fill cache_read to the full input total, discard overflow.
+		uncachedInput, cacheRead = 0, totalInput
+	default:
+		uncachedInput, cacheRead = totalInput-solvedCacheRead, solvedCacheRead
+	}
+
+	// Guarantee at least one uncached input token so callers never report
+	// input_tokens <= 0; borrow it from cache_read to keep input + cache_read
+	// equal to totalInput. totalInput >= 1 is ensured by ApplyKiroCreditCacheSplit.
+	if uncachedInput < 1 {
+		cacheRead--
+		uncachedInput = 1
+	}
+	return uncachedInput, cacheRead
+}

--- a/internal/runtime/executor/helps/kiro_credit_rates.go
+++ b/internal/runtime/executor/helps/kiro_credit_rates.go
@@ -31,12 +31,12 @@ var officialBasePrices = map[string]modelPricing{
 }
 
 // Kiro credit pricing basis.
-//   - creditToUSD: 20$ = 1000 credits => 1 credit = $0.02.
+//   - creditToUSD: 1 credit = $0.03.
 //
 // Derived credit rate per base-input token: c = (input/1e6) / creditToUSD.
 //
-//	Opus 4.7   ($5/MTok): (5/1e6)/0.02 = 0.000250 credits/token
-//	Sonnet 4.6 ($3/MTok): (3/1e6)/0.02 = 0.000150 credits/token
+//	Opus 4.7   ($5/MTok): (5/1e6)/0.03 = 0.000167 credits/token
+//	Sonnet 4.6 ($3/MTok): (3/1e6)/0.03 = 0.000100 credits/token
 const (
 	creditToUSD = 0.03 // USD per credit
 )

--- a/internal/runtime/executor/helps/kiro_credit_rates.go
+++ b/internal/runtime/executor/helps/kiro_credit_rates.go
@@ -38,7 +38,7 @@ var officialBasePrices = map[string]modelPricing{
 //	Opus 4.7   ($5/MTok): (5/1e6)/0.02 = 0.000250 credits/token
 //	Sonnet 4.6 ($3/MTok): (3/1e6)/0.02 = 0.000150 credits/token
 const (
-	creditToUSD = 20.0 / 1000.0 // 0.02 USD per credit
+	creditToUSD = 0.03 // USD per credit
 )
 
 // fallbackPricing is used when a model is absent from officialBasePrices.

--- a/internal/runtime/executor/helps/kiro_credit_rates_test.go
+++ b/internal/runtime/executor/helps/kiro_credit_rates_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestApplyKiroCreditCacheSplit(t *testing.T) {
-	// Opus 4.7 rates: cIn=(5/1e6)/0.02=0.000250, cRead=0.000025,
-	// cCre=0.0003125, cOut=0.00125 credits/token.
+	// Opus 4.7 rates: cIn=(5/1e6)/0.03=0.000167, cRead=0.000017,
+	// cCre=0.0002083, cOut=0.000833 credits/token.
 	tests := []struct {
 		name                                   string
 		model                                  string
@@ -17,11 +17,11 @@ func TestApplyKiroCreditCacheSplit(t *testing.T) {
 		wantInput, wantCacheRead, wantCacheCre int64
 	}{
 		{
-			// credits below the min billable base (cRead*T + cOut*O), so cache_read
-			// clamps to T (minus 1 borrowed for uncached); cache_creation stays 0.
+			// credits within [min,max]: back-solve cache_read R from
+			// credits = cIn*(T-R) + cRead*R + cOut*O. Uncached = T - R.
 			name: "opus-4.7 real log", model: "claude-opus-4.7",
 			input: 7982, output: 52, credits: 0.1847,
-			wantInput: 1, wantCacheRead: 7981, wantCacheCre: 0,
+			wantInput: 56, wantCacheRead: 7926, wantCacheCre: 0,
 		},
 		{
 			// Unknown model falls back to Opus pricing; credits below min base, so
@@ -32,10 +32,10 @@ func TestApplyKiroCreditCacheSplit(t *testing.T) {
 		},
 		{
 			// credits within [min,max]: back-solve R = (cIn*T - credits)/(cIn-cRead)
-			// = (0.25 - 0.125)/0.000225 = 555. Uncached = T - R = 445.
+			// = (0.166667 - 0.125)/0.000150 = 277. Uncached = T - R = 723.
 			name: "cache read within total", model: "claude-opus-4.7",
 			input: 1000, output: 0, credits: 0.125,
-			wantInput: 445, wantCacheRead: 555, wantCacheCre: 0,
+			wantInput: 723, wantCacheRead: 277, wantCacheCre: 0,
 		},
 		{
 			name: "zero credits no split", model: "claude-opus-4.7",
@@ -48,12 +48,12 @@ func TestApplyKiroCreditCacheSplit(t *testing.T) {
 			wantInput: 0, wantCacheRead: 0, wantCacheCre: 0,
 		},
 		{
-			// credits above max base (cIn*T + cOut*O = 0.25 + 0.0125 = 0.2625):
+			// credits above max base (cIn*T + cOut*O = 0.166667 + 0.008333 = 0.175):
 			// bill all input as uncached and make up the rest with cache_creation.
-			// cc = round((1.0 - 0.2625)/0.0003125) = 2360.
+			// cc = round((1.0 - 0.175)/0.0002083) = 3960.
 			name: "credits above base make up with cache creation", model: "claude-opus-4.7",
 			input: 1000, output: 10, credits: 1.0,
-			wantInput: 1000, wantCacheRead: 0, wantCacheCre: 2360,
+			wantInput: 1000, wantCacheRead: 0, wantCacheCre: 3960,
 		},
 		{
 			// Cheap call (credits below min base) => cache_read clamps to T-1 and the
@@ -99,7 +99,7 @@ func TestApplyKiroCreditCacheSplit(t *testing.T) {
 // credits exceed the all-uncached base, the cache_creation make-up brings the
 // official-price billing back to (approximately) the upstream credit value.
 func TestApplyKiroCreditCacheSplitMakeUpReconstructsCredits(t *testing.T) {
-	const creditToUSD = 20.0 / 1000.0
+	const creditToUSD = 0.03
 	// Opus pricing ($/MTok).
 	cIn := (5.0 / 1e6) / creditToUSD
 	cCre := (6.25 / 1e6) / creditToUSD

--- a/internal/runtime/executor/helps/kiro_credit_rates_test.go
+++ b/internal/runtime/executor/helps/kiro_credit_rates_test.go
@@ -1,0 +1,119 @@
+package helps
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+func TestApplyKiroCreditCacheSplit(t *testing.T) {
+	// Opus 4.7 rates: cIn=(5/1e6)/0.02=0.000250, cRead=0.000025,
+	// cCre=0.0003125, cOut=0.00125 credits/token.
+	tests := []struct {
+		name                                   string
+		model                                  string
+		input, output                          int64
+		credits                                float64
+		wantInput, wantCacheRead, wantCacheCre int64
+	}{
+		{
+			// credits below the min billable base (cRead*T + cOut*O), so cache_read
+			// clamps to T (minus 1 borrowed for uncached); cache_creation stays 0.
+			name: "opus-4.7 real log", model: "claude-opus-4.7",
+			input: 7982, output: 52, credits: 0.1847,
+			wantInput: 1, wantCacheRead: 7981, wantCacheCre: 0,
+		},
+		{
+			// Unknown model falls back to Opus pricing; credits below min base, so
+			// cache_read clamps to T-1, cache_creation stays 0.
+			name: "unknown model uses fallback price", model: "gpt-4o",
+			input: 1000, output: 100, credits: 0.05,
+			wantInput: 1, wantCacheRead: 999, wantCacheCre: 0,
+		},
+		{
+			// credits within [min,max]: back-solve R = (cIn*T - credits)/(cIn-cRead)
+			// = (0.25 - 0.125)/0.000225 = 555. Uncached = T - R = 445.
+			name: "cache read within total", model: "claude-opus-4.7",
+			input: 1000, output: 0, credits: 0.125,
+			wantInput: 445, wantCacheRead: 555, wantCacheCre: 0,
+		},
+		{
+			name: "zero credits no split", model: "claude-opus-4.7",
+			input: 1000, output: 100, credits: 0,
+			wantInput: 1000, wantCacheRead: 0, wantCacheCre: 0,
+		},
+		{
+			name: "zero input no split", model: "claude-opus-4.7",
+			input: 0, output: 100, credits: 0.05,
+			wantInput: 0, wantCacheRead: 0, wantCacheCre: 0,
+		},
+		{
+			// credits above max base (cIn*T + cOut*O = 0.25 + 0.0125 = 0.2625):
+			// bill all input as uncached and make up the rest with cache_creation.
+			// cc = round((1.0 - 0.2625)/0.0003125) = 2360.
+			name: "credits above base make up with cache creation", model: "claude-opus-4.7",
+			input: 1000, output: 10, credits: 1.0,
+			wantInput: 1000, wantCacheRead: 0, wantCacheCre: 2360,
+		},
+		{
+			// Cheap call (credits below min base) => cache_read clamps to T-1 and the
+			// overflow is discarded, so cache_creation stays 0.
+			name: "credits below base discards excess, no cache creation", model: "claude-opus-4.7",
+			input: 1000, output: 0, credits: 0.000001,
+			wantInput: 1, wantCacheRead: 999, wantCacheCre: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := usage.Detail{InputTokens: tc.input, OutputTokens: tc.output, Credits: tc.credits}
+			ApplyKiroCreditCacheSplit(tc.model, &d)
+			if d.InputTokens != tc.wantInput {
+				t.Errorf("InputTokens = %d, want %d", d.InputTokens, tc.wantInput)
+			}
+			if d.CacheReadTokens != tc.wantCacheRead {
+				t.Errorf("CacheReadTokens = %d, want %d", d.CacheReadTokens, tc.wantCacheRead)
+			}
+			if d.CachedTokens != tc.wantCacheRead {
+				t.Errorf("CachedTokens = %d, want %d", d.CachedTokens, tc.wantCacheRead)
+			}
+			if d.CacheCreationTokens != tc.wantCacheCre {
+				t.Errorf("CacheCreationTokens = %d, want %d", d.CacheCreationTokens, tc.wantCacheCre)
+			}
+			// Context-size invariant: uncached input + cache_read always equals
+			// the original total input, so context accounting covers the full
+			// prompt. cache_creation, when present, is a billing make-up reported
+			// on top of T, never carved out of the context base.
+			gotContextBase := d.InputTokens + d.CacheReadTokens
+			if gotContextBase != tc.input {
+				t.Errorf("input+cache_read = %d, want T = %d", gotContextBase, tc.input)
+			}
+			// Uncached input is never reported as zero or negative when a split occurs.
+			if tc.credits > 0 && tc.input > 0 && d.InputTokens < 1 {
+				t.Errorf("InputTokens = %d, want >= 1", d.InputTokens)
+			}
+		})
+	}
+}
+
+// TestApplyKiroCreditCacheSplitMakeUpReconstructsCredits verifies that when
+// credits exceed the all-uncached base, the cache_creation make-up brings the
+// official-price billing back to (approximately) the upstream credit value.
+func TestApplyKiroCreditCacheSplitMakeUpReconstructsCredits(t *testing.T) {
+	const creditToUSD = 20.0 / 1000.0
+	// Opus pricing ($/MTok).
+	cIn := (5.0 / 1e6) / creditToUSD
+	cCre := (6.25 / 1e6) / creditToUSD
+	cOut := (25.0 / 1e6) / creditToUSD
+
+	d := usage.Detail{InputTokens: 1000, OutputTokens: 10, Credits: 1.0}
+	ApplyKiroCreditCacheSplit("claude-opus-4.7", &d)
+
+	billed := cIn*float64(d.InputTokens) + cCre*float64(d.CacheCreationTokens) + cOut*float64(d.OutputTokens)
+	if diff := billed - d.Credits; diff < -cCre || diff > cCre {
+		t.Errorf("billed credits = %.6f, want within one cache_creation token of %.6f", billed, d.Credits)
+	}
+}
+
+func TestApplyKiroCreditCacheSplitNilDetail(t *testing.T) {
+	ApplyKiroCreditCacheSplit("claude-opus-4.7", nil) // must not panic
+}

--- a/internal/runtime/executor/kiro_executor.go
+++ b/internal/runtime/executor/kiro_executor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/uuid"
 	kiroauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/kiro"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	kiroclaude "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/kiro/claude"
 	kirocommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/kiro/common"
 	kiroopenai "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/kiro/openai"
@@ -1008,6 +1009,9 @@ func (e *KiroExecutor) executeWithRetry(ctx context.Context, auth *cliproxyauth.
 			// 3. Update TotalTokens
 			usageInfo.TotalTokens = usageInfo.InputTokens + usageInfo.OutputTokens
 
+			// Derive cache_read split from credits for billing compatibility.
+			helps.ApplyKiroCreditCacheSplit(kiroModelID, &usageInfo)
+
 			appendAPIResponseChunk(ctx, e.cfg, []byte(content))
 			reporter.publish(ctx, usageInfo)
 
@@ -1431,7 +1435,7 @@ func (e *KiroExecutor) executeStreamWithRetry(ctx context.Context, auth *cliprox
 				// So we always enable thinking parsing for Kiro responses
 				log.Debugf("kiro: stream thinkingEnabled = %v (always true for Kiro)", thinkingEnabled)
 
-				e.streamToChannel(ctx, resp.Body, out, from, payloadRequestedModel(opts, req.Model), opts.OriginalRequest, body, reporter, thinkingEnabled)
+				e.streamToChannel(ctx, resp.Body, out, from, payloadRequestedModel(opts, req.Model), kiroModelID, opts.OriginalRequest, body, reporter, thinkingEnabled)
 			}(httpResp, thinkingEnabled)
 
 			return out, nil
@@ -1655,6 +1659,7 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 
 	// Upstream usage tracking - Kiro API returns credit usage and context percentage
 	var upstreamContextPercentage float64 // Context usage percentage from upstream (e.g., 78.56)
+	var upstreamCreditUsage float64       // Credit usage from upstream meteringEvent (e.g., 0.1847)
 
 	for {
 		msg, eventErr := e.readEventStreamMessage(reader)
@@ -1937,9 +1942,8 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 				if u, ok := metering["usage"].(float64); ok {
 					usageVal = u
 				}
-				log.Infof("kiro: parseEventStream received meteringEvent: usage=%.2f %s", usageVal, unit)
-				// Store metering info for potential billing/statistics purposes
-				// Note: This is separate from token counts - it's AWS billing units
+				upstreamCreditUsage = usageVal
+				log.Infof("kiro: parseEventStream received meteringEvent: usage=%.4f %s", usageVal, unit)
 			} else {
 				// Try direct fields
 				unit := ""
@@ -1951,7 +1955,8 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 					usageVal = u
 				}
 				if unit != "" || usageVal > 0 {
-					log.Infof("kiro: parseEventStream received meteringEvent (direct): usage=%.2f %s", usageVal, unit)
+					upstreamCreditUsage = usageVal
+					log.Infof("kiro: parseEventStream received meteringEvent (direct): usage=%.4f %s", usageVal, unit)
 				}
 			}
 
@@ -2113,6 +2118,9 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 				upstreamContextPercentage, calculatedInputTokens, localEstimate)
 		}
 	}
+
+	// Carry upstream credit usage (meteringEvent) into the usage detail.
+	usageInfo.Credits = upstreamCreditUsage
 
 	return cleanedContent, toolUses, usageInfo, stopReason, nil
 }
@@ -2314,7 +2322,7 @@ func (e *KiroExecutor) extractEventTypeFromBytes(headers []byte) string {
 // Implements duplicate content filtering using lastContentEvent detection (based on AIClient-2-API).
 // Extracts stop_reason from upstream events when available.
 // thinkingEnabled controls whether <thinking> tags are parsed - only parse when request enabled thinking.
-func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out chan<- cliproxyexecutor.StreamChunk, targetFormat sdktranslator.Format, model string, originalReq, claudeBody []byte, reporter *usageReporter, thinkingEnabled bool) {
+func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out chan<- cliproxyexecutor.StreamChunk, targetFormat sdktranslator.Format, model, kiroModelID string, originalReq, claudeBody []byte, reporter *usageReporter, thinkingEnabled bool) {
 	reader := bufio.NewReaderSize(body, 20*1024*1024) // 20MB buffer to match other providers
 	var totalUsage usage.Detail
 	var hasToolUses bool          // Track if any tool uses were emitted
@@ -3423,6 +3431,14 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 	}
 
 	totalUsage.TotalTokens = totalUsage.InputTokens + totalUsage.OutputTokens
+
+	// Carry upstream credit usage (meteringEvent) into the usage detail.
+	if upstreamCreditUsage > 0 {
+		totalUsage.Credits = upstreamCreditUsage
+	}
+
+	// Derive cache_read split from credits for billing compatibility.
+	helps.ApplyKiroCreditCacheSplit(kiroModelID, &totalUsage)
 
 	// Log upstream usage information if received
 	if hasUpstreamUsage {

--- a/internal/runtime/executor/kiro_executor.go
+++ b/internal/runtime/executor/kiro_executor.go
@@ -2403,10 +2403,10 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 	isTextBlockOpen := false
 	var outputLen int
 
-	// Ensure usage is published even on early return
-	defer func() {
-		reporter.publish(ctx, totalUsage)
-	}()
+	// NOTE: usage is published only once on the successful end of stream (see the
+	// reporter.publish call after message_stop below). Every error path returns
+	// early without publishing, so pre-calculated input tokens are never billed for
+	// requests that failed (e.g. oversized context, upstream error events).
 
 	for {
 		select {
@@ -3477,7 +3477,10 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 	for _, chunk := range sseData {
 		enqueueTranslatedSSE(out, chunk)
 	}
-	// reporter.publish is called via defer
+
+	// Publish usage only after the stream completed successfully. Error paths above
+	// return early without reaching here, so failed requests report no usage.
+	reporter.publish(ctx, totalUsage)
 }
 
 // NOTE: Claude SSE event builders moved to internal/translator/kiro/claude/kiro_claude_stream.go

--- a/internal/translator/kiro/claude/kiro_claude_request.go
+++ b/internal/translator/kiro/claude/kiro_claude_request.go
@@ -642,14 +642,143 @@ func convertClaudeToolsToKiro(tools gjson.Result) []KiroToolWrapper {
 	return kiroTools
 }
 
+// extractSystemMessageText extracts the plain text from a mid-conversation
+// system message content, which may be a string or an array of text blocks.
+func extractSystemMessageText(content gjson.Result) string {
+	if content.Type == gjson.String {
+		return content.String()
+	}
+	if content.IsArray() {
+		var b strings.Builder
+		for _, part := range content.Array() {
+			if part.Get("type").String() == "text" {
+				if b.Len() > 0 {
+					b.WriteString("\n")
+				}
+				b.WriteString(part.Get("text").String())
+			}
+		}
+		return b.String()
+	}
+	return ""
+}
+
+// nearestUserIndex returns the index of the nearest "user" message scanning
+// from start toward end with the given step (-1 for backward, +1 for forward).
+// Returns -1 when none is found.
+func nearestUserIndex(messages []gjson.Result, start, step int) int {
+	for i := start; i >= 0 && i < len(messages); i += step {
+		if messages[i].Get("role").String() == "user" {
+			return i
+		}
+	}
+	return -1
+}
+
+// mergeSystemTextIntoUser rebuilds a user message with the given system text
+// blocks prepended and/or appended to its content, preserving any other fields.
+func mergeSystemTextIntoUser(m gjson.Result, prefix, suffix []string) gjson.Result {
+	var blocks []interface{}
+	for _, t := range prefix {
+		blocks = append(blocks, map[string]interface{}{"type": "text", "text": t})
+	}
+	content := m.Get("content")
+	if content.IsArray() {
+		for _, b := range content.Array() {
+			blocks = append(blocks, b.Value())
+		}
+	} else if content.Type == gjson.String && content.String() != "" {
+		blocks = append(blocks, map[string]interface{}{"type": "text", "text": content.String()})
+	}
+	for _, t := range suffix {
+		blocks = append(blocks, map[string]interface{}{"type": "text", "text": t})
+	}
+
+	msgMap := make(map[string]interface{})
+	m.ForEach(func(k, v gjson.Result) bool {
+		msgMap[k.String()] = v.Value()
+		return true
+	})
+	msgMap["content"] = blocks
+	b, err := json.Marshal(msgMap)
+	if err != nil {
+		log.Debugf("kiro: failed to merge system text into user message: %v", err)
+		return m
+	}
+	return gjson.ParseBytes(b)
+}
+
+// foldSystemMessages folds mid-conversation system messages (Anthropic
+// mid-conversation-system-2026-04-07 beta) into adjacent user turns. Kiro has no
+// concept of a system role inside the conversation, so dropping these messages
+// would lose content and, when a system message is last, break the user/assistant
+// alternation Kiro requires (causing "Improperly formed request"). Each system
+// message's text is attached to the nearest preceding user turn; if none exists,
+// to the nearest following user turn; otherwise it is promoted to a standalone
+// user message.
+func foldSystemMessages(messages []gjson.Result) []gjson.Result {
+	hasSystem := false
+	for _, m := range messages {
+		if m.Get("role").String() == "system" {
+			hasSystem = true
+			break
+		}
+	}
+	if !hasSystem {
+		return messages
+	}
+
+	prefixText := make(map[int][]string)
+	suffixText := make(map[int][]string)
+	var orphanSystem []string
+
+	for i, m := range messages {
+		if m.Get("role").String() != "system" {
+			continue
+		}
+		txt := extractSystemMessageText(m.Get("content"))
+		if strings.TrimSpace(txt) == "" {
+			continue
+		}
+		if j := nearestUserIndex(messages, i-1, -1); j >= 0 {
+			suffixText[j] = append(suffixText[j], txt)
+		} else if j := nearestUserIndex(messages, i+1, 1); j >= 0 {
+			prefixText[j] = append(prefixText[j], txt)
+		} else {
+			orphanSystem = append(orphanSystem, txt)
+		}
+	}
+
+	result := make([]gjson.Result, 0, len(messages))
+	for i, m := range messages {
+		role := m.Get("role").String()
+		if role == "system" {
+			continue
+		}
+		if role == "user" && (len(prefixText[i]) > 0 || len(suffixText[i]) > 0) {
+			m = mergeSystemTextIntoUser(m, prefixText[i], suffixText[i])
+		}
+		result = append(result, m)
+	}
+	for _, txt := range orphanSystem {
+		b, _ := json.Marshal(map[string]interface{}{"role": "user", "content": txt})
+		result = append(result, gjson.ParseBytes(b))
+	}
+	log.Infof("kiro: folded mid-conversation system message(s) into user turns")
+	return result
+}
+
 // processMessages processes Claude messages and builds Kiro history
 func processMessages(messages gjson.Result, modelID, origin string) ([]KiroHistoryMessage, *KiroUserInputMessage, []KiroToolResult) {
 	var history []KiroHistoryMessage
 	var currentUserMsg *KiroUserInputMessage
 	var currentToolResults []KiroToolResult
 
+	// Fold any mid-conversation system messages into adjacent user turns before
+	// merging, so the user/assistant alternation Kiro requires stays intact.
+	folded := foldSystemMessages(messages.Array())
 	// Merge adjacent messages with the same role
-	messagesArray := kirocommon.MergeAdjacentMessages(messages.Array())
+	messagesArray := kirocommon.MergeAdjacentMessages(folded)
 
 	// FIX: Kiro API requires history to start with a user message.
 	// Some clients (e.g., OpenClaw) send conversations starting with an assistant message,
@@ -999,4 +1128,3 @@ func BuildAssistantMessageStruct(msg gjson.Result) KiroAssistantResponseMessage 
 		ToolUses: toolUses,
 	}
 }
-

--- a/internal/translator/kiro/claude/kiro_claude_request_test.go
+++ b/internal/translator/kiro/claude/kiro_claude_request_test.go
@@ -106,6 +106,84 @@ func TestBuildKiroPayload_NoToolsNoHistoryToolUse(t *testing.T) {
 	}
 }
 
+// TestBuildKiroPayload_MidConversationSystem reproduces the production 400
+// ("Improperly formed request") triggered by Anthropic's
+// mid-conversation-system-2026-04-07 beta: the messages array contains
+// role:"system" entries interleaved with user/assistant turns, and the LAST
+// message is a system message. Without folding, the trailing system breaks
+// isLastMessage detection so currentMessage becomes a placeholder and history
+// ends with a user turn, which Kiro rejects.
+//
+// Expected: the real last user turn becomes currentMessage, the trailing system
+// text is folded onto it, and no content is dropped.
+func TestBuildKiroPayload_MidConversationSystem(t *testing.T) {
+	claudeReq := `{
+		"model": "claude-opus-4",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": "hi"},
+			{"role": "system", "content": "SKILL_LIST_MARKER"},
+			{"role": "assistant", "content": [{"type": "text", "text": "ok"}]},
+			{"role": "user", "content": "do the thing"},
+			{"role": "system", "content": "DATE_CHANGED_MARKER"}
+		]
+	}`
+
+	out, _ := BuildKiroPayload([]byte(claudeReq), "claude-opus-4", "arn:test", "test", true, false, http.Header{}, nil)
+	if len(out) == 0 {
+		t.Fatal("expected non-empty payload")
+	}
+
+	currentContent := gjson.GetBytes(out, "conversationState.currentMessage.userInputMessage.content").String()
+	// The real last user turn must drive currentMessage (not a placeholder).
+	if !strings.Contains(currentContent, "do the thing") {
+		t.Fatalf("expected last user turn as currentMessage, got: %q", currentContent)
+	}
+	// The trailing system text must be folded onto the last user turn, not dropped.
+	if !strings.Contains(currentContent, "DATE_CHANGED_MARKER") {
+		t.Fatalf("expected trailing system text folded into currentMessage, got: %q", currentContent)
+	}
+
+	// The earlier system text must survive too: it should be folded onto the
+	// preceding user turn ("hi") which is now in history.
+	allOut := string(out)
+	if !strings.Contains(allOut, "SKILL_LIST_MARKER") {
+		t.Fatalf("expected earlier system text preserved somewhere in payload, got: %s", allOut)
+	}
+
+	// History must not end with a dangling user turn caused by misdetection:
+	// with proper folding, the last history entry is the assistant response.
+	history := gjson.GetBytes(out, "conversationState.history").Array()
+	if len(history) == 0 {
+		t.Fatal("expected non-empty history")
+	}
+	last := history[len(history)-1]
+	if last.Get("assistantResponseMessage").Exists() == false {
+		t.Fatalf("expected history to end with assistant response, got: %s", last.Raw)
+	}
+}
+
+// TestBuildKiroPayload_LeadingSystemMessage covers a system message that has no
+// preceding user turn: its text must fold forward onto the following user turn.
+func TestBuildKiroPayload_LeadingSystemMessage(t *testing.T) {
+	claudeReq := `{
+		"model": "claude-opus-4",
+		"max_tokens": 256,
+		"messages": [
+			{"role": "system", "content": "LEADING_SYSTEM_MARKER"},
+			{"role": "user", "content": "question"}
+		]
+	}`
+	out, _ := BuildKiroPayload([]byte(claudeReq), "claude-opus-4", "arn:test", "test", false, true, http.Header{}, nil)
+	currentContent := gjson.GetBytes(out, "conversationState.currentMessage.userInputMessage.content").String()
+	if !strings.Contains(currentContent, "question") {
+		t.Fatalf("expected user turn in currentMessage, got: %q", currentContent)
+	}
+	if !strings.Contains(currentContent, "LEADING_SYSTEM_MARKER") {
+		t.Fatalf("expected leading system text folded forward into user turn, got: %q", currentContent)
+	}
+}
+
 // TestSynthesizeToolSpecsFromHistory_Dedup ensures repeated tool names yield a
 // single stub.
 func TestSynthesizeToolSpecsFromHistory_Dedup(t *testing.T) {

--- a/internal/translator/kiro/claude/kiro_claude_response.go
+++ b/internal/translator/kiro/claude/kiro_claude_response.go
@@ -107,8 +107,11 @@ func BuildClaudeResponse(content string, toolUses []KiroToolUse, model string, u
 		"content":     contentBlocks,
 		"stop_reason": stopReason,
 		"usage": map[string]interface{}{
-			"input_tokens":  usageInfo.InputTokens,
-			"output_tokens": usageInfo.OutputTokens,
+			"input_tokens":                usageInfo.InputTokens,
+			"output_tokens":               usageInfo.OutputTokens,
+			"cache_creation_input_tokens": usageInfo.CacheCreationTokens,
+			"cache_read_input_tokens":     usageInfo.CacheReadTokens,
+			"credits":                     usageInfo.Credits,
 		},
 	}
 	result, _ := json.Marshal(response)

--- a/internal/translator/kiro/claude/kiro_claude_stream.go
+++ b/internal/translator/kiro/claude/kiro_claude_stream.go
@@ -118,8 +118,11 @@ func BuildClaudeMessageDeltaEvent(stopReason string, usageInfo usage.Detail) []b
 			"stop_sequence": nil,
 		},
 		"usage": map[string]interface{}{
-			"input_tokens":  usageInfo.InputTokens,
-			"output_tokens": usageInfo.OutputTokens,
+			"input_tokens":                usageInfo.InputTokens,
+			"output_tokens":               usageInfo.OutputTokens,
+			"cache_creation_input_tokens": usageInfo.CacheCreationTokens,
+			"cache_read_input_tokens":     usageInfo.CacheReadTokens,
+			"credits":                     usageInfo.Credits,
 		},
 	}
 	deltaResult, _ := json.Marshal(deltaEvent)

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -54,6 +54,9 @@ type Detail struct {
 	CacheReadTokens     int64
 	CacheCreationTokens int64
 	TotalTokens         int64
+	// Credits holds the provider-billed credit usage (e.g. Kiro meteringEvent).
+	// Zero means the upstream did not report credit usage.
+	Credits float64
 }
 
 type requestedModelAliasContextKey struct{}

--- a/sync-upstream.sh
+++ b/sync-upstream.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# sync-upstream.sh
+# Fetch the upstream main branch (with prune) and sync it into the current branch.
+#
+# Usage:
+#   ./sync-upstream.sh                # fetch upstream/main and merge into current branch
+#   ./sync-upstream.sh --rebase       # rebase current branch onto upstream/main instead of merging
+#   REMOTE=upstream BRANCH=main ./sync-upstream.sh   # override remote/branch via env
+#
+set -euo pipefail
+
+REMOTE="${REMOTE:-upstream}"
+BRANCH="${BRANCH:-main}"
+MODE="merge"
+
+for arg in "$@"; do
+  case "$arg" in
+    --rebase) MODE="rebase" ;;
+    --merge)  MODE="merge" ;;
+    -h|--help)
+      echo "Usage: $0 [--merge|--rebase]"
+      echo "  REMOTE=$REMOTE BRANCH=$BRANCH (override via env vars)"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Must be inside a git work tree.
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Error: not inside a git repository." >&2
+  exit 1
+fi
+
+# Confirm the remote exists.
+if ! git remote get-url "$REMOTE" >/dev/null 2>&1; then
+  echo "Error: remote '$REMOTE' not found. Available remotes:" >&2
+  git remote -v >&2
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$CURRENT_BRANCH" = "HEAD" ]; then
+  echo "Error: detached HEAD state. Checkout a branch first." >&2
+  exit 1
+fi
+
+# Warn if there are uncommitted changes.
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "Error: you have uncommitted changes. Commit or stash them first." >&2
+  git status -s >&2
+  exit 1
+fi
+
+echo ">> Fetching $REMOTE/$BRANCH (with prune)..."
+git fetch -p "$REMOTE" "$BRANCH"
+
+echo ">> Syncing $REMOTE/$BRANCH into '$CURRENT_BRANCH' (mode: $MODE)..."
+if [ "$MODE" = "rebase" ]; then
+  git rebase "$REMOTE/$BRANCH"
+else
+  git merge "$REMOTE/$BRANCH"
+fi
+
+echo ">> Done. '$CURRENT_BRANCH' is now synced with $REMOTE/$BRANCH."


### PR DESCRIPTION
## Summary
Port fork-local Kiro usage fixes onto current upstream `main`. This makes Claude-compatible Kiro responses expose credit-based usage details and avoids recording usage for failed streams.

## Changes
- Add Kiro credit-rate helpers that derive `cache_read_input_tokens`, `cache_creation_input_tokens`, and uncached input from upstream credits.
- Emit Kiro `credits`, cache-read, and cache-creation usage fields in Claude response and streaming events.
- Fold mid-conversation system messages into user turns for Kiro Claude requests.
- Publish Kiro stream usage only after successful `message_stop` completion.
- Add `sync-upstream.sh` to simplify future fork syncs.

## Related Issues
Related to #95.

## Testing
- [x] Unit tests added/updated
- [x] All tests pass: `go test ./...`
- [x] Build passes: `go build -o test-output ./cmd/server && rm test-output`
- [ ] Manual testing completed

## Checklist
- [x] No sensitive data exposed: changed-file sensitive filename scan and hardcoded-secret regex scan found no matches; `gitleaks` is not installed locally.
- [x] Linting and type checking passed: `gofmt` applied to changed Go files and `git diff --check upstream/main...HEAD` passed.
- [x] Documentation updated (if applicable)
- [x] Breaking changes documented (if applicable)
