### PR TITLE
fix(cursor): print login URL to stdout

### DIFF
--- a/sdk/auth/cursor.go
+++ b/sdk/auth/cursor.go
@@ -46,9 +46,9 @@ func (a CursorAuthenticator) Login(ctx context.Context, cfg *config.Config, opts
 		return nil, fmt.Errorf("cursor: failed to generate auth params: %w", err)
 	}
 
-	// Display the login URL
-	log.Info("Starting Cursor authentication...")
-	log.Infof("Please visit this URL to log in: %s", authParams.LoginURL)
+	// Interactive login prompts bypass logrus so file logging cannot hide the URL.
+	fmt.Println("Starting Cursor authentication...")
+	fmt.Printf("Please visit this URL to log in: %s\n", authParams.LoginURL)
 
 	// Try to open the browser automatically
 	if !opts.NoBrowser {
@@ -59,7 +59,7 @@ func (a CursorAuthenticator) Login(ctx context.Context, cfg *config.Config, opts
 		}
 	}
 
-	log.Info("Waiting for Cursor authorization...")
+	fmt.Println("Waiting for Cursor authorization...")
 
 	// Poll for the auth result
 	tokens, err := cursorauth.PollForAuth(ctx, authParams.UUID, authParams.Verifier)

--- a/sdk/auth/cursor_test.go
+++ b/sdk/auth/cursor_test.go
@@ -1,0 +1,136 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	log "github.com/sirupsen/logrus"
+)
+
+var cursorLoginOutputMu sync.Mutex
+
+func TestCursorLoginWritesInstructionsToStdoutWithFileLogging(t *testing.T) {
+	output := captureCursorLoginOutput(t, true)
+	assertCursorLoginInstructions(t, output)
+}
+
+func TestCursorLoginWritesInstructionsOnceWithStandardLogging(t *testing.T) {
+	output := captureCursorLoginOutput(t, false)
+	assertCursorLoginInstructions(t, output)
+}
+
+func captureCursorLoginOutput(t *testing.T, loggingToFile bool) string {
+	t.Helper()
+
+	cursorLoginOutputMu.Lock()
+	t.Cleanup(cursorLoginOutputMu.Unlock)
+
+	t.Setenv("WRITABLE_PATH", t.TempDir())
+	previousLogOutput := log.StandardLogger().Out
+	t.Cleanup(func() {
+		if err := logging.ConfigureLogOutput(&config.Config{}); err != nil {
+			t.Errorf("restore log output: %v", err)
+		}
+		log.SetOutput(previousLogOutput)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	return captureStdout(t, func() {
+		if err := logging.ConfigureLogOutput(&config.Config{LoggingToFile: loggingToFile}); err != nil {
+			t.Fatalf("configure log output: %v", err)
+		}
+
+		_, err := NewCursorAuthenticator().Login(ctx, &config.Config{}, &LoginOptions{NoBrowser: true})
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("Login() error = %v, want context canceled", err)
+		}
+	})
+}
+
+func captureStdout(t *testing.T, action func()) string {
+	t.Helper()
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+
+	previousStdout := os.Stdout
+	os.Stdout = writer
+	t.Cleanup(func() {
+		os.Stdout = previousStdout
+	})
+
+	action()
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stdout pipe: %v", err)
+	}
+	os.Stdout = previousStdout
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close stdout reader: %v", err)
+	}
+	return string(output)
+}
+
+func assertCursorLoginInstructions(t *testing.T, output string) {
+	t.Helper()
+
+	const (
+		startingPrompt = "Starting Cursor authentication..."
+		urlPrompt      = "Please visit this URL to log in: "
+		waitingPrompt  = "Waiting for Cursor authorization..."
+	)
+
+	for _, prompt := range []string{startingPrompt, urlPrompt, waitingPrompt} {
+		if count := strings.Count(output, prompt); count != 1 {
+			t.Fatalf("stdout contains %q %d times, want once:\n%s", prompt, count, output)
+		}
+	}
+
+	startingIndex := strings.Index(output, startingPrompt)
+	urlIndex := strings.Index(output, urlPrompt)
+	waitingIndex := strings.Index(output, waitingPrompt)
+	if !(startingIndex < urlIndex && urlIndex < waitingIndex) {
+		t.Fatalf("stdout prompt order is wrong:\n%s", output)
+	}
+
+	urlLine := output[urlIndex+len(urlPrompt):]
+	loginURL := strings.TrimSpace(strings.SplitN(urlLine, "\n", 2)[0])
+	parsedURL, err := url.Parse(loginURL)
+	if err != nil {
+		t.Fatalf("parse login URL %q: %v", loginURL, err)
+	}
+	if parsedURL.Scheme != "https" || parsedURL.Host != "cursor.com" || parsedURL.Path != "/loginDeepControl" {
+		t.Fatalf("unexpected login URL %q", loginURL)
+	}
+	query := parsedURL.Query()
+	if query.Get("challenge") == "" || query.Get("uuid") == "" || query.Get("mode") != "login" || query.Get("redirectTarget") != "cli" {
+		t.Fatalf("incomplete login URL %q", loginURL)
+	}
+	if count := strings.Count(output, loginURL); count != 1 {
+		t.Fatalf("stdout contains the complete login URL %d times, want once:\n%s", count, output)
+	}
+
+	lowerOutput := strings.ToLower(output)
+	for _, secret := range []string{"verifier=", "access_token", "refresh_token", "authorization:"} {
+		if strings.Contains(lowerOutput, secret) {
+			t.Fatalf("stdout exposed %q:\n%s", secret, output)
+		}
+	}
+}


### PR DESCRIPTION
Restores visible Cursor device-login instructions when structured logs are redirected to a file. The start message, complete URL, and waiting message go directly to stdout before polling; browser and --no-browser behavior are unchanged.

Contributor provenance: retains the core intent from tan-yong-sheng commit 65cf04165876688b2e11b364d27a0211de5257c4, with narrowed tests and maintainer review.

Validation: focused Cursor auth race tests, full sdk/auth tests, server build, and independent review.

Refs #122