### PR TITLE
fix(models): apply OAuth excluded model updates

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -38,10 +38,12 @@ import (
 	kiroauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/kiro"
 	qoderauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/qoder"
 	xaiauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/xai"
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/diff"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
@@ -1319,8 +1321,13 @@ func (h *Handler) PatchAuthFileStatus(c *gin.Context) {
 	}
 	targetAuth.UpdatedAt = time.Now()
 
-	if _, err := h.authManager.Update(ctx, targetAuth); err != nil {
+	updatedAuth, err := h.authManager.Update(ctx, targetAuth)
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to update auth: %v", err)})
+		return
+	}
+	if errHook := h.notifyAuthFilePersisted(ctx, updatedAuth); errHook != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to refresh auth: %v", errHook)})
 		return
 	}
 
@@ -1419,12 +1426,24 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 
 	targetAuth.UpdatedAt = time.Now()
 
-	if _, err := h.authManager.Update(ctx, targetAuth); err != nil {
+	updatedAuth, err := h.authManager.Update(ctx, targetAuth)
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to update auth: %v", err)})
+		return
+	}
+	if errHook := h.notifyAuthFilePersisted(ctx, updatedAuth); errHook != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to refresh auth: %v", errHook)})
 		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func (h *Handler) notifyAuthFilePersisted(ctx context.Context, auth *coreauth.Auth) error {
+	if h == nil || h.postAuthPersistHook == nil || auth == nil {
+		return nil
+	}
+	return h.postAuthPersistHook(ctx, auth)
 }
 
 func decodeAuthFileFieldValue(raw json.RawMessage) (any, error) {
@@ -1563,6 +1582,11 @@ func syncAuthFileMetadataFields(auth *coreauth.Auth, touchedRoots map[string]str
 	if _, ok := touchedRoots["disabled"]; ok {
 		syncAuthFileDisabledState(auth)
 	}
+	if _, ok := touchedRoots["excluded_models"]; ok {
+		syncAuthFileExcludedModelsAttribute(auth, touchedRoots)
+	} else if _, ok := touchedRoots["excluded-models"]; ok {
+		syncAuthFileExcludedModelsAttribute(auth, touchedRoots)
+	}
 }
 
 func syncAuthFileHeaderAttributes(auth *coreauth.Auth) {
@@ -1654,6 +1678,52 @@ func syncAuthFileWebsocketsAttribute(auth *coreauth.Auth) {
 		return
 	}
 	auth.Attributes["websockets"] = strconv.FormatBool(websockets)
+}
+
+func syncAuthFileExcludedModelsAttribute(auth *coreauth.Auth, touchedRoots map[string]struct{}) {
+	if auth == nil {
+		return
+	}
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	sourceKey := "excluded_models"
+	if _, okUnderscore := touchedRoots["excluded_models"]; !okUnderscore {
+		if _, okHyphen := touchedRoots["excluded-models"]; okHyphen {
+			sourceKey = "excluded-models"
+		}
+	}
+	excluded := authFileExcludedModelsValue(auth.Metadata[sourceKey])
+	excluded = internalconfig.NormalizeExcludedModels(excluded)
+	delete(auth.Metadata, "excluded-models")
+	if len(excluded) == 0 {
+		delete(auth.Metadata, "excluded_models")
+		delete(auth.Attributes, "excluded_models")
+		delete(auth.Attributes, "excluded_models_hash")
+		return
+	}
+	auth.Metadata["excluded_models"] = append([]string(nil), excluded...)
+	auth.Attributes["excluded_models"] = strings.Join(excluded, ",")
+	auth.Attributes["excluded_models_hash"] = diff.ComputeExcludedModelsHash(excluded)
+}
+
+func authFileExcludedModelsValue(value any) []string {
+	switch typed := value.(type) {
+	case []string:
+		return append([]string(nil), typed...)
+	case []any:
+		out := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if value, ok := item.(string); ok {
+				out = append(out, value)
+			}
+		}
+		return out
+	case string:
+		return strings.Split(typed, ",")
+	default:
+		return nil
+	}
 }
 
 func authFileBoolValue(value any) (bool, bool) {

--- a/internal/api/handlers/management/auth_files_patch_fields_test.go
+++ b/internal/api/handlers/management/auth_files_patch_fields_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/diff"
 	fileauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
@@ -163,6 +164,143 @@ func TestPatchAuthFileFields_HeadersEmptyMapIsNoop(t *testing.T) {
 	}
 	if got := headersMeta["X-Kee"]; got != "1" {
 		t.Fatalf("metadata.headers.X-Kee = %#v, want %q", got, "1")
+	}
+}
+
+func TestPatchAuthFileFields_SyncsExcludedModelsAttributes(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{
+		ID:       "kiro.json",
+		FileName: "kiro.json",
+		Provider: "kiro",
+		Attributes: map[string]string{
+			"path": "/tmp/kiro.json",
+		},
+		Metadata: map[string]any{
+			"type": "kiro",
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("failed to register auth record: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+
+	body := `{"name":"kiro.json","excluded_models":["kiro-auto"," KIRO-AUTO ","custom-undetected"]}`
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PatchAuthFileFields(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	updated, ok := manager.GetByID("kiro.json")
+	if !ok || updated == nil {
+		t.Fatalf("expected auth record to exist after patch")
+	}
+	if got := updated.Attributes["excluded_models"]; got != "kiro-auto,custom-undetected" {
+		t.Fatalf("attrs excluded_models = %q, want %q", got, "kiro-auto,custom-undetected")
+	}
+	if got, ok := updated.Metadata["excluded_models"].([]string); !ok || len(got) != 2 || got[0] != "kiro-auto" || got[1] != "custom-undetected" {
+		t.Fatalf("metadata excluded_models = %#v, want canonical []string", updated.Metadata["excluded_models"])
+	}
+	if _, ok := updated.Metadata["excluded-models"]; ok {
+		t.Fatalf("expected metadata excluded-models alias to be removed")
+	}
+	wantHash := diff.ComputeExcludedModelsHash([]string{"kiro-auto", "custom-undetected"})
+	if got := updated.Attributes["excluded_models_hash"]; got != wantHash {
+		t.Fatalf("attrs excluded_models_hash = %q, want %q", got, wantHash)
+	}
+}
+
+func TestPatchAuthFileFields_ExcludedModelsAliasReplacesAndClears(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{
+		ID:       "alias.json",
+		FileName: "alias.json",
+		Provider: "kiro",
+		Attributes: map[string]string{
+			"path":                 "/tmp/alias.json",
+			"excluded_models":      "stale-underscore,stale-hyphen",
+			"excluded_models_hash": "stale",
+		},
+		Metadata: map[string]any{
+			"type":            "kiro",
+			"excluded_models": []any{"stale-underscore"},
+			"excluded-models": []any{"stale-hyphen"},
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("failed to register auth record: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+
+	body := `{"name":"alias.json","excluded-models":["new-model"]}`
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PatchAuthFileFields(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	updated, ok := manager.GetByID("alias.json")
+	if !ok || updated == nil {
+		t.Fatalf("expected auth record to exist after patch")
+	}
+	if got := updated.Attributes["excluded_models"]; got != "new-model" {
+		t.Fatalf("attrs excluded_models = %q, want %q", got, "new-model")
+	}
+	if got, ok := updated.Metadata["excluded_models"].([]string); !ok || len(got) != 1 || got[0] != "new-model" {
+		t.Fatalf("metadata excluded_models = %#v, want [new-model]", updated.Metadata["excluded_models"])
+	}
+	if _, ok := updated.Metadata["excluded-models"]; ok {
+		t.Fatalf("expected metadata excluded-models alias to be removed")
+	}
+
+	body = `{"name":"alias.json","excluded_models":[]}`
+	rec = httptest.NewRecorder()
+	ctx, _ = gin.CreateTestContext(rec)
+	req = httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PatchAuthFileFields(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	updated, ok = manager.GetByID("alias.json")
+	if !ok || updated == nil {
+		t.Fatalf("expected auth record to exist after clear")
+	}
+	if _, ok := updated.Attributes["excluded_models"]; ok {
+		t.Fatalf("expected attrs excluded_models to be cleared")
+	}
+	if _, ok := updated.Attributes["excluded_models_hash"]; ok {
+		t.Fatalf("expected attrs excluded_models_hash to be cleared")
+	}
+	if _, ok := updated.Metadata["excluded_models"]; ok {
+		t.Fatalf("expected metadata excluded_models to be cleared")
+	}
+	if _, ok := updated.Metadata["excluded-models"]; ok {
+		t.Fatalf("expected metadata excluded-models alias to be cleared")
 	}
 }
 

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -1129,15 +1129,7 @@ func (s *Service) tryRegisterPluginModelsForAuth(ctx context.Context, a *coreaut
 			activeAuthKind = "apikey"
 		}
 	}
-	activeExcluded := s.oauthExcludedModels(providerKey, activeAuthKind)
-	if a == activeAuth && len(activeExcluded) == 0 {
-		activeExcluded = excluded
-	}
-	if activeAuth.Attributes != nil {
-		if val, ok := activeAuth.Attributes["excluded_models"]; ok && strings.TrimSpace(val) != "" {
-			activeExcluded = strings.Split(val, ",")
-		}
-	}
+	activeExcluded := s.effectiveAuthExcludedModels(activeAuth, providerKey, activeAuthKind, excluded)
 	models := applyExcludedModels(result.Models, activeExcluded)
 	models = applyOAuthModelAlias(s.cfg, providerKey, activeAuthKind, models)
 	if len(models) > 0 {
@@ -1785,14 +1777,7 @@ func (s *Service) registerModelsForAuth(ctx context.Context, a *coreauth.Auth) {
 	if compatDetected {
 		provider = "openai-compatibility"
 	}
-	excluded := s.oauthExcludedModels(provider, authKind)
-	// The synthesizer pre-merges per-account and global exclusions into the "excluded_models" attribute.
-	// If this attribute is present, it represents the complete list of exclusions and overrides the global config.
-	if a.Attributes != nil {
-		if val, ok := a.Attributes["excluded_models"]; ok && strings.TrimSpace(val) != "" {
-			excluded = strings.Split(val, ",")
-		}
-	}
+	excluded := s.effectiveAuthExcludedModels(a, provider, authKind, nil)
 	if s.tryRegisterPluginModelsForAuth(ctx, a, provider, authKind, excluded) {
 		return
 	}
@@ -2181,6 +2166,47 @@ func (s *Service) oauthExcludedModels(provider, authKind string) []string {
 		return nil
 	}
 	return cfg.OAuthExcludedModels[providerKey]
+}
+
+func (s *Service) effectiveAuthExcludedModels(auth *coreauth.Auth, provider, authKind string, fallback []string) []string {
+	return mergeExcludedModels(
+		fallback,
+		s.oauthExcludedModels(provider, authKind),
+		excludedModelsFromAuthAttributes(auth),
+	)
+}
+
+func excludedModelsFromAuthAttributes(auth *coreauth.Auth) []string {
+	if auth == nil || auth.Attributes == nil {
+		return nil
+	}
+	value := strings.TrimSpace(auth.Attributes["excluded_models"])
+	if value == "" {
+		return nil
+	}
+	return strings.Split(value, ",")
+}
+
+func mergeExcludedModels(lists ...[]string) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0)
+	for _, list := range lists {
+		for _, item := range list {
+			trimmed := strings.ToLower(strings.TrimSpace(item))
+			if trimmed == "" {
+				continue
+			}
+			if _, exists := seen[trimmed]; exists {
+				continue
+			}
+			seen[trimmed] = struct{}{}
+			out = append(out, trimmed)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func applyExcludedModels(models []*ModelInfo, excluded []string) []*ModelInfo {

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -2,15 +2,20 @@ package cliproxy
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
+	management "github.com/router-for-me/CLIProxyAPI/v7/internal/api/handlers/management"
 	internalregistry "github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 )
 
-func TestRegisterModelsForAuth_UsesPreMergedExcludedModelsAttribute(t *testing.T) {
+func TestRegisterModelsForAuth_MergesOAuthExcludedModelsFromConfigAndAuthAttribute(t *testing.T) {
 	service := &Service{
 		cfg: &config.Config{
 			OAuthExcludedModels: map[string][]string{
@@ -51,18 +56,95 @@ func TestRegisterModelsForAuth_UsesPreMergedExcludedModelsAttribute(t *testing.T
 		}
 	}
 
-	seenGlobalExcluded := false
 	for _, model := range models {
 		if model == nil {
 			continue
 		}
 		if strings.EqualFold(strings.TrimSpace(model.ID), "gemini-2.5-pro") {
-			seenGlobalExcluded = true
-			break
+			t.Fatalf("expected global excluded model %q to be excluded", model.ID)
 		}
 	}
-	if !seenGlobalExcluded {
-		t.Fatal("expected global excluded model to be present when attribute override is set")
+}
+
+func TestPatchAuthFileFields_RefreshesModelRegistryImmediately(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	service := &Service{
+		cfg:         &config.Config{AuthDir: t.TempDir()},
+		coreManager: manager,
+	}
+	auth := &coreauth.Auth{
+		ID:       "auth-gemini-cli-patch",
+		FileName: "gemini-cli-patch.json",
+		Provider: "gemini-cli",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+		},
+		Metadata: map[string]any{
+			"type": "gemini-cli",
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("failed to register auth record: %v", errRegister)
+	}
+
+	modelRegistry := internalregistry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(auth.ID)
+	})
+	service.completeModelRegistrationForAuth(context.Background(), auth)
+
+	initialModels := modelRegistry.GetModelsForClient(auth.ID)
+	if len(initialModels) == 0 {
+		t.Fatal("expected initial gemini-cli models to be registered")
+	}
+	excludedModel := strings.TrimSpace(initialModels[0].ID)
+	if excludedModel == "" {
+		t.Fatal("expected first registered model ID to be non-empty")
+	}
+
+	handler := management.NewHandlerWithoutConfigFilePath(service.cfg, manager)
+	handler.SetPostAuthPersistHook(service.runtimeAuthSyncHook())
+	payload, errMarshal := json.Marshal(map[string]any{
+		"name":            auth.FileName,
+		"excluded_models": []string{excludedModel},
+	})
+	if errMarshal != nil {
+		t.Fatalf("failed to marshal request body: %v", errMarshal)
+	}
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(string(payload)))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	handler.PatchAuthFileFields(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	updatedModels := modelRegistry.GetModelsForClient(auth.ID)
+	if len(updatedModels) == 0 {
+		t.Fatalf("expected remaining models after excluding %q", excludedModel)
+	}
+	for _, model := range updatedModels {
+		if model == nil {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(model.ID), excludedModel) {
+			t.Fatalf("expected model %q to be removed from registry immediately", excludedModel)
+		}
+	}
+	updatedAuth, ok := manager.GetByID(auth.ID)
+	if !ok || updatedAuth == nil {
+		t.Fatalf("expected updated auth record")
+	}
+	if got := updatedAuth.Attributes["excluded_models"]; got != excludedModel {
+		t.Fatalf("attrs excluded_models = %q, want %q", got, excludedModel)
 	}
 }
 


### PR DESCRIPTION
## Summary

- merge global `oauth-excluded-models` config with per-auth `excluded_models` attributes for OAuth/file-backed model registration
- normalize management PATCH edits to canonical `excluded_models` metadata while accepting `excluded-models`
- dispatch the existing post-persist auth hook after management auth PATCH updates so registry and scheduler state refresh immediately

Closes #106

## Root Cause

Manual auth-file edits updated the stored core auth record, but the management PATCH path did not refresh model registration synchronously. Per-auth excluded models could also override, rather than merge with, global OAuth exclusions.

## Changes

| File | Change |
|------|--------|
| `sdk/cliproxy/service.go` | Merge global OAuth and auth-level excluded models before registry registration. |
| `internal/api/handlers/management/auth_files.go` | Sync `excluded_models` metadata/attributes, canonicalize aliases, and call the post-persist auth hook after PATCH updates. |
| `*_test.go` | Add regression coverage for merged exclusions, alias replacement/clearing, and immediate registry refresh after PATCH. |

## Test plan

- [x] `go test ./internal/api/handlers/management ./sdk/cliproxy`
- [x] `go build ./...`
- [x] `go test ./internal/api/handlers/management ./internal/watcher/... ./sdk/cliproxy/...`
- [x] `go test ./... -count=1 -timeout 10m`
- [x] `git diff --check`
