### PR TITLE
fix(cursor): use resolved OAuth model for runs

### DIFF
--- a/internal/runtime/executor/cursor_executor.go
+++ b/internal/runtime/executor/cursor_executor.go
@@ -296,7 +296,7 @@ func (e *CursorExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	parsed := parseOpenAIRequest(payload)
 	ccSessId := extractClaudeCodeSessionId(req.Payload)
 	conversationId := deriveConversationId(apiKeyFromContext(ctx), ccSessId, parsed.SystemPrompt)
-	params := buildRunRequestParams(parsed, conversationId)
+	params := buildRunRequestParams(parsed, conversationId, req.Model)
 
 	requestBytes := cursorproto.EncodeRunRequest(params)
 	framedRequest := cursorproto.FrameConnectMessage(requestBytes, 0)
@@ -455,7 +455,7 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	saved, hasCheckpoint := e.checkpoints[checkpointKey]
 	e.mu.Unlock()
 
-	params := buildRunRequestParams(parsed, conversationId)
+	params := buildRunRequestParams(parsed, conversationId, req.Model)
 
 	if hasCheckpoint && saved.data != nil && saved.authID == authID {
 		// Same auth — use checkpoint normally
@@ -479,7 +479,7 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		e.mu.Unlock()
 		if len(parsed.ToolResults) > 0 || len(parsed.Turns) > 0 {
 			flattenConversationIntoUserText(parsed)
-			params = buildRunRequestParams(parsed, conversationId)
+			params = buildRunRequestParams(parsed, conversationId, req.Model)
 		}
 	} else if len(parsed.ToolResults) > 0 || len(parsed.Turns) > 0 {
 		// Fallback: no checkpoint available (cold resume / proxy restart).
@@ -487,7 +487,7 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		// Cursor's turns encoding is not reliably read by the model, but userText always works.
 		log.Debugf("cursor: no checkpoint, flattening %d turns + %d tool results into userText", len(parsed.Turns), len(parsed.ToolResults))
 		flattenConversationIntoUserText(parsed)
-		params = buildRunRequestParams(parsed, conversationId)
+		params = buildRunRequestParams(parsed, conversationId, req.Model)
 	}
 	requestBytes := cursorproto.EncodeRunRequest(params)
 	framedRequest := cursorproto.FrameConnectMessage(requestBytes, 0)
@@ -1289,9 +1289,16 @@ func parseDataURL(url string) *cursorproto.ImageData {
 	}
 }
 
-func buildRunRequestParams(parsed *parsedOpenAIRequest, conversationId string) *cursorproto.RunRequestParams {
+func buildRunRequestParams(parsed *parsedOpenAIRequest, conversationId, upstreamModel string) *cursorproto.RunRequestParams {
+	// upstreamModel is the provider-resolved model name. Keep parsed.Model
+	// unchanged so OpenAI-compatible responses continue to echo the client model.
+	modelID := strings.TrimSpace(upstreamModel)
+	if modelID == "" {
+		modelID = parsed.Model
+	}
+
 	params := &cursorproto.RunRequestParams{
-		ModelId:        parsed.Model,
+		ModelId:        modelID,
 		SystemPrompt:   parsed.SystemPrompt,
 		UserText:       parsed.UserText,
 		MessageId:      uuid.New().String(),

--- a/internal/runtime/executor/cursor_executor_buildrequest_test.go
+++ b/internal/runtime/executor/cursor_executor_buildrequest_test.go
@@ -1,0 +1,52 @@
+package executor
+
+import "testing"
+
+func TestBuildRunRequestParams_ModelOverride(t *testing.T) {
+	tests := []struct {
+		name        string
+		parsedModel string
+		override    string
+		wantModelID string
+	}{
+		{
+			name:        "alias override preserves client model",
+			parsedModel: "cursor/composer-2.5",
+			override:    "composer-2.5",
+			wantModelID: "composer-2.5",
+		},
+		{
+			name:        "empty override falls back to parsed model",
+			parsedModel: "composer-2.5",
+			wantModelID: "composer-2.5",
+		},
+		{
+			name:        "whitespace override falls back to parsed model",
+			parsedModel: "composer-2.5",
+			override:    " \t ",
+			wantModelID: "composer-2.5",
+		},
+		{
+			name:        "override supplies missing parsed model",
+			override:    "composer-2.5",
+			wantModelID: "composer-2.5",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed := &parsedOpenAIRequest{Model: tc.parsedModel}
+			params := buildRunRequestParams(parsed, "conv-123", tc.override)
+
+			if params.ModelId != tc.wantModelID {
+				t.Errorf("ModelId = %q, want %q", params.ModelId, tc.wantModelID)
+			}
+			if params.ConversationId != "conv-123" {
+				t.Errorf("ConversationId = %q, want %q", params.ConversationId, "conv-123")
+			}
+			if parsed.Model != tc.parsedModel {
+				t.Errorf("parsed.Model = %q, want %q", parsed.Model, tc.parsedModel)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Replaces the oauth-model-alias portion of contributor PR #124 (original commit 59b83e02) with a narrow, tested fix.

The conductor already resolves a Cursor OAuth alias into req.Model. Cursor Run construction now sends that resolved upstream model on every initial, auth-migration, and cold-resume path, while preserving the client alias in parsed.Model for OpenAI-compatible responses.

Coverage verifies alias override, empty and whitespace fallback, missing client model, and non-mutation. Full go test, build, formatting, diff check, and review passed locally.

Tool-stream changes from #124 are intentionally excluded: there is no safe reproducer and the contributor identified unresolved index/resume/DONE/timeout defects.