### PR TITLE
fix(ci): resolve downstream release runs by title

### DIFF
--- a/.github/workflows/sync-release-tag.yml
+++ b/.github/workflows/sync-release-tag.yml
@@ -95,7 +95,8 @@ jobs:
             for _ in $(seq 1 12); do
               run_id="$(gh run list --repo "${GITHUB_REPOSITORY}" --workflow "${workflow}" \
                 --event workflow_dispatch --limit 20 --json databaseId,displayTitle \
-                --jq ".[] | select(.displayTitle == \\\"${title}\\\") | .databaseId" | head -n 1)"
+                | jq -r --arg title "${title}" \
+                  'first(.[] | select(.displayTitle == $title) | .databaseId) // empty')"
               if [ -n "${run_id}" ]; then
                 printf '%s' "${run_id}"
                 return 0


### PR DESCRIPTION
Fixes release run correlation after the v7.2.62 reconciliation. The coordinator now passes the expected display title to jq as data instead of injecting escaped quotes into a jq expression, preserving exact tag and commit matching plus fail-fast behavior.

Validation: actionlint, whitespace check, synthetic title with quote-like content, and live exact-title lookup rehearsal.