### PR TITLE
feat(kiro): surface upstream credits in usage output

### DIFF
--- a/internal/runtime/executor/kiro_executor.go
+++ b/internal/runtime/executor/kiro_executor.go
@@ -2052,9 +2052,9 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 				if u, ok := metering["usage"].(float64); ok {
 					usageVal = u
 				}
+				usageInfo.Credits = usageVal
 				log.Infof("kiro: parseEventStream received meteringEvent: usage=%.2f %s", usageVal, unit)
-				// Store metering info for potential billing/statistics purposes
-				// Note: This is separate from token counts - it's AWS billing units
+				// Note: credits are separate from token counts - it's AWS billing units
 			} else {
 				// Try direct fields
 				unit := ""
@@ -2066,6 +2066,7 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 					usageVal = u
 				}
 				if unit != "" || usageVal > 0 {
+					usageInfo.Credits = usageVal
 					log.Infof("kiro: parseEventStream received meteringEvent (direct): usage=%.2f %s", usageVal, unit)
 				}
 			}
@@ -3503,6 +3504,9 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 	}
 
 	finalizeKiroUsageTotal(&totalUsage)
+
+	// Surface upstream billing credits in the usage output.
+	totalUsage.Credits = upstreamCreditUsage
 
 	// Log upstream usage information if received
 	if hasUpstreamUsage {

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response.go
@@ -50,6 +50,7 @@ type claudeResponsesUsageTokens struct {
 	OutputTokens             int64
 	CacheCreationInputTokens int64
 	CacheReadInputTokens     int64
+	Credits                  float64
 	HasUsage                 bool
 }
 
@@ -71,6 +72,9 @@ func (u *claudeResponsesUsageTokens) Merge(usage gjson.Result) {
 	}
 	if cacheReadInputTokens := usage.Get("cache_read_input_tokens"); cacheReadInputTokens.Exists() {
 		u.CacheReadInputTokens = cacheReadInputTokens.Int()
+	}
+	if credits := usage.Get("credits"); credits.Exists() {
+		u.Credits = credits.Float()
 	}
 }
 
@@ -600,6 +604,9 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 			if totalTokens > 0 || st.Usage.HasUsage {
 				completed, _ = sjson.SetBytes(completed, "response.usage.total_tokens", totalTokens)
 			}
+			if st.Usage.Credits != 0 {
+				completed, _ = sjson.SetBytes(completed, "response.usage.credits", st.Usage.Credits)
+			}
 		}
 		out = append(out, emitEvent("response.completed", completed))
 	}
@@ -872,6 +879,9 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 	out, _ = sjson.SetBytes(out, "usage.input_tokens_details.cached_tokens", cachedTokens)
 	out, _ = sjson.SetBytes(out, "usage.output_tokens", outputTokens)
 	out, _ = sjson.SetBytes(out, "usage.total_tokens", totalTokens)
+	if usageTokens.Credits != 0 {
+		out, _ = sjson.SetBytes(out, "usage.credits", usageTokens.Credits)
+	}
 	if reasoningBuf.Len() > 0 {
 		// Rough estimate similar to chat completions
 		reasoningTokens := int64(len(reasoningBuf.String()) / 4)

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
@@ -422,7 +422,7 @@ func TestConvertClaudeResponseToOpenAIResponses_HiddenServerToolsDoNotCreateOutp
 func TestConvertClaudeResponseToOpenAIResponses_ReportsCacheTokens(t *testing.T) {
 	chunks := [][]byte{
 		[]byte(`data: {"type":"message_start","message":{"id":"msg_123","usage":{"input_tokens":13,"output_tokens":1,"cache_read_input_tokens":100,"cache_creation_input_tokens":7}}}`),
-		[]byte(`data: {"type":"message_delta","usage":{"output_tokens":4,"cache_read_input_tokens":22000,"cache_creation_input_tokens":31}}`),
+		[]byte(`data: {"type":"message_delta","usage":{"output_tokens":4,"cache_read_input_tokens":22000,"cache_creation_input_tokens":31,"credits":0.1847}}`),
 		[]byte(`data: {"type":"message_stop"}`),
 	}
 
@@ -452,6 +452,9 @@ func TestConvertClaudeResponseToOpenAIResponses_ReportsCacheTokens(t *testing.T)
 	if got := completed.Get("response.usage.total_tokens").Int(); got != 22048 {
 		t.Fatalf("response usage total_tokens = %d, want %d", got, 22048)
 	}
+	if got := completed.Get("response.usage.credits").Float(); got != 0.1847 {
+		t.Fatalf("response usage credits = %v, want %v", got, 0.1847)
+	}
 }
 
 func TestConvertClaudeResponseToOpenAIResponsesNonStream_ThinkingIncludesSignature(t *testing.T) {
@@ -479,7 +482,7 @@ func TestConvertClaudeResponseToOpenAIResponsesNonStream_ThinkingIncludesSignatu
 func TestConvertClaudeResponseToOpenAIResponsesNonStream_ReportsCacheTokens(t *testing.T) {
 	raw := []byte(strings.Join([]string{
 		`data: {"type":"message_start","message":{"id":"msg_nonstream","usage":{"input_tokens":13,"output_tokens":1,"cache_read_input_tokens":22000,"cache_creation_input_tokens":31}}}`,
-		`data: {"type":"message_delta","usage":{"output_tokens":4}}`,
+		`data: {"type":"message_delta","usage":{"output_tokens":4,"credits":0.1847}}`,
 		`data: {"type":"message_stop"}`,
 	}, "\n"))
 
@@ -497,6 +500,9 @@ func TestConvertClaudeResponseToOpenAIResponsesNonStream_ReportsCacheTokens(t *t
 	}
 	if got := root.Get("usage.total_tokens").Int(); got != 22048 {
 		t.Fatalf("non-stream usage total_tokens = %d, want %d", got, 22048)
+	}
+	if got := root.Get("usage.credits").Float(); got != 0.1847 {
+		t.Fatalf("non-stream usage credits = %v, want %v", got, 0.1847)
 	}
 }
 

--- a/internal/translator/kiro/claude/kiro_claude_response.go
+++ b/internal/translator/kiro/claude/kiro_claude_response.go
@@ -123,6 +123,9 @@ func buildClaudeUsage(usageInfo usage.Detail) map[string]interface{} {
 	if usageInfo.CacheCreationTokens != 0 {
 		payload["cache_creation_input_tokens"] = usageInfo.CacheCreationTokens
 	}
+	if usageInfo.Credits != 0 {
+		payload["credits"] = usageInfo.Credits
+	}
 	return payload
 }
 

--- a/internal/translator/kiro/claude/kiro_claude_response_test.go
+++ b/internal/translator/kiro/claude/kiro_claude_response_test.go
@@ -29,6 +29,49 @@ func TestBuildClaudeResponseIncludesCacheUsageFields(t *testing.T) {
 	assertJSONNumber(t, usagePayload, "cache_creation_input_tokens", 17)
 }
 
+func TestBuildClaudeResponseIncludesCredits(t *testing.T) {
+	response := BuildClaudeResponse("ok", nil, "claude-opus-4-7", usage.Detail{
+		InputTokens:  7982,
+		OutputTokens: 52,
+		Credits:      0.1847,
+	}, "end_turn")
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(response, &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	usagePayload, ok := payload["usage"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("usage payload missing or wrong type: %#v", payload["usage"])
+	}
+	credits, ok := usagePayload["credits"].(float64)
+	if !ok {
+		t.Fatalf("credits missing or wrong type: %#v", usagePayload["credits"])
+	}
+	if credits != 0.1847 {
+		t.Fatalf("credits = %v, want %v", credits, 0.1847)
+	}
+}
+
+func TestBuildClaudeResponseOmitsZeroCredits(t *testing.T) {
+	response := BuildClaudeResponse("ok", nil, "claude-opus-4-7", usage.Detail{
+		InputTokens:  10,
+		OutputTokens: 2,
+	}, "end_turn")
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(response, &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	usagePayload, ok := payload["usage"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("usage payload missing or wrong type: %#v", payload["usage"])
+	}
+	if _, exists := usagePayload["credits"]; exists {
+		t.Fatalf("credits should be omitted when zero, got: %#v", usagePayload["credits"])
+	}
+}
+
 func assertJSONNumber(t *testing.T, payload map[string]interface{}, key string, want int64) {
 	t.Helper()
 	got, ok := payload[key].(float64)

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -69,6 +69,8 @@ type Detail struct {
 	CacheCreationTokens int64
 	TotalTokens         int64
 	ResponseServiceTier string
+	// Credits holds upstream billing credits (e.g. Kiro meteringEvent usage).
+	Credits float64
 }
 
 type requestedModelAliasContextKey struct{}


### PR DESCRIPTION
## Summary
Kiro's upstream API emits a `meteringEvent` carrying billing credits (e.g. `{"unit":"credit","usage":0.1847}`). The executor already parsed and logged this value, but it was a dead end — it never reached the `usage` object, so clients could not see how many credits a request cost. This adds `credits` to the usage output for both the `claude` (Anthropic Messages) and `responses` (OpenAI Responses) formats, in streaming and non-streaming responses.

## Changes
- `sdk/cliproxy/usage/manager.go`: add `Credits float64` to the canonical `Detail` struct.
- `internal/runtime/executor/kiro_executor.go`: populate credits from the streaming path (`totalUsage.Credits`) and the non-stream `parseEventStream` meteringEvent case (`usageInfo.Credits`), covering nested and direct-field branches.
- `internal/translator/kiro/claude/kiro_claude_response.go`: emit `"credits"` in `buildClaudeUsage` when non-zero (feeds both stream and non-stream claude paths).
- `internal/translator/claude/openai/responses/claude_openai-responses_response.go`: carry `credits` through `claudeResponsesUsageTokens.Merge` and emit it at both usage-writing sites (streaming `response.completed` and non-stream final).

Output shape: `"usage": {"input_tokens": 7982, "output_tokens": 52, "credits": 0.1847}`. Omitted when zero.

## Testing
- [x] Unit tests added/updated (claude response presence + zero-omission; responses stream + non-stream propagation)
- [x] All tests pass (`go test ./internal/translator/kiro/... ./internal/translator/claude/openai/responses/... ./sdk/cliproxy/usage/...`)
- [x] Build verified (`go build ./cmd/server`)

## Checklist
- [x] No sensitive data exposed
- [x] Linting passed (`gofmt`, build)
- [x] Breaking changes: none; additive field

🤖 Generated with [Claude Code](https://claude.com/claude-code)