### PR TITLE
fix(cursor): retain last-good model cache

### DIFF
--- a/internal/runtime/executor/cursor_executor.go
+++ b/internal/runtime/executor/cursor_executor.go
@@ -1479,25 +1479,113 @@ func decodeMcpArgsToJSON(args map[string][]byte) string {
 
 // --- Model Discovery ---
 
+// cursorModelsCache stores the last successful model list for each auth ID.
+// A transient models request failure must not replace a verified live catalog
+// with the hardcoded cold-start fallback.
+var (
+	cursorModelsCacheMu sync.RWMutex
+	cursorModelsCache   = make(map[string][]*registry.ModelInfo)
+)
+
+// cursorModelsOrFallback returns an independent copy of the last successful
+// list for authID. The hardcoded fallback is used only before that auth has a
+// successful live fetch.
+func cursorModelsOrFallback(authID string) []*registry.ModelInfo {
+	if authID != "" {
+		cursorModelsCacheMu.RLock()
+		cached, ok := cursorModelsCache[authID]
+		if ok && len(cached) > 0 {
+			models := cloneCursorModelInfos(cached)
+			cursorModelsCacheMu.RUnlock()
+			return models
+		}
+		cursorModelsCacheMu.RUnlock()
+	}
+	return GetCursorFallbackModels()
+}
+
+// cacheCursorModels records a complete, independent snapshot after a
+// successful live fetch. Each success replaces the previous snapshot for the
+// same auth ID.
+func cacheCursorModels(authID string, models []*registry.ModelInfo) {
+	if authID == "" || len(models) == 0 {
+		return
+	}
+
+	snapshot := cloneCursorModelInfos(models)
+	cursorModelsCacheMu.Lock()
+	cursorModelsCache[authID] = snapshot
+	cursorModelsCacheMu.Unlock()
+}
+
+func cloneCursorModelInfos(models []*registry.ModelInfo) []*registry.ModelInfo {
+	if len(models) == 0 {
+		return nil
+	}
+
+	cloned := make([]*registry.ModelInfo, len(models))
+	for i, model := range models {
+		cloned[i] = cloneCursorModelInfo(model)
+	}
+	return cloned
+}
+
+func cloneCursorModelInfo(model *registry.ModelInfo) *registry.ModelInfo {
+	if model == nil {
+		return nil
+	}
+
+	cloned := *model
+	cloned.SupportedGenerationMethods = append([]string(nil), model.SupportedGenerationMethods...)
+	cloned.SupportedParameters = append([]string(nil), model.SupportedParameters...)
+	cloned.SupportedEndpoints = append([]string(nil), model.SupportedEndpoints...)
+	cloned.SupportedInputModalities = append([]string(nil), model.SupportedInputModalities...)
+	cloned.SupportedOutputModalities = append([]string(nil), model.SupportedOutputModalities...)
+	if model.Thinking != nil {
+		thinking := *model.Thinking
+		thinking.Levels = append([]string(nil), model.Thinking.Levels...)
+		cloned.Thinking = &thinking
+	}
+	if model.Config != nil {
+		modelConfig := *model.Config
+		if model.Config.OverrideHeader != nil {
+			modelConfig.OverrideHeader = make(map[string]string, len(model.Config.OverrideHeader))
+			for key, value := range model.Config.OverrideHeader {
+				modelConfig.OverrideHeader[key] = value
+			}
+		}
+		cloned.Config = &modelConfig
+	}
+	return &cloned
+}
+
 // FetchCursorModels retrieves available models from Cursor's API.
 func FetchCursorModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *config.Config) []*registry.ModelInfo {
+	if auth == nil {
+		return GetCursorFallbackModels()
+	}
+
+	authID := auth.ID
 	accessToken := cursorAccessToken(auth)
 	if accessToken == "" {
-		return GetCursorFallbackModels()
+		return cursorModelsOrFallback(authID)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
+	return fetchCursorModels(ctx, authID, accessToken, newH2Client(), cursorAPIURL+cursorModelsPath)
+}
 
+func fetchCursorModels(ctx context.Context, authID, accessToken string, client *http.Client, modelsURL string) []*registry.ModelInfo {
 	// GetUsableModels is a unary RPC call (not streaming)
 	// Send an empty protobuf request
 	emptyReq := make([]byte, 0)
 
 	h2Req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		cursorAPIURL+cursorModelsPath, bytes.NewReader(emptyReq))
+		modelsURL, bytes.NewReader(emptyReq))
 	if err != nil {
 		log.Debugf("cursor: failed to create models request: %v", err)
-		return GetCursorFallbackModels()
+		return cursorModelsOrFallback(authID)
 	}
 
 	h2Req.Header.Set("Content-Type", "application/proto")
@@ -1507,28 +1595,28 @@ func FetchCursorModels(ctx context.Context, auth *cliproxyauth.Auth, cfg *config
 	h2Req.Header.Set("X-Cursor-Client-Version", cursorClientVersion)
 	h2Req.Header.Set("X-Cursor-Client-Type", "cli")
 
-	client := newH2Client()
 	resp, err := client.Do(h2Req)
 	if err != nil {
 		log.Debugf("cursor: models request failed: %v", err)
-		return GetCursorFallbackModels()
+		return cursorModelsOrFallback(authID)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		log.Debugf("cursor: models request returned status %d", resp.StatusCode)
-		return GetCursorFallbackModels()
+		return cursorModelsOrFallback(authID)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return GetCursorFallbackModels()
+		return cursorModelsOrFallback(authID)
 	}
 
 	models := parseModelsResponse(body)
 	if len(models) == 0 {
-		return GetCursorFallbackModels()
+		return cursorModelsOrFallback(authID)
 	}
+	cacheCursorModels(authID, models)
 	return models
 }
 

--- a/internal/runtime/executor/cursor_models_cache_test.go
+++ b/internal/runtime/executor/cursor_models_cache_test.go
@@ -1,0 +1,250 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func withIsolatedCursorModelsCache(t *testing.T) {
+	t.Helper()
+	cursorModelsCacheMu.Lock()
+	previous := cursorModelsCache
+	cursorModelsCache = make(map[string][]*registry.ModelInfo)
+	cursorModelsCacheMu.Unlock()
+	t.Cleanup(func() {
+		cursorModelsCacheMu.Lock()
+		cursorModelsCache = previous
+		cursorModelsCacheMu.Unlock()
+	})
+}
+
+func cursorCacheTestModel(id string) *registry.ModelInfo {
+	return &registry.ModelInfo{
+		ID:                         id,
+		Object:                     "model",
+		Created:                    123,
+		OwnedBy:                    "cursor",
+		Type:                       cursorAuthType,
+		DisplayName:                "Live " + id,
+		Name:                       "name-" + id,
+		Version:                    "v1",
+		Description:                "live Cursor model",
+		InputTokenLimit:            100,
+		OutputTokenLimit:           50,
+		SupportedGenerationMethods: []string{"generateContent"},
+		ContextLength:              200,
+		MaxCompletionTokens:        100,
+		SupportedParameters:        []string{"temperature"},
+		SupportedEndpoints:         []string{"/v1/chat/completions"},
+		SupportedInputModalities:   []string{"TEXT", "IMAGE"},
+		SupportedOutputModalities:  []string{"TEXT"},
+		SupportsWebSearch:          true,
+		Thinking:                   &registry.ThinkingSupport{Min: 1, Max: 2, ZeroAllowed: true, DynamicAllowed: true, Levels: []string{"low", "high"}},
+		Config:                     &registry.ModelConfig{OverrideHeader: map[string]string{"x-cursor-test": id}},
+		UserDefined:                true,
+	}
+}
+
+func TestFetchCursorModelsColdStartUsesFallback(t *testing.T) {
+	withIsolatedCursorModelsCache(t)
+
+	got := FetchCursorModels(context.Background(), &cliproxyauth.Auth{ID: "cold-start"}, nil)
+	want := GetCursorFallbackModels()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("cold-start models = %+v, want hardcoded fallback %+v", got, want)
+	}
+}
+
+func TestFetchCursorModelsNilAuthUsesFallback(t *testing.T) {
+	withIsolatedCursorModelsCache(t)
+
+	got := FetchCursorModels(context.Background(), nil, nil)
+	if !reflect.DeepEqual(got, GetCursorFallbackModels()) {
+		t.Fatalf("nil auth models = %+v, want hardcoded fallback", got)
+	}
+}
+
+func TestFetchCursorModelsSuccessfulFetchReplacesLastGoodSnapshot(t *testing.T) {
+	withIsolatedCursorModelsCache(t)
+
+	const authID = "auth-1"
+	cacheCursorModels(authID, []*registry.ModelInfo{cursorCacheTestModel("old-live-model")})
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("Authorization") != "Bearer access-token" {
+			t.Errorf("Authorization = %q, want bearer access token", request.Header.Get("Authorization"))
+		}
+		if _, err := response.Write(cursorModelsResponse("new-live-model", "New Live Model")); err != nil {
+			t.Errorf("write models response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	got := fetchCursorModels(context.Background(), authID, "access-token", server.Client(), server.URL)
+	if len(got) != 1 || got[0] == nil || got[0].ID != "new-live-model" {
+		t.Fatalf("successful fetch models = %+v, want new live model", got)
+	}
+
+	got[0].DisplayName = "mutated caller model"
+	cached := cursorModelsOrFallback(authID)
+	if len(cached) != 1 || cached[0] == nil || cached[0].ID != "new-live-model" || cached[0].DisplayName != "New Live Model" {
+		t.Fatalf("successful fetch did not replace an isolated last-good snapshot: %+v", cached)
+	}
+}
+
+func TestFetchCursorModelsRepeatedFailuresReturnLastGoodSnapshot(t *testing.T) {
+	withIsolatedCursorModelsCache(t)
+
+	const authID = "auth-with-last-good"
+	var failures atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if failures.Load() {
+			response.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		if _, err := response.Write(cursorModelsResponse("live-model", "Live Model")); err != nil {
+			t.Errorf("write models response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	first := fetchCursorModels(context.Background(), authID, "access-token", server.Client(), server.URL)
+	if len(first) != 1 || first[0] == nil || first[0].ID != "live-model" {
+		t.Fatalf("successful fetch models = %+v, want live model", first)
+	}
+
+	failures.Store(true)
+	for attempt := 0; attempt < 4; attempt++ {
+		got := fetchCursorModels(context.Background(), authID, "access-token", server.Client(), server.URL)
+		if len(got) != 1 || got[0] == nil || got[0].ID != "live-model" {
+			t.Fatalf("failure %d returned %+v, want the last-good live model", attempt+1, got)
+		}
+		got[0].DisplayName = "mutated failure result"
+	}
+
+	cached := cursorModelsOrFallback(authID)
+	if len(cached) != 1 || cached[0] == nil || cached[0].ID != "live-model" || cached[0].DisplayName != "Live Model" {
+		t.Fatalf("repeated failures changed the last-good snapshot: %+v", cached)
+	}
+}
+
+func TestCursorModelsCacheReturnsMutationIsolatedCopies(t *testing.T) {
+	withIsolatedCursorModelsCache(t)
+
+	cacheCursorModels("auth-1", []*registry.ModelInfo{cursorCacheTestModel("live-model")})
+	first := cursorModelsOrFallback("auth-1")
+	mutateCursorCacheTestModel(first[0])
+
+	got := cursorModelsOrFallback("auth-1")
+	want := cursorCacheTestModel("live-model")
+	if !reflect.DeepEqual(got, []*registry.ModelInfo{want}) {
+		t.Fatalf("cached snapshot was mutated through a returned copy: got %+v, want %+v", got, []*registry.ModelInfo{want})
+	}
+}
+
+func TestCacheCursorModelsStoresWriterDeepSnapshot(t *testing.T) {
+	withIsolatedCursorModelsCache(t)
+
+	source := cursorCacheTestModel("live-model")
+	cacheCursorModels("auth-1", []*registry.ModelInfo{source})
+	mutateCursorCacheTestModel(source)
+
+	got := cursorModelsOrFallback("auth-1")
+	want := cursorCacheTestModel("live-model")
+	if !reflect.DeepEqual(got, []*registry.ModelInfo{want}) {
+		t.Fatalf("cached snapshot was mutated through the source: got %+v, want %+v", got, []*registry.ModelInfo{want})
+	}
+}
+
+func TestCursorModelsCacheConcurrentAuthIsolation(t *testing.T) {
+	withIsolatedCursorModelsCache(t)
+
+	const authCount = 8
+	const updatesPerAuth = 64
+	for authIndex := 0; authIndex < authCount; authIndex++ {
+		authID := fmt.Sprintf("auth-%d", authIndex)
+		cacheCursorModels(authID, []*registry.ModelInfo{cursorCacheTestModel(authID + "-seed")})
+	}
+
+	var wg sync.WaitGroup
+	var once sync.Once
+	var failure string
+	recordFailure := func(format string, args ...any) {
+		once.Do(func() {
+			failure = fmt.Sprintf(format, args...)
+		})
+	}
+
+	for authIndex := 0; authIndex < authCount; authIndex++ {
+		authID := fmt.Sprintf("auth-%d", authIndex)
+
+		wg.Add(1)
+		go func(authID string) {
+			defer wg.Done()
+			for update := 0; update < updatesPerAuth; update++ {
+				cacheCursorModels(authID, []*registry.ModelInfo{cursorCacheTestModel(fmt.Sprintf("%s-live-%d", authID, update))})
+			}
+		}(authID)
+
+		wg.Add(1)
+		go func(authID string) {
+			defer wg.Done()
+			for read := 0; read < updatesPerAuth; read++ {
+				models := cursorModelsOrFallback(authID)
+				if len(models) != 1 || models[0] == nil || !strings.HasPrefix(models[0].ID, authID+"-") {
+					recordFailure("auth %s read %+v", authID, models)
+					return
+				}
+				mutateCursorCacheTestModel(models[0])
+			}
+		}(authID)
+	}
+
+	wg.Wait()
+	if failure != "" {
+		t.Fatal(failure)
+	}
+
+	for authIndex := 0; authIndex < authCount; authIndex++ {
+		authID := fmt.Sprintf("auth-%d", authIndex)
+		wantID := fmt.Sprintf("%s-live-%d", authID, updatesPerAuth-1)
+		got := cursorModelsOrFallback(authID)
+		if len(got) != 1 || got[0] == nil || got[0].ID != wantID {
+			t.Fatalf("auth %s final snapshot = %+v, want %q", authID, got, wantID)
+		}
+	}
+}
+
+func mutateCursorCacheTestModel(model *registry.ModelInfo) {
+	model.ID = "mutated"
+	model.DisplayName = "mutated"
+	model.SupportedGenerationMethods[0] = "mutated"
+	model.SupportedParameters[0] = "mutated"
+	model.SupportedEndpoints[0] = "mutated"
+	model.SupportedInputModalities[0] = "mutated"
+	model.SupportedOutputModalities[0] = "mutated"
+	model.Thinking.Levels[0] = "mutated"
+	model.Config.OverrideHeader["x-cursor-test"] = "mutated"
+}
+
+func cursorModelsResponse(modelID, displayName string) []byte {
+	entry := make([]byte, 0, len(modelID)+len(displayName)+4)
+	entry = append(entry, 0x0a, byte(len(modelID)))
+	entry = append(entry, modelID...)
+	entry = append(entry, 0x22, byte(len(displayName)))
+	entry = append(entry, displayName...)
+
+	response := make([]byte, 0, len(entry)+2)
+	response = append(response, 0x0a, byte(len(entry)))
+	response = append(response, entry...)
+	return response
+}


### PR DESCRIPTION
Replaces the model-cache slice of contributor PR #124 with safe per-auth last-good snapshots. A transient discovery failure returns an isolated deep copy of the last successful catalog; cold start retains the existing fallback without overwriting live data.

Contributor provenance: retains the intent from tan-yong-sheng commits 69d09fe597f3996e78e3189b3d2a4d5c29fc9b27 and c996e20c7a7f2c6aeee539bc70aa646d2000e82c, with maintainer repairs for full deep copy and failure behavior.

Validation: focused race tests covering cold start, success, repeated failures, reader/writer nested mutation isolation, concurrent auths, full go test, server build, and independent re-review.

Refs #124