### PR TITLE
fix(kiro): accept raw IDE token imports

### DIFF
--- a/internal/auth/kiro/aws.go
+++ b/internal/auth/kiro/aws.go
@@ -495,17 +495,12 @@ func ExtractIDCIdentifier(startURL string) string {
 // when email is unavailable to prevent filename collisions.
 // Format: kiro-{authMethod}-{identifier}[-{seq}].json
 func GenerateTokenFileName(tokenData *KiroTokenData) string {
-	authMethod := tokenData.AuthMethod
-	if authMethod == "" {
-		authMethod = "unknown"
-	}
+	authMethod := sanitizeTokenFileComponent(tokenData.AuthMethod, "unknown")
 
 	// Priority 1: Use email if available (no sequence needed, email is unique)
 	if tokenData.Email != "" {
 		// Sanitize email for filename (replace @ and . with -)
-		sanitizedEmail := tokenData.Email
-		sanitizedEmail = strings.ReplaceAll(sanitizedEmail, "@", "-")
-		sanitizedEmail = strings.ReplaceAll(sanitizedEmail, ".", "-")
+		sanitizedEmail := sanitizeTokenFileComponent(tokenData.Email, "account")
 		return fmt.Sprintf("kiro-%s-%s.json", authMethod, sanitizedEmail)
 	}
 
@@ -514,7 +509,7 @@ func GenerateTokenFileName(tokenData *KiroTokenData) string {
 
 	// Priority 2: For IDC, use startUrl identifier with sequence
 	if authMethod == "idc" && tokenData.StartURL != "" {
-		identifier := ExtractIDCIdentifier(tokenData.StartURL)
+		identifier := sanitizeTokenFileComponent(ExtractIDCIdentifier(tokenData.StartURL), "")
 		if identifier != "" {
 			return fmt.Sprintf("kiro-%s-%s-%05d.json", authMethod, identifier, seq)
 		}
@@ -522,6 +517,37 @@ func GenerateTokenFileName(tokenData *KiroTokenData) string {
 
 	// Priority 3: Fallback to authMethod only with sequence
 	return fmt.Sprintf("kiro-%s-%05d.json", authMethod, seq)
+}
+
+func sanitizeTokenFileComponent(value, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+
+	var builder strings.Builder
+	lastDash := false
+	for _, r := range value {
+		keep := (r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') ||
+			r == '_' || r == '-' || r == '+'
+		if keep {
+			builder.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			builder.WriteByte('-')
+			lastDash = true
+		}
+	}
+
+	safe := strings.Trim(builder.String(), "-_")
+	if safe == "" {
+		return fallback
+	}
+	return safe
 }
 
 // DefaultKiroRegion is the fallback region when none is specified.

--- a/internal/auth/kiro/aws_auth.go
+++ b/internal/auth/kiro/aws_auth.go
@@ -274,6 +274,7 @@ func (k *KiroAuth) CreateTokenStorage(tokenData *KiroTokenData) *KiroTokenStorag
 		LastRefresh:  time.Now().Format(time.RFC3339),
 		ClientID:     tokenData.ClientID,
 		ClientSecret: tokenData.ClientSecret,
+		ClientIDHash: tokenData.ClientIDHash,
 		Region:       tokenData.Region,
 		StartURL:     tokenData.StartURL,
 		Email:        tokenData.Email,
@@ -313,6 +314,9 @@ func (k *KiroAuth) UpdateTokenStorage(storage *KiroTokenStorage, tokenData *Kiro
 	}
 	if tokenData.ClientSecret != "" {
 		storage.ClientSecret = tokenData.ClientSecret
+	}
+	if tokenData.ClientIDHash != "" {
+		storage.ClientIDHash = tokenData.ClientIDHash
 	}
 	if tokenData.Region != "" {
 		storage.Region = tokenData.Region

--- a/internal/auth/kiro/aws_test.go
+++ b/internal/auth/kiro/aws_test.go
@@ -318,6 +318,47 @@ func TestGenerateTokenFileName(t *testing.T) {
 	}
 }
 
+func TestGenerateTokenFileNameSanitizesUserControlledComponents(t *testing.T) {
+	tests := []struct {
+		name      string
+		tokenData *KiroTokenData
+	}{
+		{
+			name: "auth method traversal",
+			tokenData: &KiroTokenData{
+				AuthMethod: "../evil",
+				Email:      "user@example.com",
+			},
+		},
+		{
+			name: "email traversal",
+			tokenData: &KiroTokenData{
+				AuthMethod: "social",
+				Email:      "../../owned@example.com",
+			},
+		},
+		{
+			name: "idc identifier traversal",
+			tokenData: &KiroTokenData{
+				AuthMethod: "idc",
+				StartURL:   "https://../../etc.awsapps.com/start",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name := GenerateTokenFileName(tt.tokenData)
+			if strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
+				t.Fatalf("GenerateTokenFileName() = %q, contains unsafe path component", name)
+			}
+			if !strings.HasPrefix(name, "kiro-") || !strings.HasSuffix(name, ".json") {
+				t.Fatalf("GenerateTokenFileName() = %q, want kiro-*.json", name)
+			}
+		})
+	}
+}
+
 func TestParseProfileARN(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/auth/kiro/oauth_web.go
+++ b/internal/auth/kiro/oauth_web.go
@@ -396,6 +396,16 @@ func (h *OAuthWebHandler) pollForToken(ctx context.Context, session *webAuthSess
 				StartURL:     session.startURL,
 			}
 
+			if _, errSave := h.saveTokenToFile(tokenData); errSave != nil {
+				log.Errorf("OAuth Web: failed to save token to file: %v", errSave)
+				h.mu.Lock()
+				session.status = statusFailed
+				session.error = "Failed to save authentication tokens"
+				session.completedAt = time.Now()
+				h.mu.Unlock()
+				return
+			}
+
 			h.mu.Lock()
 			session.status = statusSuccess
 			session.completedAt = time.Now()
@@ -407,24 +417,21 @@ func (h *OAuthWebHandler) pollForToken(ctx context.Context, session *webAuthSess
 				h.onTokenObtained(tokenData)
 			}
 
-			// Save token to file
-			h.saveTokenToFile(tokenData)
-
 			log.Infof("OAuth Web: authentication successful for %s", email)
 			return
 		}
 	}
 }
 
-// saveTokenToFile saves the token data to the auth directory
-func (h *OAuthWebHandler) saveTokenToFile(tokenData *KiroTokenData) {
+// saveTokenToFile saves the token data to the auth directory.
+func (h *OAuthWebHandler) saveTokenToFile(tokenData *KiroTokenData) (string, error) {
 	// Get auth directory from config or use default
 	authDir := ""
 	if h.cfg != nil && h.cfg.AuthDir != "" {
 		var err error
 		authDir, err = util.ResolveAuthDir(h.cfg.AuthDir)
 		if err != nil {
-			log.Errorf("OAuth Web: failed to resolve auth directory: %v", err)
+			return "", fmt.Errorf("failed to resolve auth directory: %w", err)
 		}
 	}
 
@@ -432,22 +439,29 @@ func (h *OAuthWebHandler) saveTokenToFile(tokenData *KiroTokenData) {
 	if authDir == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			log.Errorf("OAuth Web: failed to get home directory: %v", err)
-			return
+			return "", fmt.Errorf("failed to get home directory: %w", err)
 		}
 		authDir = filepath.Join(home, ".cli-proxy-api")
 	}
 
 	// Create directory if not exists
 	if err := os.MkdirAll(authDir, 0700); err != nil {
-		log.Errorf("OAuth Web: failed to create auth directory: %v", err)
-		return
+		return "", fmt.Errorf("failed to create auth directory: %w", err)
 	}
 
 	// Generate filename using the unified function
 	fileName := GenerateTokenFileName(tokenData)
 
 	authFilePath := filepath.Join(authDir, fileName)
+	absAuthDir, errAuthDir := filepath.Abs(authDir)
+	absAuthFilePath, errAuthFilePath := filepath.Abs(authFilePath)
+	if errAuthDir != nil || errAuthFilePath != nil {
+		return "", fmt.Errorf("failed to resolve token output path")
+	}
+	authDirPrefix := absAuthDir + string(os.PathSeparator)
+	if absAuthFilePath != absAuthDir && !strings.HasPrefix(absAuthFilePath, authDirPrefix) {
+		return "", fmt.Errorf("invalid token output path")
+	}
 
 	// Convert to storage format and save
 	storage := &KiroTokenStorage{
@@ -461,17 +475,18 @@ func (h *OAuthWebHandler) saveTokenToFile(tokenData *KiroTokenData) {
 		LastRefresh:  time.Now().Format(time.RFC3339),
 		ClientID:     tokenData.ClientID,
 		ClientSecret: tokenData.ClientSecret,
+		ClientIDHash: tokenData.ClientIDHash,
 		Region:       tokenData.Region,
 		StartURL:     tokenData.StartURL,
 		Email:        tokenData.Email,
 	}
 
 	if err := storage.SaveTokenToFile(authFilePath); err != nil {
-		log.Errorf("OAuth Web: failed to save token to file: %v", err)
-		return
+		return "", fmt.Errorf("failed to save token to file: %w", err)
 	}
 
 	log.Infof("OAuth Web: token saved to %s", authFilePath)
+	return fileName, nil
 }
 
 func (h *OAuthWebHandler) ssoClient(session *webAuthSession) *SSOOIDCClient {
@@ -591,6 +606,17 @@ func (h *OAuthWebHandler) handleSocialCallback(c *gin.Context) {
 		Region:       "us-east-1",
 	}
 
+	if _, errSave := h.saveTokenToFile(tokenData); errSave != nil {
+		log.Errorf("OAuth Web: failed to save social token: %v", errSave)
+		h.mu.Lock()
+		session.status = statusFailed
+		session.error = "Failed to save authentication tokens"
+		session.completedAt = time.Now()
+		h.mu.Unlock()
+		h.renderError(c, session.error)
+		return
+	}
+
 	h.mu.Lock()
 	session.status = statusSuccess
 	session.completedAt = time.Now()
@@ -605,9 +631,6 @@ func (h *OAuthWebHandler) handleSocialCallback(c *gin.Context) {
 	if h.onTokenObtained != nil {
 		h.onTokenObtained(tokenData)
 	}
-
-	// Save token to file
-	h.saveTokenToFile(tokenData)
 
 	log.Infof("OAuth Web: social authentication successful for %s via %s", email, provider)
 	h.renderSuccess(c, session)
@@ -751,10 +774,10 @@ type ImportTokenRequest struct {
 	RefreshToken string `json:"refreshToken"`
 }
 
-// handleImportToken handles manual refresh token import from Kiro IDE
+// handleImportToken handles manual token imports from Kiro IDE.
 func (h *OAuthWebHandler) handleImportToken(c *gin.Context) {
-	var req ImportTokenRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
+	data, err := c.GetRawData()
+	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"success": false,
 			"error":   "Invalid request body",
@@ -762,7 +785,39 @@ func (h *OAuthWebHandler) handleImportToken(c *gin.Context) {
 		return
 	}
 
-	refreshToken := strings.TrimSpace(req.RefreshToken)
+	parsed, err := parseImportTokenPayload(data)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   err.Error(),
+		})
+		return
+	}
+	if parsed.rawKiroIDEJSON {
+		tokenData := parsed.tokenData
+		fileName, errSave := h.saveTokenToFile(tokenData)
+		if errSave != nil {
+			log.Errorf("OAuth Web: failed to save imported token: %v", errSave)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"success": false,
+				"error":   "Failed to save token",
+			})
+			return
+		}
+		if h.onTokenObtained != nil {
+			h.onTokenObtained(tokenData)
+		}
+
+		log.Infof("OAuth Web: raw Kiro IDE token imported successfully")
+		c.JSON(http.StatusOK, gin.H{
+			"success":  true,
+			"message":  "Token imported successfully",
+			"fileName": fileName,
+		})
+		return
+	}
+
+	refreshToken := strings.TrimSpace(parsed.tokenData.RefreshToken)
 	if refreshToken == "" {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"success": false,
@@ -801,16 +856,19 @@ func (h *OAuthWebHandler) handleImportToken(c *gin.Context) {
 	tokenData.AuthMethod = "social"
 	tokenData.Provider = "imported"
 
-	// Notify callback if set
+	// Save token to file
+	fileName, errSave := h.saveTokenToFile(tokenData)
+	if errSave != nil {
+		log.Errorf("OAuth Web: failed to save imported token: %v", errSave)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success": false,
+			"error":   "Failed to save token",
+		})
+		return
+	}
 	if h.onTokenObtained != nil {
 		h.onTokenObtained(tokenData)
 	}
-
-	// Save token to file
-	h.saveTokenToFile(tokenData)
-
-	// Generate filename for response using the unified function
-	fileName := GenerateTokenFileName(tokenData)
 
 	log.Infof("OAuth Web: token imported successfully")
 	c.JSON(http.StatusOK, gin.H{

--- a/internal/auth/kiro/oauth_web_import.go
+++ b/internal/auth/kiro/oauth_web_import.go
@@ -1,0 +1,153 @@
+package kiro
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type parsedImportToken struct {
+	tokenData      *KiroTokenData
+	rawKiroIDEJSON bool
+}
+
+func parseImportTokenPayload(data []byte) (*parsedImportToken, error) {
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return nil, fmt.Errorf("invalid request body")
+	}
+
+	if tokenData, ok, err := parseRawKiroIDETokenJSON(data); ok || err != nil {
+		return &parsedImportToken{tokenData: tokenData, rawKiroIDEJSON: ok}, err
+	}
+
+	var req ImportTokenRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return nil, fmt.Errorf("invalid request body")
+	}
+
+	refreshToken := strings.TrimSpace(req.RefreshToken)
+	if strings.HasPrefix(refreshToken, "{") {
+		if tokenData, ok, err := parseRawKiroIDETokenJSON([]byte(refreshToken)); ok || err != nil {
+			return &parsedImportToken{tokenData: tokenData, rawKiroIDEJSON: ok}, err
+		}
+	}
+
+	return &parsedImportToken{
+		tokenData: &KiroTokenData{RefreshToken: refreshToken},
+	}, nil
+}
+
+func parseRawKiroIDETokenJSON(data []byte) (*KiroTokenData, bool, error) {
+	var fields map[string]any
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return nil, false, nil
+	}
+
+	accessToken := importStringField(fields, "accessToken", "access_token")
+	refreshToken := importStringField(fields, "refreshToken", "refresh_token")
+	hasKiroIDEField := accessToken != "" ||
+		importStringField(fields, "profileArn", "profile_arn") != "" ||
+		importStringField(fields, "clientIdHash", "client_id_hash") != "" ||
+		importStringField(fields, "startUrl", "start_url") != "" ||
+		importStringField(fields, "authMethod", "auth_method") != ""
+
+	if !hasKiroIDEField {
+		return nil, false, nil
+	}
+	if accessToken == "" {
+		return nil, true, fmt.Errorf("accessToken is required when importing raw Kiro IDE token JSON")
+	}
+	if refreshToken == "" {
+		return nil, true, fmt.Errorf("refreshToken is required when importing raw Kiro IDE token JSON")
+	}
+
+	authMethod := normalizeImportedKiroAuthMethod(fields)
+	region := strings.TrimSpace(importStringField(fields, "region"))
+	if region == "" {
+		region = DefaultKiroRegion
+	}
+
+	email := strings.TrimSpace(importStringField(fields, "email"))
+	if email == "" {
+		email = ExtractEmailFromJWT(accessToken)
+	}
+
+	provider := strings.TrimSpace(importStringField(fields, "provider"))
+	if provider == "" {
+		provider = "imported"
+	}
+
+	tokenData := &KiroTokenData{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		ProfileArn:   strings.TrimSpace(importStringField(fields, "profileArn", "profile_arn")),
+		ExpiresAt:    strings.TrimSpace(importStringField(fields, "expiresAt", "expires_at")),
+		AuthMethod:   authMethod,
+		Provider:     provider,
+		ClientID:     strings.TrimSpace(importStringField(fields, "clientId", "client_id")),
+		ClientSecret: strings.TrimSpace(importStringField(fields, "clientSecret", "client_secret")),
+		ClientIDHash: strings.TrimSpace(importStringField(fields, "clientIdHash", "client_id_hash")),
+		Email:        email,
+		StartURL:     strings.TrimSpace(importStringField(fields, "startUrl", "start_url")),
+		Region:       region,
+	}
+	if err := prepareImportedKiroTokenData(tokenData); err != nil {
+		return nil, true, err
+	}
+	return tokenData, true, nil
+}
+
+func normalizeImportedKiroAuthMethod(fields map[string]any) string {
+	authMethod := strings.ToLower(strings.TrimSpace(importStringField(fields, "authMethod", "auth_method")))
+	authMethod = strings.ReplaceAll(authMethod, "_", "-")
+	switch authMethod {
+	case "idc", "builder-id", "social", "google", "github", "imported":
+		return authMethod
+	case "builderid", "aws":
+		return "builder-id"
+	}
+
+	if importStringField(fields, "clientIdHash", "client_id_hash") != "" ||
+		importStringField(fields, "startUrl", "start_url") != "" {
+		return "idc"
+	}
+	return "imported"
+}
+
+func prepareImportedKiroTokenData(tokenData *KiroTokenData) error {
+	if tokenData == nil || tokenData.AuthMethod != "idc" {
+		return nil
+	}
+	if tokenData.ClientIDHash != "" && (tokenData.ClientID == "" || tokenData.ClientSecret == "") {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to load Kiro IDE device registration: %w", err)
+		}
+		if err := loadDeviceRegistration(homeDir, tokenData.ClientIDHash, tokenData); err != nil {
+			return fmt.Errorf("failed to load Kiro IDE device registration for clientIdHash %q: %w", tokenData.ClientIDHash, err)
+		}
+	}
+	if tokenData.ClientID == "" || tokenData.ClientSecret == "" {
+		return fmt.Errorf("Kiro IDC token import requires clientId/clientSecret or a readable device registration file")
+	}
+	return nil
+}
+
+func importStringField(fields map[string]any, names ...string) string {
+	for _, name := range names {
+		raw, ok := fields[name]
+		if !ok || raw == nil {
+			continue
+		}
+		switch value := raw.(type) {
+		case string:
+			return value
+		case fmt.Stringer:
+			return value.String()
+		default:
+			return fmt.Sprint(value)
+		}
+	}
+	return ""
+}

--- a/internal/auth/kiro/oauth_web_import_test.go
+++ b/internal/auth/kiro/oauth_web_import_test.go
@@ -1,0 +1,242 @@
+package kiro
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestOAuthWebImportAcceptsRawKiroIDETokenJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	authDir := t.TempDir()
+	handler := NewOAuthWebHandler(&config.Config{AuthDir: authDir})
+	router := gin.New()
+	handler.RegisterRoutes(router)
+
+	rawToken := `{
+		"accessToken": "access-token",
+		"refreshToken": "aorAAAAAGraw-token",
+		"profileArn": "arn:aws:codewhisperer:us-west-2:123456789012:profile/abc",
+		"expiresAt": "2027-01-02T03:04:05Z",
+		"authMethod": "IdC",
+		"provider": "Google",
+		"clientId": "client-id",
+		"clientSecret": "client-secret",
+		"clientIdHash": "client-hash",
+		"email": "user@example.com",
+		"startUrl": "https://d-1234567890.awsapps.com/start",
+		"region": "us-west-2"
+	}`
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v0/oauth/kiro/import", strings.NewReader(rawToken))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if body["success"] != true {
+		t.Fatalf("success = %v, want true", body["success"])
+	}
+	if body["fileName"] != "kiro-idc-user-example-com.json" {
+		t.Fatalf("fileName = %v", body["fileName"])
+	}
+
+	written, err := os.ReadFile(filepath.Join(authDir, "kiro-idc-user-example-com.json"))
+	if err != nil {
+		t.Fatalf("failed to read saved token: %v", err)
+	}
+	var saved KiroTokenStorage
+	if err := json.Unmarshal(written, &saved); err != nil {
+		t.Fatalf("failed to parse saved token: %v", err)
+	}
+	if saved.Type != "kiro" {
+		t.Fatalf("type = %q, want kiro", saved.Type)
+	}
+	if saved.AccessToken != "access-token" || saved.RefreshToken != "aorAAAAAGraw-token" {
+		t.Fatalf("saved token mismatch: access=%q refresh=%q", saved.AccessToken, saved.RefreshToken)
+	}
+	if saved.AuthMethod != "idc" {
+		t.Fatalf("auth_method = %q, want idc", saved.AuthMethod)
+	}
+	if saved.ClientID != "client-id" || saved.ClientSecret != "client-secret" {
+		t.Fatalf("client credentials not preserved: id=%q secret=%q", saved.ClientID, saved.ClientSecret)
+	}
+	if saved.Region != "us-west-2" || saved.StartURL != "https://d-1234567890.awsapps.com/start" {
+		t.Fatalf("IDC metadata mismatch: region=%q startURL=%q", saved.Region, saved.StartURL)
+	}
+}
+
+func TestOAuthWebImportLoadsIDCDeviceRegistrationFromClientIDHash(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	cacheDir := filepath.Join(homeDir, ".aws", "sso", "cache")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		t.Fatalf("failed to create cache dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "client-hash.json"), []byte(`{"clientId":"loaded-client-id","clientSecret":"loaded-client-secret"}`), 0o600); err != nil {
+		t.Fatalf("failed to write device registration: %v", err)
+	}
+
+	authDir := t.TempDir()
+	handler := NewOAuthWebHandler(&config.Config{AuthDir: authDir})
+	router := gin.New()
+	handler.RegisterRoutes(router)
+
+	rawToken := `{
+		"accessToken": "access-token",
+		"refreshToken": "aorAAAAAGraw-token",
+		"authMethod": "IdC",
+		"clientIdHash": "client-hash",
+		"email": "user@example.com",
+		"startUrl": "https://d-1234567890.awsapps.com/start"
+	}`
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v0/oauth/kiro/import", strings.NewReader(rawToken))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	written, err := os.ReadFile(filepath.Join(authDir, "kiro-idc-user-example-com.json"))
+	if err != nil {
+		t.Fatalf("failed to read saved token: %v", err)
+	}
+	var saved KiroTokenStorage
+	if err := json.Unmarshal(written, &saved); err != nil {
+		t.Fatalf("failed to parse saved token: %v", err)
+	}
+	if saved.ClientID != "loaded-client-id" || saved.ClientSecret != "loaded-client-secret" {
+		t.Fatalf("loaded credentials not preserved: id=%q secret=%q", saved.ClientID, saved.ClientSecret)
+	}
+	if saved.ClientIDHash != "client-hash" {
+		t.Fatalf("client_id_hash = %q, want client-hash", saved.ClientIDHash)
+	}
+}
+
+func TestOAuthWebImportRejectsIDCClientIDHashWithoutDeviceRegistration(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Setenv("HOME", t.TempDir())
+	handler := NewOAuthWebHandler(&config.Config{AuthDir: t.TempDir()})
+	router := gin.New()
+	handler.RegisterRoutes(router)
+
+	rawToken := `{
+		"accessToken": "access-token",
+		"refreshToken": "aorAAAAAGraw-token",
+		"authMethod": "IdC",
+		"clientIdHash": "missing-client-hash",
+		"email": "user@example.com"
+	}`
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v0/oauth/kiro/import", strings.NewReader(rawToken))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "device registration") {
+		t.Fatalf("body = %s, want device registration error", rec.Body.String())
+	}
+}
+
+func TestOAuthWebImportAcceptsPastedKiroIDETokenJSONInRefreshTokenField(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	authDir := t.TempDir()
+	handler := NewOAuthWebHandler(&config.Config{AuthDir: authDir})
+	router := gin.New()
+	handler.RegisterRoutes(router)
+
+	rawToken := `{"accessToken":"access-token","refreshToken":"aorAAAAAGraw-token","authMethod":"social","provider":"Github","email":"user@example.com","region":"us-east-1"}`
+	wrappedBody, err := json.Marshal(map[string]string{"refreshToken": rawToken})
+	if err != nil {
+		t.Fatalf("failed to marshal wrapped body: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v0/oauth/kiro/import", strings.NewReader(string(wrappedBody)))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(authDir, "kiro-social-user-example-com.json")); err != nil {
+		t.Fatalf("expected pasted token JSON to be saved: %v", err)
+	}
+}
+
+func TestOAuthWebImportReportsSaveFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	authDirFile := filepath.Join(t.TempDir(), "auth-dir-file")
+	if err := os.WriteFile(authDirFile, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("failed to create auth dir file: %v", err)
+	}
+	handler := NewOAuthWebHandler(&config.Config{AuthDir: authDirFile})
+	callbackCalled := false
+	handler.SetTokenCallback(func(*KiroTokenData) {
+		callbackCalled = true
+	})
+	router := gin.New()
+	handler.RegisterRoutes(router)
+
+	rawToken := `{"accessToken":"access-token","refreshToken":"aorAAAAAGraw-token","authMethod":"social","provider":"Github","email":"user@example.com","region":"us-east-1"}`
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v0/oauth/kiro/import", strings.NewReader(rawToken))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Failed to save token") {
+		t.Fatalf("body = %s, want save failure error", rec.Body.String())
+	}
+	if callbackCalled {
+		t.Fatal("token callback was called despite save failure")
+	}
+}
+
+func TestOAuthWebImportRejectsInvalidBareRefreshToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := NewOAuthWebHandler(&config.Config{AuthDir: t.TempDir()})
+	router := gin.New()
+	handler.RegisterRoutes(router)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v0/oauth/kiro/import", strings.NewReader(`{"refreshToken":"not-a-token"}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Invalid token format") {
+		t.Fatalf("body = %s, want invalid token format error", rec.Body.String())
+	}
+}

--- a/internal/auth/kiro/oauth_web_templates.go
+++ b/internal/auth/kiro/oauth_web_templates.go
@@ -643,9 +643,9 @@ const (
         <div class="manual-form" id="manualForm">
             <form id="importForm" onsubmit="submitImport(event)">
                 <div class="form-group">
-                    <label for="refreshToken">Refresh Token</label>
-                    <textarea id="refreshToken" name="refreshToken" placeholder="Paste your refreshToken here (starts with aorAAAAAG...)" required></textarea>
-                    <div class="hint">Copy from Kiro IDE: ~/.kiro/kiro-auth-token.json → refreshToken field</div>
+                    <label for="refreshToken">Kiro Token JSON or Refresh Token</label>
+                    <textarea id="refreshToken" name="refreshToken" placeholder="Paste the full kiro-auth-token.json content, or just refreshToken (starts with aorAAAAAG...)" required></textarea>
+                    <div class="hint">Copy from Kiro IDE: ~/.aws/sso/cache/kiro-auth-token.json, or paste only its refreshToken field</div>
                 </div>
                 
                 <button type="submit" class="submit-btn" id="importBtn">
@@ -663,8 +663,8 @@ const (
         <div class="info-box">
             💡 <strong>How to get RefreshToken:</strong><br>
             1. Open Kiro IDE and login with Google/GitHub<br>
-            2. Find the token file: <code>~/.kiro/kiro-auth-token.json</code><br>
-            3. Copy the <code>refreshToken</code> value and paste it above
+            2. Find the token file: <code>~/.aws/sso/cache/kiro-auth-token.json</code><br>
+            3. Paste the full JSON content above, or copy only the <code>refreshToken</code> value
         </div>
     </div>
     
@@ -701,10 +701,22 @@ const (
                 return;
             }
             
-            if (!refreshToken.startsWith('aorAAAAAG')) {
+            let requestBody;
+            if (refreshToken.startsWith('{')) {
+                try {
+                    JSON.parse(refreshToken);
+                    requestBody = refreshToken;
+                } catch (error) {
+                    statusEl.className = 'status-message error';
+                    statusEl.textContent = 'Invalid token JSON: ' + error.message;
+                    return;
+                }
+            } else if (!refreshToken.startsWith('aorAAAAAG')) {
                 statusEl.className = 'status-message error';
-                statusEl.textContent = 'Invalid token format. Token should start with aorAAAAAG...';
+                statusEl.textContent = 'Invalid token format. Paste full token JSON, or a refreshToken starting with aorAAAAAG...';
                 return;
+            } else {
+                requestBody = JSON.stringify({ refreshToken: refreshToken });
             }
             
             btn.disabled = true;
@@ -716,7 +728,7 @@ const (
                 const response = await fetch('/v0/oauth/kiro/import', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ refreshToken: refreshToken })
+                    body: requestBody
                 });
                 
                 const data = await response.json();

--- a/internal/auth/kiro/token.go
+++ b/internal/auth/kiro/token.go
@@ -29,6 +29,8 @@ type KiroTokenStorage struct {
 	ClientID string `json:"client_id,omitempty"`
 	// ClientSecret is the OAuth client secret (required for token refresh)
 	ClientSecret string `json:"client_secret,omitempty"`
+	// ClientIDHash identifies the Kiro IDE device-registration file.
+	ClientIDHash string `json:"client_id_hash,omitempty"`
 	// Region is the OIDC region for IDC login and token refresh
 	Region string `json:"region,omitempty"`
 	// StartURL is the AWS Identity Center start URL (for IDC auth)
@@ -82,6 +84,7 @@ func (s *KiroTokenStorage) ToTokenData() *KiroTokenData {
 		Provider:     s.Provider,
 		ClientID:     s.ClientID,
 		ClientSecret: s.ClientSecret,
+		ClientIDHash: s.ClientIDHash,
 		Region:       s.Region,
 		StartURL:     s.StartURL,
 		Email:        s.Email,


### PR DESCRIPTION
## Summary

- Accept full Kiro IDE token JSON in `/v0/oauth/kiro/import`, including JSON pasted into the legacy refresh-token field.
- Preserve Kiro IDC metadata, resolve `clientIdHash` device registrations when available, and reject unrefreshable IDC imports with a clear error.
- Harden Kiro token filename generation and report disk-save failures instead of returning false success.

Closes #114

## Root Cause

The Kiro web import route only accepted a bare `refreshToken` value and immediately called the social refresh endpoint. The actual Kiro IDE token file is JSON under `~/.aws/sso/cache/kiro-auth-token.json`, so full-file imports were either rejected by prefix validation or treated as a refresh-only request.

## Changes

| File | Change |
|------|--------|
| `internal/auth/kiro/oauth_web.go` | Parses raw IDE JSON imports, saves before callbacks, and returns save errors to clients. |
| `internal/auth/kiro/oauth_web_import.go` | Adds raw Kiro token parser, auth-method normalization, and IDC `clientIdHash` device-registration loading. |
| `internal/auth/kiro/token.go` | Persists `client_id_hash` in Kiro token storage. |
| `internal/auth/kiro/aws.go` | Sanitizes token filename components from auth method, email, and IDC identifiers. |
| `internal/auth/kiro/oauth_web_templates.go` | Updates the import UI to accept full JSON or bare refresh token and points to the correct Kiro IDE path. |
| `internal/auth/kiro/*_test.go` | Adds regressions for raw JSON import, pasted JSON, invalid tokens, device registration, save failures, and filename sanitization. |

## Test plan

- [x] `go test ./internal/auth/kiro -run 'TestOAuthWebImport|TestGenerateTokenFileNameSanitizes' -count=1`
- [x] `go test ./internal/auth/kiro -count=1`
- [x] `go test ./internal/auth/kiro ./sdk/auth -run 'Kiro|OAuthWebImport|Import' -count=1`
- [x] `go build -o test-output ./cmd/server && rm test-output`
- [x] `git diff --check`
