### PR TITLE
fix(kiro): preserve cache usage fields

### DIFF
--- a/internal/runtime/executor/kiro_executor.go
+++ b/internal/runtime/executor/kiro_executor.go
@@ -1006,7 +1006,7 @@ func (e *KiroExecutor) executeWithRetry(ctx context.Context, auth *cliproxyauth.
 			}
 
 			// 3. Update TotalTokens
-			usageInfo.TotalTokens = usageInfo.InputTokens + usageInfo.OutputTokens
+			finalizeKiroUsageTotal(&usageInfo)
 
 			appendAPIResponseChunk(ctx, e.cfg, []byte(content))
 			reporter.publish(ctx, usageInfo)
@@ -1638,6 +1638,140 @@ type eventStreamMessage struct {
 // NOTE: Request building functions moved to internal/translator/kiro/claude/kiro_claude_request.go
 // The executor now uses kiroclaude.BuildKiroPayload() instead
 
+func applyKiroTokenUsage(detail *usage.Detail, tokenUsage map[string]interface{}) bool {
+	if detail == nil || tokenUsage == nil {
+		return false
+	}
+	updated := false
+	if outputTokens, ok := kiroTokenUsageInt64(tokenUsage, "outputTokens"); ok {
+		detail.OutputTokens = outputTokens
+		updated = true
+	}
+	if totalTokens, ok := kiroTokenUsageInt64(tokenUsage, "totalTokens"); ok {
+		detail.TotalTokens = totalTokens
+		updated = true
+	}
+	if uncachedInputTokens, ok := kiroTokenUsageInt64(tokenUsage, "uncachedInputTokens"); ok {
+		detail.InputTokens = uncachedInputTokens
+		updated = true
+	}
+	if cacheReadTokens, ok := kiroTokenUsageInt64(tokenUsage, "cacheReadInputTokens"); ok {
+		detail.CacheReadTokens = cacheReadTokens
+		detail.CachedTokens = cacheReadTokens
+		updated = true
+	}
+	if cacheCreationTokens, ok := kiroTokenUsageInt64(tokenUsage, "cacheWriteInputTokens"); ok {
+		detail.CacheCreationTokens = cacheCreationTokens
+		if detail.CachedTokens == 0 {
+			detail.CachedTokens = cacheCreationTokens
+		}
+		updated = true
+	}
+	return updated
+}
+
+func finalizeKiroUsageTotal(detail *usage.Detail) {
+	if detail == nil || detail.TotalTokens != 0 {
+		return
+	}
+	detail.TotalTokens = detail.InputTokens +
+		detail.OutputTokens +
+		detail.ReasoningTokens +
+		detail.CacheReadTokens +
+		detail.CacheCreationTokens
+}
+
+func applyKiroContextUsageFallback(detail *usage.Detail, contextUsagePercentage float64, hasPreciseTokenUsage bool) (int64, bool) {
+	if detail == nil || contextUsagePercentage <= 0 || hasPreciseTokenUsage {
+		return 0, false
+	}
+	calculatedInputTokens := int64(contextUsagePercentage * 200000 / 100)
+	if calculatedInputTokens <= 0 {
+		return 0, false
+	}
+	detail.InputTokens = calculatedInputTokens
+	finalizeKiroUsageTotal(detail)
+	return calculatedInputTokens, true
+}
+
+func kiroTokenUsageInt64(tokenUsage map[string]interface{}, key string) (int64, bool) {
+	raw, ok := tokenUsage[key]
+	if !ok || raw == nil {
+		return 0, false
+	}
+	switch value := raw.(type) {
+	case int:
+		return int64(value), true
+	case int8:
+		return int64(value), true
+	case int16:
+		return int64(value), true
+	case int32:
+		return int64(value), true
+	case int64:
+		return value, true
+	case uint:
+		return int64(value), true
+	case uint8:
+		return int64(value), true
+	case uint16:
+		return int64(value), true
+	case uint32:
+		return int64(value), true
+	case uint64:
+		return int64(value), true
+	case float32:
+		return int64(value), true
+	case float64:
+		return int64(value), true
+	case json.Number:
+		if n, err := value.Int64(); err == nil {
+			return n, true
+		}
+		if n, err := value.Float64(); err == nil {
+			return int64(n), true
+		}
+	}
+	return 0, false
+}
+
+func kiroTokenUsageFloat64(tokenUsage map[string]interface{}, key string) (float64, bool) {
+	raw, ok := tokenUsage[key]
+	if !ok || raw == nil {
+		return 0, false
+	}
+	switch value := raw.(type) {
+	case int:
+		return float64(value), true
+	case int8:
+		return float64(value), true
+	case int16:
+		return float64(value), true
+	case int32:
+		return float64(value), true
+	case int64:
+		return float64(value), true
+	case uint:
+		return float64(value), true
+	case uint8:
+		return float64(value), true
+	case uint16:
+		return float64(value), true
+	case uint32:
+		return float64(value), true
+	case uint64:
+		return float64(value), true
+	case float32:
+		return float64(value), true
+	case float64:
+		return value, true
+	case json.Number:
+		n, err := value.Float64()
+		return n, err == nil
+	}
+	return 0, false
+}
+
 // parseEventStream parses AWS Event Stream binary format.
 // Extracts text content, tool uses, and stop_reason from the response.
 // Supports embedded [Called ...] tool calls and input buffering for toolUseEvent.
@@ -1655,6 +1789,7 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 
 	// Upstream usage tracking - Kiro API returns credit usage and context percentage
 	var upstreamContextPercentage float64 // Context usage percentage from upstream (e.g., 78.56)
+	var hasPreciseTokenUsage bool         // Whether official tokenUsage supplied precise counts
 
 	for {
 		msg, eventErr := e.readEventStreamMessage(reader)
@@ -1827,33 +1962,13 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 
 			// Check for nested tokenUsage object (official format)
 			if tokenUsage, ok := metadata["tokenUsage"].(map[string]interface{}); ok {
-				// outputTokens - precise output token count
-				if outputTokens, ok := tokenUsage["outputTokens"].(float64); ok {
-					usageInfo.OutputTokens = int64(outputTokens)
-					log.Infof("kiro: parseEventStream found precise outputTokens in tokenUsage: %d", usageInfo.OutputTokens)
-				}
-				// totalTokens - precise total token count
-				if totalTokens, ok := tokenUsage["totalTokens"].(float64); ok {
-					usageInfo.TotalTokens = int64(totalTokens)
-					log.Infof("kiro: parseEventStream found precise totalTokens in tokenUsage: %d", usageInfo.TotalTokens)
-				}
-				// uncachedInputTokens - input tokens not from cache
-				if uncachedInputTokens, ok := tokenUsage["uncachedInputTokens"].(float64); ok {
-					usageInfo.InputTokens = int64(uncachedInputTokens)
-					log.Infof("kiro: parseEventStream found uncachedInputTokens in tokenUsage: %d", usageInfo.InputTokens)
-				}
-				// cacheReadInputTokens - tokens read from cache
-				if cacheReadTokens, ok := tokenUsage["cacheReadInputTokens"].(float64); ok {
-					// Add to input tokens if we have uncached tokens, otherwise use as input
-					if usageInfo.InputTokens > 0 {
-						usageInfo.InputTokens += int64(cacheReadTokens)
-					} else {
-						usageInfo.InputTokens = int64(cacheReadTokens)
-					}
-					log.Debugf("kiro: parseEventStream found cacheReadInputTokens in tokenUsage: %d", int64(cacheReadTokens))
+				if applyKiroTokenUsage(&usageInfo, tokenUsage) {
+					hasPreciseTokenUsage = true
+					log.Infof("kiro: parseEventStream found tokenUsage input=%d cache_read=%d cache_creation=%d output=%d total=%d",
+						usageInfo.InputTokens, usageInfo.CacheReadTokens, usageInfo.CacheCreationTokens, usageInfo.OutputTokens, usageInfo.TotalTokens)
 				}
 				// contextUsagePercentage - can be used as fallback for input token estimation
-				if ctxPct, ok := tokenUsage["contextUsagePercentage"].(float64); ok {
+				if ctxPct, ok := kiroTokenUsageFloat64(tokenUsage, "contextUsagePercentage"); ok {
 					upstreamContextPercentage = ctxPct
 					log.Debugf("kiro: parseEventStream found contextUsagePercentage in tokenUsage: %.2f%%", ctxPct)
 				}
@@ -2103,15 +2218,10 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 	// Use contextUsagePercentage to calculate more accurate input tokens
 	// Kiro model has 200k max context, contextUsagePercentage represents the percentage used
 	// Formula: input_tokens = contextUsagePercentage * 200000 / 100
-	if upstreamContextPercentage > 0 {
-		calculatedInputTokens := int64(upstreamContextPercentage * 200000 / 100)
-		if calculatedInputTokens > 0 {
-			localEstimate := usageInfo.InputTokens
-			usageInfo.InputTokens = calculatedInputTokens
-			usageInfo.TotalTokens = usageInfo.InputTokens + usageInfo.OutputTokens
-			log.Infof("kiro: parseEventStream using contextUsagePercentage (%.2f%%) to calculate input tokens: %d (local estimate was: %d)",
-				upstreamContextPercentage, calculatedInputTokens, localEstimate)
-		}
+	localEstimate := usageInfo.InputTokens
+	if calculatedInputTokens, ok := applyKiroContextUsageFallback(&usageInfo, upstreamContextPercentage, hasPreciseTokenUsage); ok {
+		log.Infof("kiro: parseEventStream using contextUsagePercentage (%.2f%%) to calculate input tokens: %d (local estimate was: %d)",
+			upstreamContextPercentage, calculatedInputTokens, localEstimate)
 	}
 
 	return cleanedContent, toolUses, usageInfo, stopReason, nil
@@ -2344,6 +2454,7 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 	var upstreamCreditUsage float64       // Credit usage from upstream (e.g., 1.458)
 	var upstreamContextPercentage float64 // Context usage percentage from upstream (e.g., 78.56)
 	var hasUpstreamUsage bool             // Whether we received usage from upstream
+	var hasPreciseTokenUsage bool         // Whether official tokenUsage supplied precise counts
 
 	// Translator param for maintaining tool call state across streaming events
 	// IMPORTANT: This must persist across all TranslateStream calls
@@ -3165,36 +3276,14 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 
 			// Check for nested tokenUsage object (official format)
 			if tokenUsage, ok := metadata["tokenUsage"].(map[string]interface{}); ok {
-				// outputTokens - precise output token count
-				if outputTokens, ok := tokenUsage["outputTokens"].(float64); ok {
-					totalUsage.OutputTokens = int64(outputTokens)
+				if applyKiroTokenUsage(&totalUsage, tokenUsage) {
+					hasPreciseTokenUsage = true
 					hasUpstreamUsage = true
-					log.Infof("kiro: streamToChannel found precise outputTokens in tokenUsage: %d", totalUsage.OutputTokens)
-				}
-				// totalTokens - precise total token count
-				if totalTokens, ok := tokenUsage["totalTokens"].(float64); ok {
-					totalUsage.TotalTokens = int64(totalTokens)
-					log.Infof("kiro: streamToChannel found precise totalTokens in tokenUsage: %d", totalUsage.TotalTokens)
-				}
-				// uncachedInputTokens - input tokens not from cache
-				if uncachedInputTokens, ok := tokenUsage["uncachedInputTokens"].(float64); ok {
-					totalUsage.InputTokens = int64(uncachedInputTokens)
-					hasUpstreamUsage = true
-					log.Infof("kiro: streamToChannel found uncachedInputTokens in tokenUsage: %d", totalUsage.InputTokens)
-				}
-				// cacheReadInputTokens - tokens read from cache
-				if cacheReadTokens, ok := tokenUsage["cacheReadInputTokens"].(float64); ok {
-					// Add to input tokens if we have uncached tokens, otherwise use as input
-					if totalUsage.InputTokens > 0 {
-						totalUsage.InputTokens += int64(cacheReadTokens)
-					} else {
-						totalUsage.InputTokens = int64(cacheReadTokens)
-					}
-					hasUpstreamUsage = true
-					log.Debugf("kiro: streamToChannel found cacheReadInputTokens in tokenUsage: %d", int64(cacheReadTokens))
+					log.Infof("kiro: streamToChannel found tokenUsage input=%d cache_read=%d cache_creation=%d output=%d total=%d",
+						totalUsage.InputTokens, totalUsage.CacheReadTokens, totalUsage.CacheCreationTokens, totalUsage.OutputTokens, totalUsage.TotalTokens)
 				}
 				// contextUsagePercentage - can be used as fallback for input token estimation
-				if ctxPct, ok := tokenUsage["contextUsagePercentage"].(float64); ok {
+				if ctxPct, ok := kiroTokenUsageFloat64(tokenUsage, "contextUsagePercentage"); ok {
 					upstreamContextPercentage = ctxPct
 					log.Debugf("kiro: streamToChannel found contextUsagePercentage in tokenUsage: %.2f%%", ctxPct)
 				}
@@ -3407,22 +3496,13 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 	// Kiro model has 200k max context, contextUsagePercentage represents the percentage used
 	// Formula: input_tokens = contextUsagePercentage * 200000 / 100
 	// Note: The effective input context is ~170k (200k - 30k reserved for output)
-	if upstreamContextPercentage > 0 {
-		// Calculate input tokens from context percentage
-		// Using 200k as the base since that's what Kiro reports against
-		calculatedInputTokens := int64(upstreamContextPercentage * 200000 / 100)
-
-		// Only use calculated value if it's significantly different from local estimate
-		// This provides more accurate token counts based on upstream data
-		if calculatedInputTokens > 0 {
-			localEstimate := totalUsage.InputTokens
-			totalUsage.InputTokens = calculatedInputTokens
-			log.Debugf("kiro: using contextUsagePercentage (%.2f%%) to calculate input tokens: %d (local estimate was: %d)",
-				upstreamContextPercentage, calculatedInputTokens, localEstimate)
-		}
+	localEstimate := totalUsage.InputTokens
+	if calculatedInputTokens, ok := applyKiroContextUsageFallback(&totalUsage, upstreamContextPercentage, hasPreciseTokenUsage); ok {
+		log.Debugf("kiro: using contextUsagePercentage (%.2f%%) to calculate input tokens: %d (local estimate was: %d)",
+			upstreamContextPercentage, calculatedInputTokens, localEstimate)
 	}
 
-	totalUsage.TotalTokens = totalUsage.InputTokens + totalUsage.OutputTokens
+	finalizeKiroUsageTotal(&totalUsage)
 
 	// Log upstream usage information if received
 	if hasUpstreamUsage {

--- a/internal/runtime/executor/kiro_executor_test.go
+++ b/internal/runtime/executor/kiro_executor_test.go
@@ -6,6 +6,7 @@ import (
 
 	kiroauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/kiro"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 )
 
 func TestBuildKiroEndpointConfigs(t *testing.T) {
@@ -492,5 +493,91 @@ func TestMapModelToKiro_MapsClaudeOpus47Variants(t *testing.T) {
 				t.Fatalf("mapModelToKiro(%q) = %q, want %q", tt.model, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestApplyKiroTokenUsagePreservesCacheTokenBreakdown(t *testing.T) {
+	detail := usage.Detail{}
+	ok := applyKiroTokenUsage(&detail, map[string]interface{}{
+		"uncachedInputTokens":   float64(290),
+		"outputTokens":          float64(1),
+		"totalTokens":           float64(4130),
+		"cacheReadInputTokens":  float64(3822),
+		"cacheWriteInputTokens": float64(17),
+	})
+	if !ok {
+		t.Fatal("applyKiroTokenUsage() = false, want true")
+	}
+	if detail.InputTokens != 290 {
+		t.Fatalf("InputTokens = %d, want 290", detail.InputTokens)
+	}
+	if detail.OutputTokens != 1 {
+		t.Fatalf("OutputTokens = %d, want 1", detail.OutputTokens)
+	}
+	if detail.TotalTokens != 4130 {
+		t.Fatalf("TotalTokens = %d, want 4130", detail.TotalTokens)
+	}
+	if detail.CacheReadTokens != 3822 {
+		t.Fatalf("CacheReadTokens = %d, want 3822", detail.CacheReadTokens)
+	}
+	if detail.CacheCreationTokens != 17 {
+		t.Fatalf("CacheCreationTokens = %d, want 17", detail.CacheCreationTokens)
+	}
+	if detail.CachedTokens != 3822 {
+		t.Fatalf("CachedTokens = %d, want 3822", detail.CachedTokens)
+	}
+}
+
+func TestFinalizeKiroUsageTotalIncludesCacheTokensWhenUpstreamTotalMissing(t *testing.T) {
+	detail := usage.Detail{
+		InputTokens:         290,
+		OutputTokens:        1,
+		CacheReadTokens:     3822,
+		CacheCreationTokens: 17,
+	}
+	finalizeKiroUsageTotal(&detail)
+	if detail.TotalTokens != 4130 {
+		t.Fatalf("TotalTokens = %d, want 4130", detail.TotalTokens)
+	}
+}
+
+func TestKiroContextUsageFallbackDoesNotOverwritePreciseTokenUsage(t *testing.T) {
+	detail := usage.Detail{}
+	hasPreciseTokenUsage := applyKiroTokenUsage(&detail, map[string]interface{}{
+		"uncachedInputTokens":    float64(290),
+		"outputTokens":           float64(1),
+		"totalTokens":            float64(4130),
+		"cacheReadInputTokens":   float64(3822),
+		"cacheWriteInputTokens":  float64(17),
+		"contextUsagePercentage": float64(50),
+	})
+	if !hasPreciseTokenUsage {
+		t.Fatal("applyKiroTokenUsage() = false, want true")
+	}
+	if _, applied := applyKiroContextUsageFallback(&detail, 50, hasPreciseTokenUsage); applied {
+		t.Fatal("applyKiroContextUsageFallback() applied despite precise token usage")
+	}
+	if detail.InputTokens != 290 {
+		t.Fatalf("InputTokens = %d, want precise uncached value 290", detail.InputTokens)
+	}
+	if detail.TotalTokens != 4130 {
+		t.Fatalf("TotalTokens = %d, want upstream total 4130", detail.TotalTokens)
+	}
+}
+
+func TestKiroContextUsageFallbackAppliesWhenPreciseTokenUsageMissing(t *testing.T) {
+	detail := usage.Detail{OutputTokens: 3}
+	calculated, applied := applyKiroContextUsageFallback(&detail, 50, false)
+	if !applied {
+		t.Fatal("applyKiroContextUsageFallback() applied = false, want true")
+	}
+	if calculated != 100000 {
+		t.Fatalf("calculated input tokens = %d, want 100000", calculated)
+	}
+	if detail.InputTokens != 100000 {
+		t.Fatalf("InputTokens = %d, want 100000", detail.InputTokens)
+	}
+	if detail.TotalTokens != 100003 {
+		t.Fatalf("TotalTokens = %d, want 100003", detail.TotalTokens)
 	}
 }

--- a/internal/translator/kiro/claude/kiro_claude_response.go
+++ b/internal/translator/kiro/claude/kiro_claude_response.go
@@ -106,13 +106,24 @@ func BuildClaudeResponse(content string, toolUses []KiroToolUse, model string, u
 		"model":       model,
 		"content":     contentBlocks,
 		"stop_reason": stopReason,
-		"usage": map[string]interface{}{
-			"input_tokens":  usageInfo.InputTokens,
-			"output_tokens": usageInfo.OutputTokens,
-		},
+		"usage":       buildClaudeUsage(usageInfo),
 	}
 	result, _ := json.Marshal(response)
 	return result
+}
+
+func buildClaudeUsage(usageInfo usage.Detail) map[string]interface{} {
+	payload := map[string]interface{}{
+		"input_tokens":  usageInfo.InputTokens,
+		"output_tokens": usageInfo.OutputTokens,
+	}
+	if usageInfo.CacheReadTokens != 0 {
+		payload["cache_read_input_tokens"] = usageInfo.CacheReadTokens
+	}
+	if usageInfo.CacheCreationTokens != 0 {
+		payload["cache_creation_input_tokens"] = usageInfo.CacheCreationTokens
+	}
+	return payload
 }
 
 // ExtractThinkingFromContent parses content to extract thinking blocks and text.

--- a/internal/translator/kiro/claude/kiro_claude_response_test.go
+++ b/internal/translator/kiro/claude/kiro_claude_response_test.go
@@ -1,0 +1,41 @@
+package claude
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+func TestBuildClaudeResponseIncludesCacheUsageFields(t *testing.T) {
+	response := BuildClaudeResponse("ok", nil, "claude-haiku-4-5", usage.Detail{
+		InputTokens:         290,
+		OutputTokens:        1,
+		CacheReadTokens:     3822,
+		CacheCreationTokens: 17,
+	}, "end_turn")
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(response, &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	usagePayload, ok := payload["usage"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("usage payload missing or wrong type: %#v", payload["usage"])
+	}
+	assertJSONNumber(t, usagePayload, "input_tokens", 290)
+	assertJSONNumber(t, usagePayload, "output_tokens", 1)
+	assertJSONNumber(t, usagePayload, "cache_read_input_tokens", 3822)
+	assertJSONNumber(t, usagePayload, "cache_creation_input_tokens", 17)
+}
+
+func assertJSONNumber(t *testing.T, payload map[string]interface{}, key string, want int64) {
+	t.Helper()
+	got, ok := payload[key].(float64)
+	if !ok {
+		t.Fatalf("%s missing or wrong type: %#v", key, payload[key])
+	}
+	if int64(got) != want {
+		t.Fatalf("%s = %d, want %d", key, int64(got), want)
+	}
+}

--- a/internal/translator/kiro/claude/kiro_claude_stream.go
+++ b/internal/translator/kiro/claude/kiro_claude_stream.go
@@ -117,10 +117,7 @@ func BuildClaudeMessageDeltaEvent(stopReason string, usageInfo usage.Detail) []b
 			"stop_reason":   stopReason,
 			"stop_sequence": nil,
 		},
-		"usage": map[string]interface{}{
-			"input_tokens":  usageInfo.InputTokens,
-			"output_tokens": usageInfo.OutputTokens,
-		},
+		"usage": buildClaudeUsage(usageInfo),
 	}
 	deltaResult, _ := json.Marshal(deltaEvent)
 	return []byte("event: message_delta\ndata: " + string(deltaResult))

--- a/internal/translator/kiro/claude/kiro_claude_stream_test.go
+++ b/internal/translator/kiro/claude/kiro_claude_stream_test.go
@@ -1,0 +1,43 @@
+package claude
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+func TestBuildClaudeMessageDeltaEventIncludesCacheUsageFields(t *testing.T) {
+	event := BuildClaudeMessageDeltaEvent("end_turn", usage.Detail{
+		InputTokens:         290,
+		OutputTokens:        1,
+		CacheReadTokens:     3822,
+		CacheCreationTokens: 17,
+	})
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(claudeSSEData(t, event), &payload); err != nil {
+		t.Fatalf("unmarshal message_delta: %v", err)
+	}
+	usagePayload, ok := payload["usage"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("usage payload missing or wrong type: %#v", payload["usage"])
+	}
+	assertJSONNumber(t, usagePayload, "input_tokens", 290)
+	assertJSONNumber(t, usagePayload, "output_tokens", 1)
+	assertJSONNumber(t, usagePayload, "cache_read_input_tokens", 3822)
+	assertJSONNumber(t, usagePayload, "cache_creation_input_tokens", 17)
+}
+
+func claudeSSEData(t *testing.T, event []byte) []byte {
+	t.Helper()
+	for _, line := range strings.Split(string(event), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "data:") {
+			return []byte(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		}
+	}
+	t.Fatalf("event has no data line: %s", string(event))
+	return nil
+}

--- a/internal/translator/kiro/openai/kiro_openai.go
+++ b/internal/translator/kiro/openai/kiro_openai.go
@@ -144,13 +144,7 @@ func ConvertKiroStreamToOpenAI(ctx context.Context, model string, originalReques
 
 		// Extract usage if present
 		if eventJSON.Get("usage").Exists() {
-			inputTokens := eventJSON.Get("usage.input_tokens").Int()
-			outputTokens := eventJSON.Get("usage.output_tokens").Int()
-			usageInfo := usage.Detail{
-				InputTokens:  inputTokens,
-				OutputTokens: outputTokens,
-				TotalTokens:  inputTokens + outputTokens,
-			}
+			usageInfo := usageDetailFromClaudeUsage(eventJSON.Get("usage"))
 			chunk := BuildOpenAISSEUsage(state, usageInfo)
 			results = append(results, []byte(chunk))
 		}
@@ -163,13 +157,7 @@ func ConvertKiroStreamToOpenAI(ctx context.Context, model string, originalReques
 	case "ping":
 		// Ping event with usage - optionally emit usage chunk
 		if eventJSON.Get("usage").Exists() {
-			inputTokens := eventJSON.Get("usage.input_tokens").Int()
-			outputTokens := eventJSON.Get("usage.output_tokens").Int()
-			usageInfo := usage.Detail{
-				InputTokens:  inputTokens,
-				OutputTokens: outputTokens,
-				TotalTokens:  inputTokens + outputTokens,
-			}
+			usageInfo := usageDetailFromClaudeUsage(eventJSON.Get("usage"))
 			chunk := BuildOpenAISSEUsage(state, usageInfo)
 			results = append(results, []byte(chunk))
 		}
@@ -230,14 +218,35 @@ func ConvertKiroNonStreamToOpenAI(ctx context.Context, model string, originalReq
 
 	// Extract usage
 	usageInfo := usage.Detail{
-		InputTokens:  response.Get("usage.input_tokens").Int(),
-		OutputTokens: response.Get("usage.output_tokens").Int(),
+		InputTokens:         response.Get("usage.input_tokens").Int(),
+		OutputTokens:        response.Get("usage.output_tokens").Int(),
+		CacheReadTokens:     response.Get("usage.cache_read_input_tokens").Int(),
+		CacheCreationTokens: response.Get("usage.cache_creation_input_tokens").Int(),
 	}
-	usageInfo.TotalTokens = usageInfo.InputTokens + usageInfo.OutputTokens
+	if usageInfo.CacheReadTokens != 0 {
+		usageInfo.CachedTokens = usageInfo.CacheReadTokens
+	} else {
+		usageInfo.CachedTokens = usageInfo.CacheCreationTokens
+	}
 
 	// Build OpenAI response with reasoning_content support
 	openaiResponse := BuildOpenAIResponseWithReasoning(content, reasoningContent, toolUses, model, usageInfo, stopReason)
 	return openaiResponse
+}
+
+func usageDetailFromClaudeUsage(usageNode gjson.Result) usage.Detail {
+	detail := usage.Detail{
+		InputTokens:         usageNode.Get("input_tokens").Int(),
+		OutputTokens:        usageNode.Get("output_tokens").Int(),
+		CacheReadTokens:     usageNode.Get("cache_read_input_tokens").Int(),
+		CacheCreationTokens: usageNode.Get("cache_creation_input_tokens").Int(),
+	}
+	if detail.CacheReadTokens != 0 {
+		detail.CachedTokens = detail.CacheReadTokens
+	} else {
+		detail.CachedTokens = detail.CacheCreationTokens
+	}
+	return detail
 }
 
 // ParseClaudeEvent parses a Claude SSE event and returns the event type and data

--- a/internal/translator/kiro/openai/kiro_openai_response.go
+++ b/internal/translator/kiro/openai/kiro_openai_response.go
@@ -84,15 +84,32 @@ func BuildOpenAIResponseWithReasoning(content, reasoningContent string, toolUses
 				"finish_reason": finishReason,
 			},
 		},
-		"usage": map[string]interface{}{
-			"prompt_tokens":     usageInfo.InputTokens,
-			"completion_tokens": usageInfo.OutputTokens,
-			"total_tokens":      usageInfo.InputTokens + usageInfo.OutputTokens,
-		},
+		"usage": buildOpenAIUsage(usageInfo),
 	}
 
 	result, _ := json.Marshal(response)
 	return result
+}
+
+func buildOpenAIUsage(usageInfo usage.Detail) map[string]interface{} {
+	promptTokens := usageInfo.InputTokens + usageInfo.CacheCreationTokens + usageInfo.CacheReadTokens
+	completionTokens := usageInfo.OutputTokens
+	totalTokens := usageInfo.TotalTokens
+	if totalTokens == 0 {
+		totalTokens = promptTokens + completionTokens
+	}
+
+	payload := map[string]interface{}{
+		"prompt_tokens":     promptTokens,
+		"completion_tokens": completionTokens,
+		"total_tokens":      totalTokens,
+	}
+	if usageInfo.CacheReadTokens != 0 {
+		payload["prompt_tokens_details"] = map[string]interface{}{
+			"cached_tokens": usageInfo.CacheReadTokens,
+		}
+	}
+	return payload
 }
 
 // mapKiroStopReasonToOpenAI converts Kiro/Claude stop_reason to OpenAI finish_reason

--- a/internal/translator/kiro/openai/kiro_openai_response_test.go
+++ b/internal/translator/kiro/openai/kiro_openai_response_test.go
@@ -1,0 +1,87 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+func TestBuildOpenAIResponseIncludesCachedPromptDetails(t *testing.T) {
+	response := BuildOpenAIResponseWithReasoning("ok", "", nil, "claude-haiku-4-5", usage.Detail{
+		InputTokens:         290,
+		OutputTokens:        1,
+		CacheReadTokens:     3822,
+		CacheCreationTokens: 17,
+	}, "end_turn")
+
+	payload := parseOpenAIJSON(t, response)
+	usagePayload := openAIUsagePayload(t, payload)
+	assertOpenAINumber(t, usagePayload, "prompt_tokens", 4129)
+	assertOpenAINumber(t, usagePayload, "completion_tokens", 1)
+	assertOpenAINumber(t, usagePayload, "total_tokens", 4130)
+
+	promptDetails, ok := usagePayload["prompt_tokens_details"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("prompt_tokens_details missing or wrong type: %#v", usagePayload["prompt_tokens_details"])
+	}
+	assertOpenAINumber(t, promptDetails, "cached_tokens", 3822)
+}
+
+func TestConvertKiroNonStreamToOpenAIPreservesCacheUsage(t *testing.T) {
+	claudeResponse := []byte(`{
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-haiku-4-5",
+		"content":[{"type":"text","text":"ok"}],
+		"stop_reason":"end_turn",
+		"usage":{
+			"input_tokens":290,
+			"output_tokens":1,
+			"cache_read_input_tokens":3822,
+			"cache_creation_input_tokens":17
+		}
+	}`)
+
+	response := ConvertKiroNonStreamToOpenAI(nil, "claude-haiku-4-5", nil, nil, claudeResponse, nil)
+	payload := parseOpenAIJSON(t, response)
+	usagePayload := openAIUsagePayload(t, payload)
+	assertOpenAINumber(t, usagePayload, "prompt_tokens", 4129)
+	assertOpenAINumber(t, usagePayload, "completion_tokens", 1)
+	assertOpenAINumber(t, usagePayload, "total_tokens", 4130)
+
+	promptDetails, ok := usagePayload["prompt_tokens_details"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("prompt_tokens_details missing or wrong type: %#v", usagePayload["prompt_tokens_details"])
+	}
+	assertOpenAINumber(t, promptDetails, "cached_tokens", 3822)
+}
+
+func parseOpenAIJSON(t *testing.T, data []byte) map[string]interface{} {
+	t.Helper()
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal OpenAI payload: %v", err)
+	}
+	return payload
+}
+
+func openAIUsagePayload(t *testing.T, payload map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	usagePayload, ok := payload["usage"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("usage payload missing or wrong type: %#v", payload["usage"])
+	}
+	return usagePayload
+}
+
+func assertOpenAINumber(t *testing.T, payload map[string]interface{}, key string, want int64) {
+	t.Helper()
+	got, ok := payload[key].(float64)
+	if !ok {
+		t.Fatalf("%s missing or wrong type: %#v", key, payload[key])
+	}
+	if int64(got) != want {
+		t.Fatalf("%s = %d, want %d", key, int64(got), want)
+	}
+}

--- a/internal/translator/kiro/openai/kiro_openai_stream.go
+++ b/internal/translator/kiro/openai/kiro_openai_stream.go
@@ -122,11 +122,7 @@ func BuildOpenAISSEUsage(state *OpenAIStreamState, usageInfo usage.Detail) strin
 		"created": state.Created,
 		"model":   state.Model,
 		"choices": []map[string]interface{}{},
-		"usage": map[string]interface{}{
-			"prompt_tokens":     usageInfo.InputTokens,
-			"completion_tokens": usageInfo.OutputTokens,
-			"total_tokens":      usageInfo.InputTokens + usageInfo.OutputTokens,
-		},
+		"usage":   buildOpenAIUsage(usageInfo),
 	}
 	result, _ := json.Marshal(chunk)
 	return FormatSSEEvent(result)

--- a/internal/translator/kiro/openai/kiro_openai_stream_test.go
+++ b/internal/translator/kiro/openai/kiro_openai_stream_test.go
@@ -1,0 +1,60 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+)
+
+func TestBuildOpenAISSEUsageIncludesCachedPromptDetails(t *testing.T) {
+	state := NewOpenAIStreamState("claude-haiku-4-5")
+	chunk := BuildOpenAISSEUsage(state, usage.Detail{
+		InputTokens:         290,
+		OutputTokens:        1,
+		CacheReadTokens:     3822,
+		CacheCreationTokens: 17,
+	})
+
+	payload := parseOpenAIJSON(t, []byte(chunk))
+	usagePayload := openAIUsagePayload(t, payload)
+	assertOpenAINumber(t, usagePayload, "prompt_tokens", 4129)
+	assertOpenAINumber(t, usagePayload, "completion_tokens", 1)
+	assertOpenAINumber(t, usagePayload, "total_tokens", 4130)
+
+	promptDetails, ok := usagePayload["prompt_tokens_details"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("prompt_tokens_details missing or wrong type: %#v", usagePayload["prompt_tokens_details"])
+	}
+	assertOpenAINumber(t, promptDetails, "cached_tokens", 3822)
+}
+
+func TestConvertKiroStreamToOpenAIPreservesCacheUsage(t *testing.T) {
+	var param any
+	raw := []byte(`event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":290,"output_tokens":1,"cache_read_input_tokens":3822,"cache_creation_input_tokens":17}}`)
+
+	chunks := ConvertKiroStreamToOpenAI(context.Background(), "claude-haiku-4-5", nil, nil, raw, &param)
+	var usagePayload map[string]interface{}
+	for _, chunk := range chunks {
+		payload := parseOpenAIJSON(t, chunk)
+		if usageValue, ok := payload["usage"].(map[string]interface{}); ok {
+			usagePayload = usageValue
+			break
+		}
+	}
+	if usagePayload == nil {
+		rawChunks, _ := json.Marshal(chunks)
+		t.Fatalf("usage chunk missing from chunks: %s", rawChunks)
+	}
+	assertOpenAINumber(t, usagePayload, "prompt_tokens", 4129)
+	assertOpenAINumber(t, usagePayload, "completion_tokens", 1)
+	assertOpenAINumber(t, usagePayload, "total_tokens", 4130)
+
+	promptDetails, ok := usagePayload["prompt_tokens_details"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("prompt_tokens_details missing or wrong type: %#v", usagePayload["prompt_tokens_details"])
+	}
+	assertOpenAINumber(t, promptDetails, "cached_tokens", 3822)
+}


### PR DESCRIPTION
## Summary
- map Kiro tokenUsage cache read/write fields into usage.Detail
- keep uncached input separate from cache reads
- emit Claude cache usage fields in stream and non-stream responses
- emit OpenAI prompt_tokens_details.cached_tokens for Kiro OpenAI conversion
- prevent contextUsagePercentage fallback from overwriting precise tokenUsage counts

Closes #113

## Validation
- go test ./internal/runtime/executor ./internal/translator/kiro/... -run 'Kiro|Usage|BuildClaude|OpenAI' -count=1\n- go build -o test-output ./cmd/server && rm test-output\n\nDocs impact: none\nAction: no update needed - response usage fields now match existing Claude/OpenAI cache usage semantics