### PR TITLE
fix(kiro): add fallback models and IDE import normalization

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1010,13 +1010,34 @@ func (h *Handler) writeAuthFile(ctx context.Context, name string, data []byte) e
 	if err != nil {
 		return err
 	}
-	if errWrite := os.WriteFile(dst, data, 0o600); errWrite != nil {
+	persistData := data
+	if metadata := metadataFromAuthFileBytes(data); metadata != nil {
+		if normalized, ok := normalizeKiroIDETokenMetadata(metadata); ok {
+			normalizedData, errMarshal := json.MarshalIndent(normalized, "", "  ")
+			if errMarshal != nil {
+				return fmt.Errorf("failed to encode normalized auth file: %w", errMarshal)
+			}
+			persistData = append(normalizedData, '\n')
+		}
+	}
+	if errWrite := os.WriteFile(dst, persistData, 0o600); errWrite != nil {
 		return fmt.Errorf("failed to write file: %w", errWrite)
 	}
 	if err := h.upsertAuthRecord(ctx, auth); err != nil {
 		return err
 	}
 	return nil
+}
+
+func metadataFromAuthFileBytes(data []byte) map[string]any {
+	if len(data) == 0 {
+		return nil
+	}
+	metadata := make(map[string]any)
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return nil
+	}
+	return metadata
 }
 
 func requestedAuthFileNamesForDelete(c *gin.Context) ([]string, error) {
@@ -1204,6 +1225,9 @@ func (h *Handler) buildAuthFromFileData(path string, data []byte) (*coreauth.Aut
 	if err := json.Unmarshal(data, &metadata); err != nil {
 		return nil, fmt.Errorf("invalid auth file: %w", err)
 	}
+	if normalized, ok := normalizeKiroIDETokenMetadata(metadata); ok {
+		metadata = normalized
+	}
 	provider, _ := metadata["type"].(string)
 	if provider == "" {
 		provider = "unknown"
@@ -1248,6 +1272,64 @@ func (h *Handler) buildAuthFromFileData(path string, data []byte) (*coreauth.Aut
 	}
 	coreauth.ApplyCustomHeadersFromMetadata(auth)
 	return auth, nil
+}
+
+func normalizeKiroIDETokenMetadata(metadata map[string]any) (map[string]any, bool) {
+	if len(metadata) == 0 {
+		return nil, false
+	}
+	if existingType, _ := metadata["type"].(string); strings.TrimSpace(existingType) != "" {
+		return nil, false
+	}
+	accessToken := strings.TrimSpace(stringFromMetadata(metadata, "accessToken"))
+	if accessToken == "" {
+		return nil, false
+	}
+	hasKiroIDEField := false
+	for _, key := range []string{"profileArn", "clientIdHash", "startUrl"} {
+		if strings.TrimSpace(stringFromMetadata(metadata, key)) != "" {
+			hasKiroIDEField = true
+			break
+		}
+	}
+	if !hasKiroIDEField {
+		return nil, false
+	}
+
+	email := strings.TrimSpace(stringFromMetadata(metadata, "email"))
+	if email == "" {
+		email = kiroauth.ExtractEmailFromJWT(accessToken)
+	}
+	return map[string]any{
+		"type":           "kiro",
+		"access_token":   accessToken,
+		"refresh_token":  strings.TrimSpace(stringFromMetadata(metadata, "refreshToken")),
+		"profile_arn":    strings.TrimSpace(stringFromMetadata(metadata, "profileArn")),
+		"expires_at":     strings.TrimSpace(stringFromMetadata(metadata, "expiresAt")),
+		"auth_method":    strings.ToLower(strings.TrimSpace(stringFromMetadata(metadata, "authMethod"))),
+		"provider":       strings.TrimSpace(stringFromMetadata(metadata, "provider")),
+		"client_id":      strings.TrimSpace(stringFromMetadata(metadata, "clientId")),
+		"client_secret":  strings.TrimSpace(stringFromMetadata(metadata, "clientSecret")),
+		"client_id_hash": strings.TrimSpace(stringFromMetadata(metadata, "clientIdHash")),
+		"email":          email,
+		"start_url":      strings.TrimSpace(stringFromMetadata(metadata, "startUrl")),
+		"region":         strings.TrimSpace(stringFromMetadata(metadata, "region")),
+	}, true
+}
+
+func stringFromMetadata(metadata map[string]any, key string) string {
+	raw, ok := metadata[key]
+	if !ok || raw == nil {
+		return ""
+	}
+	switch value := raw.(type) {
+	case string:
+		return value
+	case fmt.Stringer:
+		return value.String()
+	default:
+		return fmt.Sprint(value)
+	}
 }
 
 func (h *Handler) upsertAuthRecord(ctx context.Context, auth *coreauth.Auth) error {

--- a/internal/api/handlers/management/auth_files_batch_test.go
+++ b/internal/api/handlers/management/auth_files_batch_test.go
@@ -2,6 +2,7 @@ package management
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"mime/multipart"
 	"net/http"
@@ -147,6 +148,153 @@ func TestUploadAuthFile_BatchMultipart_InvalidJSONDoesNotOverwriteExistingFile(t
 	}
 	if string(betaData) != files[1].content {
 		t.Fatalf("expected beta auth file content %q, got %q", files[1].content, string(betaData))
+	}
+}
+
+func TestBuildAuthFromFileData_NormalizesKiroIDETokenJSON(t *testing.T) {
+	authDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+	path := filepath.Join(authDir, "kiro-auth-token.json")
+	data := []byte(`{
+		"accessToken":"access-token",
+		"refreshToken":"refresh-token",
+		"profileArn":"arn:aws:codewhisperer:us-east-1:123456789012:profile/test",
+		"expiresAt":"2026-06-19T12:00:00Z",
+		"authMethod":"Google",
+		"provider":"Google",
+		"clientId":"client-id",
+		"clientSecret":"client-secret",
+		"clientIdHash":"client-hash",
+		"email":"user@example.com",
+		"startUrl":"https://example.awsapps.com/start",
+		"region":"us-east-1"
+	}`)
+
+	auth, err := h.buildAuthFromFileData(path, data)
+	if err != nil {
+		t.Fatalf("buildAuthFromFileData() error = %v", err)
+	}
+	if auth.Provider != "kiro" {
+		t.Fatalf("Provider = %q, want kiro", auth.Provider)
+	}
+	if auth.Label != "user@example.com" {
+		t.Fatalf("Label = %q, want user@example.com", auth.Label)
+	}
+
+	wantMetadata := map[string]string{
+		"type":           "kiro",
+		"access_token":   "access-token",
+		"refresh_token":  "refresh-token",
+		"profile_arn":    "arn:aws:codewhisperer:us-east-1:123456789012:profile/test",
+		"expires_at":     "2026-06-19T12:00:00Z",
+		"auth_method":    "google",
+		"provider":       "Google",
+		"client_id":      "client-id",
+		"client_secret":  "client-secret",
+		"client_id_hash": "client-hash",
+		"email":          "user@example.com",
+		"start_url":      "https://example.awsapps.com/start",
+		"region":         "us-east-1",
+	}
+	for key, want := range wantMetadata {
+		got, _ := auth.Metadata[key].(string)
+		if got != want {
+			t.Fatalf("metadata[%q] = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestBuildAuthFromFileData_DoesNotNormalizeTypedAuthJSON(t *testing.T) {
+	authDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+	path := filepath.Join(authDir, "codex.json")
+	data := []byte(`{"type":"codex","accessToken":"looks-like-token","email":"codex@example.com"}`)
+
+	auth, err := h.buildAuthFromFileData(path, data)
+	if err != nil {
+		t.Fatalf("buildAuthFromFileData() error = %v", err)
+	}
+	if auth.Provider != "codex" {
+		t.Fatalf("Provider = %q, want codex", auth.Provider)
+	}
+	if _, exists := auth.Metadata["access_token"]; exists {
+		t.Fatalf("typed auth JSON was unexpectedly normalized: %#v", auth.Metadata)
+	}
+	if got, _ := auth.Metadata["accessToken"].(string); got != "looks-like-token" {
+		t.Fatalf("metadata accessToken = %q, want original camelCase value", got)
+	}
+}
+
+func TestBuildAuthFromFileData_DoesNotNormalizeUntypedNonKiroOAuthJSON(t *testing.T) {
+	authDir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+	path := filepath.Join(authDir, "oauth-token.json")
+	data := []byte(`{
+		"accessToken":"access-token",
+		"refreshToken":"refresh-token",
+		"provider":"generic-oauth",
+		"clientId":"client-id",
+		"clientSecret":"client-secret",
+		"email":"oauth@example.com"
+	}`)
+
+	auth, err := h.buildAuthFromFileData(path, data)
+	if err != nil {
+		t.Fatalf("buildAuthFromFileData() error = %v", err)
+	}
+	if auth.Provider != "unknown" {
+		t.Fatalf("Provider = %q, want unknown", auth.Provider)
+	}
+	if _, exists := auth.Metadata["access_token"]; exists {
+		t.Fatalf("untyped generic OAuth JSON was unexpectedly normalized: %#v", auth.Metadata)
+	}
+	if got, _ := auth.Metadata["accessToken"].(string); got != "access-token" {
+		t.Fatalf("metadata accessToken = %q, want original camelCase value", got)
+	}
+}
+
+func TestWriteAuthFile_PersistsNormalizedKiroIDETokenJSON(t *testing.T) {
+	authDir := t.TempDir()
+	manager := coreauth.NewManager(nil, nil, nil)
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+	data := []byte(`{
+		"accessToken":"access-token",
+		"refreshToken":"refresh-token",
+		"profileArn":"arn:aws:codewhisperer:us-east-1:123456789012:profile/test",
+		"expiresAt":"2026-06-19T12:00:00Z",
+		"authMethod":"Google",
+		"provider":"Google",
+		"email":"user@example.com"
+	}`)
+
+	if err := h.writeAuthFile(context.Background(), "kiro-auth-token.json", data); err != nil {
+		t.Fatalf("writeAuthFile() error = %v", err)
+	}
+
+	written, err := os.ReadFile(filepath.Join(authDir, "kiro-auth-token.json"))
+	if err != nil {
+		t.Fatalf("read written auth file: %v", err)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(written, &metadata); err != nil {
+		t.Fatalf("unmarshal written auth file: %v", err)
+	}
+	if got, _ := metadata["type"].(string); got != "kiro" {
+		t.Fatalf("written metadata type = %q, want kiro", got)
+	}
+	if got, _ := metadata["access_token"].(string); got != "access-token" {
+		t.Fatalf("written access_token = %q, want access-token", got)
+	}
+	if _, exists := metadata["accessToken"]; exists {
+		t.Fatalf("written metadata still contains raw accessToken: %#v", metadata)
+	}
+
+	auth, ok := manager.GetByID("kiro-auth-token.json")
+	if !ok {
+		t.Fatal("expected auth manager to contain uploaded Kiro auth")
+	}
+	if auth.Provider != "kiro" {
+		t.Fatalf("manager auth provider = %q, want kiro", auth.Provider)
 	}
 }
 

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -692,24 +692,74 @@ func GetGitHubCopilotModels() []*ModelInfo {
 	}...)
 }
 
-// GetKiroModels returns Kiro-hosted model definitions.
+// GetKiroModels returns Kiro-hosted fallback model definitions.
 //
-// Kiro supports a growing list of models (Claude variants, GLM, DeepSeek,
-// MiniMax, Qwen, …) and the set changes without SDK releases. Rather than
-// hardcoding every model, we rely entirely on the dynamic discovery path
-// (sdk/cliproxy/service.go fetchKiroModels → ConvertKiroAPIModels), which
-// asks Kiro's own API what is currently available and generates ModelInfo
-// entries on the fly. That keeps the proxy in sync with Kiro automatically.
-//
-// An empty (non-nil) slice is returned so callers can distinguish "kiro is a
-// known channel with no static entries" from "unknown channel" — the latter
-// is signaled by nil and produces an HTTP 400 in the management endpoint.
-// When API discovery is unreachable, /v1/models simply shows no Kiro models
-// until the next successful fetch. GenerateAgenticVariants is still the
-// place where agentic variants are layered on top of whatever the API
-// returns.
+// Dynamic Kiro discovery remains the primary source of truth. This small
+// fallback set mirrors the built-in Kiro OAuth aliases and prevents a valid
+// Kiro auth from registering zero models when model discovery is temporarily
+// unavailable.
 func GetKiroModels() []*ModelInfo {
-	return []*ModelInfo{}
+	now := int64(1732752000) // 2024-11-27
+	endpoints := []string{"/chat/completions", "/messages"}
+	entries := []struct {
+		id          string
+		displayName string
+		description string
+	}{
+		{
+			id:          "kiro-claude-sonnet-4-6",
+			displayName: "Claude Sonnet 4.6",
+			description: "Claude Sonnet 4.6 via Kiro",
+		},
+		{
+			id:          "kiro-claude-sonnet-4-5",
+			displayName: "Claude Sonnet 4.5",
+			description: "Claude Sonnet 4.5 via Kiro",
+		},
+		{
+			id:          "kiro-claude-sonnet-4",
+			displayName: "Claude Sonnet 4",
+			description: "Claude Sonnet 4 via Kiro",
+		},
+		{
+			id:          "kiro-claude-opus-4-7",
+			displayName: "Claude Opus 4.7",
+			description: "Claude Opus 4.7 via Kiro",
+		},
+		{
+			id:          "kiro-claude-opus-4-6",
+			displayName: "Claude Opus 4.6",
+			description: "Claude Opus 4.6 via Kiro",
+		},
+		{
+			id:          "kiro-claude-opus-4-5",
+			displayName: "Claude Opus 4.5",
+			description: "Claude Opus 4.5 via Kiro",
+		},
+		{
+			id:          "kiro-claude-haiku-4-5",
+			displayName: "Claude Haiku 4.5",
+			description: "Claude Haiku 4.5 via Kiro",
+		},
+	}
+
+	models := make([]*ModelInfo, 0, len(entries))
+	for _, entry := range entries {
+		models = append(models, &ModelInfo{
+			ID:                  entry.id,
+			Object:              "model",
+			Created:             now,
+			OwnedBy:             "kiro",
+			Type:                "kiro",
+			DisplayName:         entry.displayName,
+			Description:         entry.description,
+			ContextLength:       200000,
+			MaxCompletionTokens: 64000,
+			SupportedEndpoints:  endpoints,
+			Thinking:            cloneThinkingSupport(DefaultKiroThinkingSupport),
+		})
+	}
+	return models
 }
 
 // GetAmazonQModels returns the Amazon Q (AWS CodeWhisperer) model definitions.

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -1,6 +1,9 @@
 package registry
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestWithXAIBuiltinsIncludesVideoPreviewModel(t *testing.T) {
 	models := WithXAIBuiltins(nil)
@@ -15,4 +18,56 @@ func TestWithXAIBuiltinsIncludesVideoPreviewModel(t *testing.T) {
 	}
 
 	t.Fatalf("expected xAI builtin model %s", xaiBuiltinVideo15PreviewModelID)
+}
+
+func TestGetKiroModelsReturnsStaticFallbackSet(t *testing.T) {
+	models := GetKiroModels()
+	if len(models) == 0 {
+		t.Fatal("expected Kiro static fallback models")
+	}
+
+	seen := make(map[string]struct{}, len(models))
+	required := map[string]bool{
+		"kiro-claude-sonnet-4-6": false,
+		"kiro-claude-sonnet-4-5": false,
+		"kiro-claude-sonnet-4":   false,
+		"kiro-claude-opus-4-7":   false,
+		"kiro-claude-opus-4-6":   false,
+		"kiro-claude-opus-4-5":   false,
+		"kiro-claude-haiku-4-5":  false,
+	}
+
+	for _, model := range models {
+		if model == nil {
+			t.Fatal("expected no nil Kiro models")
+		}
+		if !strings.HasPrefix(model.ID, "kiro-") {
+			t.Fatalf("expected Kiro model ID to use kiro- prefix, got %q", model.ID)
+		}
+		if model.Type != "kiro" {
+			t.Fatalf("model %q type = %q, want kiro", model.ID, model.Type)
+		}
+		if model.Thinking == nil {
+			t.Fatalf("model %q missing Kiro thinking metadata", model.ID)
+		}
+		if model.Thinking.Min != DefaultKiroThinkingSupport.Min ||
+			model.Thinking.Max != DefaultKiroThinkingSupport.Max ||
+			model.Thinking.ZeroAllowed != DefaultKiroThinkingSupport.ZeroAllowed ||
+			model.Thinking.DynamicAllowed != DefaultKiroThinkingSupport.DynamicAllowed {
+			t.Fatalf("model %q thinking = %+v, want %+v", model.ID, model.Thinking, DefaultKiroThinkingSupport)
+		}
+		if _, exists := seen[model.ID]; exists {
+			t.Fatalf("duplicate Kiro model ID %q", model.ID)
+		}
+		seen[model.ID] = struct{}{}
+		if _, ok := required[model.ID]; ok {
+			required[model.ID] = true
+		}
+	}
+
+	for modelID, found := range required {
+		if !found {
+			t.Fatalf("expected fallback model %q", modelID)
+		}
+	}
 }

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -66,6 +66,46 @@ func TestRegisterModelsForAuth_MergesOAuthExcludedModelsFromConfigAndAuthAttribu
 	}
 }
 
+func TestRegisterModelsForAuth_KiroFallbackModelsApplyExcludedModels(t *testing.T) {
+	excludedModel := "kiro-claude-sonnet-4-6"
+	service := &Service{
+		cfg: &config.Config{},
+	}
+	auth := &coreauth.Auth{
+		ID:       "auth-kiro-fallback",
+		Provider: "kiro",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"auth_kind":       "oauth",
+			"excluded_models": excludedModel,
+		},
+	}
+
+	modelRegistry := internalregistry.GetGlobalRegistry()
+	modelRegistry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(context.Background(), auth)
+
+	models := modelRegistry.GetModelsForClient(auth.ID)
+	if len(models) == 0 {
+		t.Fatal("expected Kiro fallback models to be registered")
+	}
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(model.ID), excludedModel) {
+			t.Fatalf("expected Kiro fallback model %q to be excluded", excludedModel)
+		}
+		if model.Type != "kiro" {
+			t.Fatalf("model %q type = %q, want kiro", model.ID, model.Type)
+		}
+	}
+}
+
 func TestPatchAuthFileFields_RefreshesModelRegistryImmediately(t *testing.T) {
 	t.Setenv("MANAGEMENT_PASSWORD", "")
 	gin.SetMode(gin.TestMode)


### PR DESCRIPTION
## Summary
- add a small static Kiro fallback model set matching built-in Kiro aliases
- preserve Kiro thinking metadata on fallback models
- keep excluded-model filtering working when Kiro dynamic discovery fails
- normalize raw Kiro IDE token JSON on management auth-file import
- persist normalized metadata so uploads survive restart/reload
- avoid normalizing typed auth JSON or untyped generic OAuth token exports

Addresses the #106 follow-up no-models/custom-disable symptom and the repo-owned part of #114 raw IDE token import.

## Validation
- go test ./internal/api/handlers/management -run 'TestUploadAuthFile_BatchMultipart|TestBuildAuthFromFileData_(NormalizesKiroIDETokenJSON|DoesNotNormalizeTypedAuthJSON|DoesNotNormalizeUntypedNonKiroOAuthJSON)|TestWriteAuthFile_PersistsNormalizedKiroIDETokenJSON|PatchAuthFileFields' -count=1\n- go test ./internal/registry ./sdk/cliproxy -run 'TestGetKiroModelsReturnsStaticFallbackSet|TestRegisterModelsForAuth_KiroFallbackModelsApplyExcludedModels|Kiro|ExcludedModels' -count=1\n- go build -o test-output ./cmd/server && rm test-output\n\nDocs impact: none\nAction: no update needed - backend fallback/import robustness, no documented command or API contract change