### PR TITLE
test(claude): cover OAuth cloak metadata fallback

### DIFF
--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"regexp"
 	"strings"
 	"sync"
@@ -2709,6 +2710,128 @@ func TestApplyCloaking_PreservesConfiguredStrictModeAndSensitiveWordsWhenModeOmi
 	}
 	if got := gjson.GetBytes(out, "messages.0.content.0.text").String(); !strings.Contains(got, "\u200B") {
 		t.Fatalf("expected configured sensitive word obfuscation to apply, got %q", got)
+	}
+}
+
+func TestGetCloakConfigFromAuth(t *testing.T) {
+	tests := []struct {
+		name       string
+		auth       *cliproxyauth.Auth
+		wantMode   string
+		wantStrict bool
+		wantWords  []string
+		wantCache  bool
+	}{
+		{
+			name: "metadata fallback parses cloak settings",
+			auth: &cliproxyauth.Auth{Metadata: map[string]any{
+				"cloak_mode":            "  always ",
+				"cloak_strict_mode":     "TrUe",
+				"cloak_sensitive_words": " alpha, beta ",
+				"cloak_cache_user_id":   "TRUE",
+			}},
+			wantMode:   "always",
+			wantStrict: true,
+			wantWords:  []string{"alpha", "beta"},
+			wantCache:  true,
+		},
+		{
+			name: "nonblank attributes take precedence over metadata",
+			auth: &cliproxyauth.Auth{
+				Attributes: map[string]string{
+					"cloak_mode":            "  never ",
+					"cloak_strict_mode":     "false",
+					"cloak_sensitive_words": "attribute-one, attribute-two",
+					"cloak_cache_user_id":   "true",
+				},
+				Metadata: map[string]any{
+					"cloak_mode":            "always",
+					"cloak_strict_mode":     "true",
+					"cloak_sensitive_words": "metadata-one, metadata-two",
+					"cloak_cache_user_id":   "false",
+				},
+			},
+			wantMode:  "never",
+			wantWords: []string{"attribute-one", "attribute-two"},
+			wantCache: true,
+		},
+		{
+			name: "blank attributes fall back to metadata",
+			auth: &cliproxyauth.Auth{
+				Attributes: map[string]string{
+					"cloak_mode":            " \t ",
+					"cloak_strict_mode":     "",
+					"cloak_sensitive_words": "  ",
+					"cloak_cache_user_id":   "\n",
+				},
+				Metadata: map[string]any{
+					"cloak_mode":            "always",
+					"cloak_strict_mode":     "true",
+					"cloak_sensitive_words": "metadata-one, metadata-two",
+					"cloak_cache_user_id":   "true",
+				},
+			},
+			wantMode:   "always",
+			wantStrict: true,
+			wantWords:  []string{"metadata-one", "metadata-two"},
+			wantCache:  true,
+		},
+		{
+			name: "nonstring and nil metadata are ignored",
+			auth: &cliproxyauth.Auth{Metadata: map[string]any{
+				"cloak_mode":            1,
+				"cloak_strict_mode":     true,
+				"cloak_sensitive_words": []string{"not-a-string"},
+				"cloak_cache_user_id":   nil,
+			}},
+		},
+		{
+			name: "nil auth keeps empty credential override",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMode, gotStrict, gotWords, gotCache := getCloakConfigFromAuth(tt.auth)
+			if gotMode != tt.wantMode || gotStrict != tt.wantStrict || gotCache != tt.wantCache {
+				t.Fatalf("getCloakConfigFromAuth() = (%q, %t, ..., %t), want (%q, %t, ..., %t)", gotMode, gotStrict, gotCache, tt.wantMode, tt.wantStrict, tt.wantCache)
+			}
+			if !reflect.DeepEqual(gotWords, tt.wantWords) {
+				t.Fatal("getCloakConfigFromAuth() sensitive words do not match")
+			}
+		})
+	}
+}
+
+func TestApplyCloaking_EmptyCredentialModeRespectsDefaultAndGlobalPrecedence(t *testing.T) {
+	payload := []byte(`{"system":"original system","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`)
+	tests := []struct {
+		name        string
+		cfg         *config.Config
+		wantCloaked bool
+	}{
+		{
+			name:        "default auto mode applies cloaking",
+			cfg:         &config.Config{},
+			wantCloaked: true,
+		},
+		{
+			name:        "global disable mode overrides an empty credential mode",
+			cfg:         &config.Config{DisableClaudeCloakMode: true},
+			wantCloaked: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, errCloaking := applyCloaking(context.Background(), tt.cfg, &cliproxyauth.Auth{}, payload, "claude-3-5-sonnet-20241022", "test-key")
+			if errCloaking != nil {
+				t.Fatalf("applyCloaking() error = %v", errCloaking)
+			}
+			if gotCloaked := !bytes.Equal(got, payload); gotCloaked != tt.wantCloaked {
+				t.Fatalf("applyCloaking() cloaked = %t, want %t", gotCloaked, tt.wantCloaked)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Adds regression coverage for the existing upstream OAuth credential cloak fallback: Attributes take precedence, Metadata supplies missing string values, invalid/nil data is safe, and global/default cloak precedence is preserved.

Validation: focused executor tests, executor/synthesizer race tests, server build, and independent review.

Refs #123