### PR TITLE
fix(cursor): normalize and smooth agent streams

### DIFF
--- a/internal/runtime/executor/cursor_executor.go
+++ b/internal/runtime/executor/cursor_executor.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/google/uuid"
 	cursorauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/cursor"
@@ -317,15 +318,23 @@ func (e *CursorExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	defer sessionCancel()
 	go cursorH2Heartbeat(sessionCtx, stream)
 
-	// Collect full text from streaming response
+	// Collect full text from streaming response, keeping thinking separate so
+	// it can be reported as `reasoning_content` instead of polluting `content`.
 	var fullText strings.Builder
+	var thinkingText strings.Builder
+	usage := &cursorTokenUsage{}
+	usage.setInputEstimate(len(payload))
 	if streamErr := processH2SessionFrames(sessionCtx, stream, params.BlobStore, nil,
 		func(text string, isThinking bool) {
-			fullText.WriteString(text)
+			if isThinking {
+				thinkingText.WriteString(text)
+			} else {
+				fullText.WriteString(text)
+			}
 		},
 		nil,
 		nil,
-		nil, // tokenUsage - non-streaming
+		usage,
 		nil, // onCheckpoint - non-streaming doesn't persist
 	); streamErr != nil && fullText.Len() == 0 {
 		return resp, classifyCursorError(fmt.Errorf("cursor: stream error: %w", streamErr))
@@ -333,8 +342,13 @@ func (e *CursorExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 
 	id := "chatcmpl-" + uuid.New().String()[:28]
 	created := time.Now().Unix()
-	openaiResp := fmt.Sprintf(`{"id":"%s","object":"chat.completion","created":%d,"model":"%s","choices":[{"index":0,"message":{"role":"assistant","content":%s},"finish_reason":"stop"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`,
-		id, created, parsed.Model, jsonString(fullText.String()))
+	inputTok, outputTok := usage.get()
+	reasoningField := ""
+	if thinkingText.Len() > 0 {
+		reasoningField = fmt.Sprintf(`,"reasoning_content":%s`, jsonString(thinkingText.String()))
+	}
+	openaiResp := fmt.Sprintf(`{"id":"%s","object":"chat.completion","created":%d,"model":"%s","choices":[{"index":0,"message":{"role":"assistant","content":%s%s},"finish_reason":"stop"}],"usage":{"prompt_tokens":%d,"completion_tokens":%d,"total_tokens":%d}}`,
+		id, created, parsed.Model, jsonString(fullText.String()), reasoningField, inputTok, outputTok, inputTok+outputTok)
 
 	// Translate response back to source format if needed
 	result := []byte(openaiResp)
@@ -560,9 +574,10 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			for _, d := range done {
 				emitToOut(cliproxyexecutor.StreamChunk{Payload: bytes.Clone(d)})
 			}
-		} else {
-			emitToOut(cliproxyexecutor.StreamChunk{Payload: []byte("[DONE]")})
 		}
+		// No explicit [DONE] in the non-translated (OpenAI) case: the HTTP
+		// handler already writes `data: [DONE]` when the chunk channel closes,
+		// so emitting one here produced a duplicated [DONE] marker downstream.
 	}
 
 	// Pre-response error detection for transparent failover:
@@ -590,27 +605,27 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 
 		streamErr := processH2SessionFrames(sessionCtx, stream, params.BlobStore, params.McpTools,
 			func(text string, isThinking bool) {
+				// Emit thinking as the standard OpenAI `reasoning_content` delta
+				// field instead of inline <think>...</think> tags. Inline tags
+				// pollute `content` for OpenAI clients and end up rendered as
+				// literal text in Anthropic/Claude clients; `reasoning_content`
+				// is understood by the translators (mapped to thinking blocks
+				// for Claude) and by downstream proxies.
 				if isThinking {
 					if !thinkingActive {
 						thinkingActive = true
-						sendChunkSwitchable(`{"role":"assistant","content":"<think>"}`, "")
+						sendChunkSwitchable(`{"role":"assistant","content":""}`, "")
 					}
-					sendChunkSwitchable(fmt.Sprintf(`{"content":%s}`, jsonString(text)), "")
+					sendChunkSwitchable(fmt.Sprintf(`{"reasoning_content":%s}`, jsonString(text)), "")
 				} else {
-					if thinkingActive {
-						thinkingActive = false
-						sendChunkSwitchable(`{"content":"</think>"}`, "")
-					}
+					thinkingActive = false
 					sendChunkSwitchable(fmt.Sprintf(`{"content":%s}`, jsonString(text)), "")
 				}
 			},
 			func(exec pendingMcpExec) {
-				if thinkingActive {
-					thinkingActive = false
-					sendChunkSwitchable(`{"content":"</think>"}`, "")
-				}
-				toolCallJSON := fmt.Sprintf(`{"tool_calls":[{"index":%d,"id":"%s","type":"function","function":{"name":"%s","arguments":%s}}]}`,
-					toolCallIndex, exec.ToolCallId, exec.ToolName, jsonString(exec.Args))
+				thinkingActive = false
+				toolCallJSON := fmt.Sprintf(`{"tool_calls":[{"index":%d,"id":%s,"type":"function","function":{"name":%s,"arguments":%s}}]}`,
+					toolCallIndex, jsonString(exec.ToolCallId), jsonString(exec.ToolName), jsonString(exec.Args))
 				toolCallIndex++
 				sendChunkSwitchable(toolCallJSON, "")
 				sendChunkSwitchable(`{}`, `"tool_calls"`)
@@ -696,9 +711,6 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			}
 		}
 
-		if thinkingActive {
-			sendChunkSwitchable(`{"content":"</think>"}`, "")
-		}
 		// Include token usage in the final stop chunk
 		inputTok, outputTok := usage.get()
 		stopDelta := fmt.Sprintf(`{},"usage":{"prompt_tokens":%d,"completion_tokens":%d,"total_tokens":%d}`,
@@ -958,7 +970,7 @@ func processH2SessionFrames(
 				case cursorproto.ServerMsgExecMcpArgs:
 					if onMcpExec != nil {
 						decodedArgs := decodeMcpArgsToJSON(msg.McpArgs)
-						toolCallId := msg.McpToolCallId
+						toolCallId := normalizeToolCallID(msg.McpToolCallId)
 						if toolCallId == "" {
 							toolCallId = uuid.New().String()
 						}
@@ -1127,7 +1139,7 @@ func parseOpenAIRequest(payload []byte) *parsedOpenAIRequest {
 			continue
 		case "tool":
 			p.ToolResults = append(p.ToolResults, toolResultInfo{
-				ToolCallId: msg.Get("tool_call_id").String(),
+				ToolCallId: normalizeToolCallID(msg.Get("tool_call_id").String()),
 				Content:    extractTextContent(msg.Get("content")),
 			})
 		case "user":
@@ -1459,6 +1471,15 @@ func sseChunk(id string, created int64, model string, delta string, finishReason
 func jsonString(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
+}
+
+func normalizeToolCallID(id string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) || unicode.IsSpace(r) {
+			return -1
+		}
+		return r
+	}, id)
 }
 
 func decodeMcpArgsToJSON(args map[string][]byte) string {

--- a/internal/runtime/executor/cursor_executor.go
+++ b/internal/runtime/executor/cursor_executor.go
@@ -39,6 +39,8 @@ const (
 	cursorHeartbeatInterval = 5 * time.Second
 	cursorSessionTTL        = 5 * time.Minute
 	cursorCheckpointTTL     = 30 * time.Minute
+	cursorStreamFlushDelay  = 16 * time.Millisecond
+	cursorStreamMaxBatch    = 512
 )
 
 // CursorExecutor handles requests to the Cursor API via Connect+Protobuf protocol.
@@ -603,26 +605,36 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		usage := &cursorTokenUsage{}
 		usage.setInputEstimate(len(payload))
 
-		streamErr := processH2SessionFrames(sessionCtx, stream, params.BlobStore, params.McpTools,
-			func(text string, isThinking bool) {
-				// Emit thinking as the standard OpenAI `reasoning_content` delta
-				// field instead of inline <think>...</think> tags. Inline tags
-				// pollute `content` for OpenAI clients and end up rendered as
-				// literal text in Anthropic/Claude clients; `reasoning_content`
-				// is understood by the translators (mapped to thinking blocks
-				// for Claude) and by downstream proxies.
-				if isThinking {
-					if !thinkingActive {
-						thinkingActive = true
-						sendChunkSwitchable(`{"role":"assistant","content":""}`, "")
-					}
-					sendChunkSwitchable(fmt.Sprintf(`{"reasoning_content":%s}`, jsonString(text)), "")
-				} else {
-					thinkingActive = false
-					sendChunkSwitchable(fmt.Sprintf(`{"content":%s}`, jsonString(text)), "")
+		emitTextDelta := func(text string, isThinking bool) {
+			// Emit thinking as the standard OpenAI `reasoning_content` delta
+			// field instead of inline <think>...</think> tags. Inline tags
+			// pollute `content` for OpenAI clients and end up rendered as
+			// literal text in Anthropic/Claude clients; `reasoning_content`
+			// is understood by the translators (mapped to thinking blocks
+			// for Claude) and by downstream proxies.
+			if isThinking {
+				if !thinkingActive {
+					thinkingActive = true
+					sendChunkSwitchable(`{"role":"assistant","content":""}`, "")
 				}
-			},
+				sendChunkSwitchable(fmt.Sprintf(`{"reasoning_content":%s}`, jsonString(text)), "")
+			} else {
+				thinkingActive = false
+				sendChunkSwitchable(fmt.Sprintf(`{"content":%s}`, jsonString(text)), "")
+			}
+		}
+		streamCoalescer := newCursorStreamCoalescer(
+			sessionCtx,
+			cursorStreamFlushDelay,
+			emitTextDelta,
+		)
+
+		streamErr := processH2SessionFrames(sessionCtx, stream, params.BlobStore, params.McpTools,
+			streamCoalescer.push,
 			func(exec pendingMcpExec) {
+				// Preserve ordering: all assistant text must reach the client
+				// before the tool-call boundary is emitted.
+				streamCoalescer.flush()
 				thinkingActive = false
 				toolCallJSON := fmt.Sprintf(`{"tool_calls":[{"index":%d,"id":%s,"type":"function","function":{"name":%s,"arguments":%s}}]}`,
 					toolCallIndex, jsonString(exec.ToolCallId), jsonString(exec.ToolName), jsonString(exec.Args))
@@ -669,7 +681,7 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				resumeOutCh = resumeOut
 
 				// processH2SessionFrames will now block on toolResultCh (inline wait loop)
-				// while continuing to handle KV messages
+				// while continuing to handle KV messages.
 			},
 			toolResultCh,
 			usage,
@@ -686,6 +698,7 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				log.Debugf("cursor: saved checkpoint (%d bytes) for conv=%s auth=%s", len(cpData), checkpointKey, authID)
 			},
 		)
+		streamCoalescer.close()
 
 		// processH2SessionFrames returned — stream is done.
 		// Check if error happened before any chunks were emitted.
@@ -828,6 +841,152 @@ func cursorH2Heartbeat(ctx context.Context, stream *cursorproto.H2Stream) {
 }
 
 // --- Response processing ---
+
+type cursorStreamDeltaCommand struct {
+	text       string
+	isThinking bool
+	flush      bool
+	close      bool
+	ack        chan struct{}
+}
+
+// cursorStreamCoalescer turns Cursor's bursty protobuf deltas into SSE-sized
+// updates at roughly one display frame. The first delta remains immediate,
+// while later adjacent deltas are grouped for at most cursorStreamFlushDelay.
+type cursorStreamCoalescer struct {
+	commands chan cursorStreamDeltaCommand
+	done     chan struct{}
+}
+
+func newCursorStreamCoalescer(
+	ctx context.Context,
+	flushDelay time.Duration,
+	emit func(text string, isThinking bool),
+) *cursorStreamCoalescer {
+	coalescer := &cursorStreamCoalescer{
+		commands: make(chan cursorStreamDeltaCommand),
+		done:     make(chan struct{}),
+	}
+	go coalescer.run(ctx, flushDelay, emit)
+	return coalescer
+}
+
+func (c *cursorStreamCoalescer) push(text string, isThinking bool) {
+	if text == "" {
+		return
+	}
+	select {
+	case c.commands <- cursorStreamDeltaCommand{text: text, isThinking: isThinking}:
+	case <-c.done:
+	}
+}
+
+func (c *cursorStreamCoalescer) flush() {
+	c.sync(cursorStreamDeltaCommand{flush: true, ack: make(chan struct{})})
+}
+
+func (c *cursorStreamCoalescer) close() {
+	c.sync(cursorStreamDeltaCommand{close: true, ack: make(chan struct{})})
+}
+
+func (c *cursorStreamCoalescer) sync(command cursorStreamDeltaCommand) {
+	select {
+	case c.commands <- command:
+	case <-c.done:
+		return
+	}
+	select {
+	case <-command.ack:
+	case <-c.done:
+	}
+}
+
+func (c *cursorStreamCoalescer) run(
+	ctx context.Context,
+	flushDelay time.Duration,
+	emit func(text string, isThinking bool),
+) {
+	defer close(c.done)
+
+	timer := time.NewTimer(flushDelay)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	defer timer.Stop()
+
+	var pending strings.Builder
+	var pendingThinking bool
+	var timerC <-chan time.Time
+	emittedFirst := false
+
+	stopTimer := func() {
+		if timerC == nil {
+			return
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timerC = nil
+	}
+	flushPending := func() {
+		stopTimer()
+		if pending.Len() == 0 {
+			return
+		}
+		text := pending.String()
+		pending.Reset()
+		emit(text, pendingThinking)
+	}
+	queue := func(text string, isThinking bool) {
+		if !emittedFirst {
+			emittedFirst = true
+			emit(text, isThinking)
+			return
+		}
+		if pending.Len() > 0 && pendingThinking != isThinking {
+			flushPending()
+		}
+		if pending.Len() == 0 {
+			pendingThinking = isThinking
+			timer.Reset(flushDelay)
+			timerC = timer.C
+		}
+		pending.WriteString(text)
+		if pending.Len() >= cursorStreamMaxBatch {
+			flushPending()
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			flushPending()
+			return
+		case <-timerC:
+			timerC = nil
+			if pending.Len() > 0 {
+				text := pending.String()
+				pending.Reset()
+				emit(text, pendingThinking)
+			}
+		case command := <-c.commands:
+			switch {
+			case command.close:
+				flushPending()
+				close(command.ack)
+				return
+			case command.flush:
+				flushPending()
+				close(command.ack)
+			default:
+				queue(command.text, command.isThinking)
+			}
+		}
+	}
+}
 
 // cursorTokenUsage tracks token counts from Cursor's TokenDeltaUpdate messages.
 type cursorTokenUsage struct {

--- a/internal/runtime/executor/cursor_executor.go
+++ b/internal/runtime/executor/cursor_executor.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 
@@ -45,10 +46,12 @@ const (
 
 // CursorExecutor handles requests to the Cursor API via Connect+Protobuf protocol.
 type CursorExecutor struct {
-	cfg         *config.Config
-	mu          sync.Mutex
-	sessions    map[string]*cursorSession
-	checkpoints map[string]*savedCheckpoint // keyed by conversationId
+	cfg           *config.Config
+	mu            sync.Mutex
+	sessions      map[string]*cursorSession
+	checkpoints   map[string]*savedCheckpoint // keyed by conversationId
+	openStream    func(string) (cursorStream, error)
+	processFrames cursorFrameProcessor
 }
 
 // savedCheckpoint stores the server's conversation_checkpoint_update for reuse.
@@ -59,17 +62,38 @@ type savedCheckpoint struct {
 	updatedAt time.Time
 }
 
+type cursorStream interface {
+	ID() string
+	Write([]byte) error
+	Data() <-chan []byte
+	Done() <-chan struct{}
+	Err() error
+	Close()
+}
+
+type cursorFrameProcessor func(
+	ctx context.Context,
+	stream cursorStream,
+	blobStore map[string][]byte,
+	mcpTools []cursorproto.McpToolDef,
+	onText func(text string, isThinking bool),
+	onMcpExec func(exec pendingMcpExec),
+	toolResultCh <-chan []toolResultInfo,
+	tokenUsage *cursorTokenUsage,
+	onCheckpoint func(data []byte),
+) error
+
 type cursorSession struct {
-	stream       *cursorproto.H2Stream
+	stream       cursorStream
 	blobStore    map[string][]byte
 	mcpTools     []cursorproto.McpToolDef
 	pending      []pendingMcpExec
 	cancel       context.CancelFunc // cancels the session-scoped heartbeat (NOT tied to HTTP request)
 	createdAt    time.Time
-	authID       string                                     // auth file ID that created this session (for multi-account isolation)
-	toolResultCh chan []toolResultInfo                      // receives tool results from the next HTTP request
-	resumeOutCh  chan cliproxyexecutor.StreamChunk          // output channel for resumed response
-	switchOutput func(ch chan cliproxyexecutor.StreamChunk) // callback to switch output channel
+	authID       string                                                                // auth file ID that created this session (for multi-account isolation)
+	toolResultCh chan []toolResultInfo                                                 // receives tool results from the next HTTP request
+	resumeOutCh  chan cliproxyexecutor.StreamChunk                                     // output channel for resumed response
+	switchOutput func(ch chan cliproxyexecutor.StreamChunk, outputCtx context.Context) // switch output channel/request context
 }
 
 type pendingMcpExec struct {
@@ -86,6 +110,10 @@ func NewCursorExecutor(cfg *config.Config) *CursorExecutor {
 		cfg:         cfg,
 		sessions:    make(map[string]*cursorSession),
 		checkpoints: make(map[string]*savedCheckpoint),
+		openStream: func(accessToken string) (cursorStream, error) {
+			return openCursorH2Stream(accessToken)
+		},
+		processFrames: processH2SessionFrames,
 	}
 	go e.cleanupLoop()
 	return e
@@ -304,7 +332,7 @@ func (e *CursorExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	requestBytes := cursorproto.EncodeRunRequest(params)
 	framedRequest := cursorproto.FrameConnectMessage(requestBytes, 0)
 
-	stream, err := openCursorH2Stream(accessToken)
+	stream, err := e.openStream(accessToken)
 	if err != nil {
 		return resp, err
 	}
@@ -326,7 +354,7 @@ func (e *CursorExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	var thinkingText strings.Builder
 	usage := &cursorTokenUsage{}
 	usage.setInputEstimate(len(payload))
-	if streamErr := processH2SessionFrames(sessionCtx, stream, params.BlobStore, nil,
+	if streamErr := e.processFrames(sessionCtx, stream, params.BlobStore, nil,
 		func(text string, isThinking bool) {
 			if isThinking {
 				thinkingText.WriteString(text)
@@ -338,7 +366,7 @@ func (e *CursorExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		nil,
 		usage,
 		nil, // onCheckpoint - non-streaming doesn't persist
-	); streamErr != nil && fullText.Len() == 0 {
+	); streamErr != nil {
 		return resp, classifyCursorError(fmt.Errorf("cursor: stream error: %w", streamErr))
 	}
 
@@ -508,7 +536,7 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	requestBytes := cursorproto.EncodeRunRequest(params)
 	framedRequest := cursorproto.FrameConnectMessage(requestBytes, 0)
 
-	stream, err := openCursorH2Stream(accessToken)
+	stream, err := e.openStream(accessToken)
 	if err != nil {
 		return nil, err
 	}
@@ -540,13 +568,23 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	// it switches to `resumeOutCh` (created by resumeWithToolResults).
 	var outMu sync.Mutex
 	currentOut := chunks
+	currentOutputCtx := ctx
 
-	emitToOut := func(chunk cliproxyexecutor.StreamChunk) {
+	emitToOut := func(chunk cliproxyexecutor.StreamChunk) bool {
 		outMu.Lock()
 		out := currentOut
+		outputCtx := currentOutputCtx
 		outMu.Unlock()
-		if out != nil {
-			out <- chunk
+		if out == nil {
+			return false
+		}
+		select {
+		case out <- chunk:
+			return true
+		case <-outputCtx.Done():
+			return false
+		case <-sessionCtx.Done():
+			return false
 		}
 	}
 
@@ -587,14 +625,19 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	// ExecuteStream returns an error so the conductor retries with a different auth.
 	streamErrCh := make(chan error, 1)
 	firstChunkSent := make(chan struct{}, 1) // buffered: goroutine won't block signaling
+	var outputStarted atomic.Bool
 
 	origEmitToOut := emitToOut
-	emitToOut = func(chunk cliproxyexecutor.StreamChunk) {
+	emitToOut = func(chunk cliproxyexecutor.StreamChunk) bool {
+		if !origEmitToOut(chunk) {
+			return false
+		}
+		outputStarted.Store(true)
 		select {
 		case firstChunkSent <- struct{}{}:
 		default:
 		}
-		origEmitToOut(chunk)
+		return true
 	}
 
 	go func() {
@@ -629,7 +672,7 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			emitTextDelta,
 		)
 
-		streamErr := processH2SessionFrames(sessionCtx, stream, params.BlobStore, params.McpTools,
+		streamErr := e.processFrames(sessionCtx, stream, params.BlobStore, params.McpTools,
 			streamCoalescer.push,
 			func(exec pendingMcpExec) {
 				// Preserve ordering: all assistant text must reach the client
@@ -665,13 +708,11 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 					authID:       authID,
 					toolResultCh: toolResultCh, // reuse same channel across rounds
 					resumeOutCh:  resumeOut,
-					switchOutput: func(ch chan cliproxyexecutor.StreamChunk) {
+					switchOutput: func(ch chan cliproxyexecutor.StreamChunk, outputCtx context.Context) {
 						outMu.Lock()
 						currentOut = ch
-						// Reset translator state so the new HTTP response gets
-						// a fresh message_start, content_block_start, etc.
+						currentOutputCtx = outputCtx
 						streamParam = nil
-						// New response needs its own message ID
 						chatId = "chatcmpl-" + uuid.New().String()[:28]
 						created = time.Now().Unix()
 						outMu.Unlock()
@@ -703,13 +744,20 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		// processH2SessionFrames returned — stream is done.
 		// Check if error happened before any chunks were emitted.
 		if streamErr != nil {
-			select {
-			case <-firstChunkSent:
-				// Chunks were already sent to client — can't transparently retry.
-				// Next request will failover via conductor's cooldown mechanism.
+			if outputStarted.Load() {
+				// Partial output must never be presented as a successful stop.
 				log.Warnf("cursor: stream error after data sent (auth=%s conv=%s): %v", authID, conversationId, streamErr)
-			default:
-				// No data sent yet — propagate error for transparent conductor retry.
+				emitToOut(cliproxyexecutor.StreamChunk{Err: classifyCursorError(fmt.Errorf("cursor: stream interrupted after partial response: %w", streamErr))})
+				outMu.Lock()
+				if currentOut != nil {
+					close(currentOut)
+					currentOut = nil
+				}
+				outMu.Unlock()
+				sessionCancel()
+				stream.Close()
+				return
+			} else {
 				log.Warnf("cursor: stream error before data sent (auth=%s conv=%s): %v — signaling retry", authID, conversationId, streamErr)
 				streamErrCh <- streamErr
 				outMu.Lock()
@@ -796,11 +844,15 @@ func (e *CursorExecutor) resumeWithToolResults(
 	// processH2SessionFrames unblocks and starts emitting text, it writes
 	// to the resumeOutCh which the new HTTP handler is reading from.
 	if session.switchOutput != nil {
-		session.switchOutput(session.resumeOutCh)
+		session.switchOutput(session.resumeOutCh, ctx)
 	}
 
-	// Inject tool results — this unblocks the waiting processH2SessionFrames
-	session.toolResultCh <- parsed.ToolResults
+	// Inject tool results — this unblocks the intentionally parked session.
+	select {
+	case session.toolResultCh <- parsed.ToolResults:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 
 	// Return the resumeOutCh for the new HTTP handler to read from
 	return &cliproxyexecutor.StreamResult{Chunks: session.resumeOutCh}, nil
@@ -823,7 +875,7 @@ func openCursorH2Stream(accessToken string) (*cursorproto.H2Stream, error) {
 	return cursorproto.DialH2Stream("api2.cursor.sh", headers)
 }
 
-func cursorH2Heartbeat(ctx context.Context, stream *cursorproto.H2Stream) {
+func cursorH2Heartbeat(ctx context.Context, stream cursorStream) {
 	ticker := time.NewTicker(cursorHeartbeatInterval)
 	defer ticker.Stop()
 	for {
@@ -1019,7 +1071,7 @@ func (u *cursorTokenUsage) get() (input, output int64) {
 
 func processH2SessionFrames(
 	ctx context.Context,
-	stream *cursorproto.H2Stream,
+	stream cursorStream,
 	blobStore map[string][]byte,
 	mcpTools []cursorproto.McpToolDef,
 	onText func(text string, isThinking bool),
@@ -1633,12 +1685,15 @@ func jsonString(s string) string {
 }
 
 func normalizeToolCallID(id string) string {
-	return strings.Map(func(r rune) rune {
+	var normalized strings.Builder
+	for _, r := range id {
 		if unicode.IsControl(r) || unicode.IsSpace(r) {
-			return -1
+			fmt.Fprintf(&normalized, "_u%04x_", r)
+			continue
 		}
-		return r
-	}, id)
+		normalized.WriteRune(r)
+	}
+	return normalized.String()
 }
 
 func decodeMcpArgsToJSON(args map[string][]byte) string {

--- a/internal/runtime/executor/cursor_executor_test.go
+++ b/internal/runtime/executor/cursor_executor_test.go
@@ -1,0 +1,12 @@
+package executor
+
+import "testing"
+
+func TestNormalizeToolCallID(t *testing.T) {
+	input := "call-cce860e6-ab07-414d-812c-785db35b17ca-4\nfc_d2335004-a95f-93b4-977b-e9eee6316be7_0"
+	want := "call-cce860e6-ab07-414d-812c-785db35b17ca-4fc_d2335004-a95f-93b4-977b-e9eee6316be7_0"
+
+	if got := normalizeToolCallID(input); got != want {
+		t.Fatalf("normalizeToolCallID() = %q, want %q", got, want)
+	}
+}

--- a/internal/runtime/executor/cursor_executor_test.go
+++ b/internal/runtime/executor/cursor_executor_test.go
@@ -2,16 +2,143 @@ package executor
 
 import (
 	"context"
+	"errors"
+	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	cursorproto "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/cursor/proto"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
 )
+
+type fakeCursorStream struct {
+	data chan []byte
+	done chan struct{}
+	mu   sync.Mutex
+	err  error
+}
+
+func newFakeCursorStream() *fakeCursorStream {
+	return &fakeCursorStream{data: make(chan []byte), done: make(chan struct{})}
+}
+func (s *fakeCursorStream) ID() string            { return "test-stream" }
+func (s *fakeCursorStream) Write([]byte) error    { return nil }
+func (s *fakeCursorStream) Data() <-chan []byte   { return s.data }
+func (s *fakeCursorStream) Done() <-chan struct{} { return s.done }
+func (s *fakeCursorStream) Err() error            { s.mu.Lock(); defer s.mu.Unlock(); return s.err }
+func (s *fakeCursorStream) Close()                {}
+
+func newCursorExecutorHarness(process cursorFrameProcessor) *CursorExecutor {
+	e := NewCursorExecutor(nil)
+	e.openStream = func(string) (cursorStream, error) { return newFakeCursorStream(), nil }
+	e.processFrames = process
+	return e
+}
+
+func cursorTestAuth() *cliproxyauth.Auth {
+	return &cliproxyauth.Auth{ID: "cursor-test", Metadata: map[string]any{"access_token": "test-token"}}
+}
+
+func cursorTestRequest(stream bool) cliproxyexecutor.Request {
+	payload := `{"model":"cursor-test-model","messages":[{"role":"user","content":"hello"}]}`
+	if stream {
+		payload = `{"model":"cursor-test-model","stream":true,"messages":[{"role":"user","content":"hello"}]}`
+	}
+	return cliproxyexecutor.Request{Model: "cursor-test-model", Payload: []byte(payload)}
+}
+
+func TestCursorExecuteReturnsReasoningAndUsage(t *testing.T) {
+	e := newCursorExecutorHarness(func(_ context.Context, _ cursorStream, _ map[string][]byte, _ anyMCPTools, onText func(string, bool), _ func(pendingMcpExec), _ <-chan []toolResultInfo, usage *cursorTokenUsage, _ func([]byte)) error {
+		onText("plan", true)
+		onText("answer", false)
+		usage.addOutput(7)
+		return nil
+	})
+
+	resp, err := e.Execute(context.Background(), cursorTestAuth(), cursorTestRequest(false), cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := gjson.GetBytes(resp.Payload, "choices.0.message.reasoning_content").String(); got != "plan" {
+		t.Fatalf("reasoning_content = %q", got)
+	}
+	if got := gjson.GetBytes(resp.Payload, "choices.0.message.content").String(); got != "answer" {
+		t.Fatalf("content = %q", got)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.completion_tokens").Int(); got != 7 {
+		t.Fatalf("completion_tokens = %d", got)
+	}
+}
+
+func TestCursorExecuteReasoningOnlyErrorIsFailure(t *testing.T) {
+	boom := errors.New("upstream reset")
+	e := newCursorExecutorHarness(func(_ context.Context, _ cursorStream, _ map[string][]byte, _ anyMCPTools, onText func(string, bool), _ func(pendingMcpExec), _ <-chan []toolResultInfo, _ *cursorTokenUsage, _ func([]byte)) error {
+		onText("partial thought", true)
+		return boom
+	})
+	if _, err := e.Execute(context.Background(), cursorTestAuth(), cursorTestRequest(false), cliproxyexecutor.Options{}); !errors.Is(err, boom) {
+		t.Fatalf("Execute() error = %v, want wrapped %v", err, boom)
+	}
+}
+
+func TestCursorExecuteStreamPostChunkErrorIsTerminalError(t *testing.T) {
+	boom := errors.New("upstream reset")
+	e := newCursorExecutorHarness(func(_ context.Context, _ cursorStream, _ map[string][]byte, _ anyMCPTools, onText func(string, bool), _ func(pendingMcpExec), _ <-chan []toolResultInfo, _ *cursorTokenUsage, _ func([]byte)) error {
+		onText("partial", false)
+		return boom
+	})
+	result, err := e.ExecuteStream(context.Background(), cursorTestAuth(), cursorTestRequest(true), cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	var sawPayload, sawError, sawStop bool
+	for chunk := range result.Chunks {
+		if len(chunk.Payload) > 0 {
+			sawPayload = true
+			if gjson.GetBytes(chunk.Payload, "choices.0.finish_reason").String() == "stop" {
+				sawStop = true
+			}
+		}
+		if chunk.Err != nil {
+			sawError = true
+		}
+	}
+	if !sawPayload || !sawError || sawStop {
+		t.Fatalf("payload=%v error=%v stop=%v", sawPayload, sawError, sawStop)
+	}
+}
 
 func TestNormalizeToolCallID(t *testing.T) {
 	input := "call-cce860e6-ab07-414d-812c-785db35b17ca-4\nfc_d2335004-a95f-93b4-977b-e9eee6316be7_0"
-	want := "call-cce860e6-ab07-414d-812c-785db35b17ca-4fc_d2335004-a95f-93b4-977b-e9eee6316be7_0"
-
+	want := "call-cce860e6-ab07-414d-812c-785db35b17ca-4_u000a_fc_d2335004-a95f-93b4-977b-e9eee6316be7_0"
 	if got := normalizeToolCallID(input); got != want {
 		t.Fatalf("normalizeToolCallID() = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeToolCallIDCollisionsRemainDistinct(t *testing.T) {
+	ids := []string{"call-a b", "call-ab", "call-a\nb", "call-a\tb"}
+	seen := map[string]string{}
+	for _, id := range ids {
+		normalized := normalizeToolCallID(id)
+		if prior, ok := seen[normalized]; ok && prior != id {
+			t.Fatalf("IDs %q and %q collide as %q", prior, id, normalized)
+		}
+		seen[normalized] = id
+	}
+}
+
+func TestParseOpenAIToolCallIDRoundTrip(t *testing.T) {
+	id := "call-a b\n"
+	parsed := parseOpenAIRequest([]byte(`{"model":"m","messages":[{"role":"tool","tool_call_id":"call-a b\n","content":"ok"}]}`))
+	if len(parsed.ToolResults) != 1 {
+		t.Fatalf("tool results = %d", len(parsed.ToolResults))
+	}
+	if got, want := parsed.ToolResults[0].ToolCallId, normalizeToolCallID(id); got != want {
+		t.Fatalf("tool_call_id = %q, want %q", got, want)
 	}
 }
 
@@ -20,65 +147,61 @@ func TestCursorStreamCoalescerBatchesAdjacentDeltas(t *testing.T) {
 		text       string
 		isThinking bool
 	}
-
 	emitted := make(chan emittedDelta, 4)
-	coalescer := newCursorStreamCoalescer(
-		context.Background(),
-		time.Hour,
-		func(text string, isThinking bool) {
-			emitted <- emittedDelta{text: text, isThinking: isThinking}
-		},
-	)
-
+	coalescer := newCursorStreamCoalescer(context.Background(), time.Hour, func(text string, isThinking bool) { emitted <- emittedDelta{text, isThinking} })
 	coalescer.push("first", true)
 	coalescer.push(" second", true)
 	coalescer.push(" third", true)
 	coalescer.push("answer", false)
 	coalescer.close()
 	close(emitted)
-
-	got := make([]emittedDelta, 0, 3)
+	var got []emittedDelta
 	for delta := range emitted {
 		got = append(got, delta)
 	}
-	want := []emittedDelta{
-		{text: "first", isThinking: true},
-		{text: " second third", isThinking: true},
-		{text: "answer", isThinking: false},
-	}
+	want := []emittedDelta{{"first", true}, {" second third", true}, {"answer", false}}
 	if len(got) != len(want) {
-		t.Fatalf("got %d emitted deltas, want %d: %#v", len(got), len(want), got)
+		t.Fatalf("got %#v, want %#v", got, want)
 	}
-	for index := range want {
-		if got[index] != want[index] {
-			t.Fatalf("delta %d = %#v, want %#v", index, got[index], want[index])
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("delta %d = %#v, want %#v", i, got[i], want[i])
 		}
 	}
 }
 
-func TestCursorStreamCoalescerFlushesOnTimer(t *testing.T) {
-	emitted := make(chan string, 2)
-	coalescer := newCursorStreamCoalescer(
-		context.Background(),
-		5*time.Millisecond,
-		func(text string, _ bool) {
-			emitted <- text
-		},
-	)
-	defer coalescer.close()
-
-	coalescer.push("first", false)
-	if got := <-emitted; got != "first" {
-		t.Fatalf("first emitted delta = %q, want %q", got, "first")
-	}
-
-	coalescer.push(" second", false)
+func TestCursorStreamCoalescerCancellationDoesNotBlock(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	blocked := make(chan struct{})
+	coalescer := newCursorStreamCoalescer(ctx, time.Hour, func(string, bool) { <-blocked })
+	done := make(chan struct{})
+	go func() { coalescer.push("first", false); close(done) }()
+	cancel()
 	select {
-	case got := <-emitted:
-		if got != " second" {
-			t.Fatalf("timed emitted delta = %q, want %q", got, " second")
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("timed delta was not emitted")
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("push blocked after cancellation")
+	}
+	close(blocked)
+}
+
+func TestCursorOpenAIExecutorEmitsNoDoneChunk(t *testing.T) {
+	e := newCursorExecutorHarness(func(_ context.Context, _ cursorStream, _ map[string][]byte, _ anyMCPTools, onText func(string, bool), _ func(pendingMcpExec), _ <-chan []toolResultInfo, _ *cursorTokenUsage, _ func([]byte)) error {
+		onText("ok", false)
+		return nil
+	})
+	result, err := e.ExecuteStream(context.Background(), cursorTestAuth(), cursorTestRequest(true), cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload strings.Builder
+	for chunk := range result.Chunks {
+		payload.Write(chunk.Payload)
+	}
+	if strings.Contains(payload.String(), "[DONE]") {
+		t.Fatalf("executor emitted DONE: %s", payload.String())
 	}
 }
+
+// Alias keeps test processor signatures readable without weakening production types.
+type anyMCPTools = []cursorproto.McpToolDef

--- a/internal/runtime/executor/cursor_executor_test.go
+++ b/internal/runtime/executor/cursor_executor_test.go
@@ -1,6 +1,10 @@
 package executor
 
-import "testing"
+import (
+	"context"
+	"testing"
+	"time"
+)
 
 func TestNormalizeToolCallID(t *testing.T) {
 	input := "call-cce860e6-ab07-414d-812c-785db35b17ca-4\nfc_d2335004-a95f-93b4-977b-e9eee6316be7_0"
@@ -8,5 +12,73 @@ func TestNormalizeToolCallID(t *testing.T) {
 
 	if got := normalizeToolCallID(input); got != want {
 		t.Fatalf("normalizeToolCallID() = %q, want %q", got, want)
+	}
+}
+
+func TestCursorStreamCoalescerBatchesAdjacentDeltas(t *testing.T) {
+	type emittedDelta struct {
+		text       string
+		isThinking bool
+	}
+
+	emitted := make(chan emittedDelta, 4)
+	coalescer := newCursorStreamCoalescer(
+		context.Background(),
+		time.Hour,
+		func(text string, isThinking bool) {
+			emitted <- emittedDelta{text: text, isThinking: isThinking}
+		},
+	)
+
+	coalescer.push("first", true)
+	coalescer.push(" second", true)
+	coalescer.push(" third", true)
+	coalescer.push("answer", false)
+	coalescer.close()
+	close(emitted)
+
+	got := make([]emittedDelta, 0, 3)
+	for delta := range emitted {
+		got = append(got, delta)
+	}
+	want := []emittedDelta{
+		{text: "first", isThinking: true},
+		{text: " second third", isThinking: true},
+		{text: "answer", isThinking: false},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d emitted deltas, want %d: %#v", len(got), len(want), got)
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("delta %d = %#v, want %#v", index, got[index], want[index])
+		}
+	}
+}
+
+func TestCursorStreamCoalescerFlushesOnTimer(t *testing.T) {
+	emitted := make(chan string, 2)
+	coalescer := newCursorStreamCoalescer(
+		context.Background(),
+		5*time.Millisecond,
+		func(text string, _ bool) {
+			emitted <- text
+		},
+	)
+	defer coalescer.close()
+
+	coalescer.push("first", false)
+	if got := <-emitted; got != "first" {
+		t.Fatalf("first emitted delta = %q, want %q", got, "first")
+	}
+
+	coalescer.push(" second", false)
+	select {
+	case got := <-emitted:
+		if got != " second" {
+			t.Fatalf("timed emitted delta = %q, want %q", got, " second")
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("timed delta was not emitted")
 	}
 }


### PR DESCRIPTION
## Summary
- emit Cursor thinking as OpenAI `reasoning_content` and keep reasoning separate in non-streaming responses
- normalize whitespace and control characters in tool call IDs so generated calls match returned tool results
- report non-stream token usage and avoid duplicate `[DONE]` markers in OpenAI streams
- coalesce bursty protobuf deltas at a 16 ms display cadence while preserving immediate first output and flushing before tool-call boundaries

## Test plan
- [x] `gofmt -w internal/runtime/executor/cursor_executor.go internal/runtime/executor/cursor_executor_test.go`
- [x] `go test ./...`
- [x] `go test -race ./internal/runtime/executor -run 'Test(CursorStreamCoalescer|NormalizeToolCallID)' -count=10`
- [x] `go build -o test-output ./cmd/server`
- [x] validate OpenAI and Anthropic streaming tool calls against an isolated server
- [x] benchmark direct and downstream-proxied streams for cadence, first output, and completion latency