### PR TITLE
feat(kiro): surface upstream billing credits in usage output

### DIFF
--- a/internal/pluginhost/adapters.go
+++ b/internal/pluginhost/adapters.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -1847,6 +1848,7 @@ func (a *usageAdapter) HandleUsage(ctx context.Context, record coreusage.Record)
 			CacheCreationTokens: record.Detail.CacheCreationTokens,
 			TotalTokens:         record.Detail.TotalTokens,
 		},
+		Metadata:        maps.Clone(record.Metadata),
 		ResponseHeaders: cloneHeader(record.ResponseHeaders),
 	})
 }

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"reflect"
 	"strings"
@@ -40,6 +41,7 @@ type UsageReporter struct {
 	ttftStart    time.Time
 	ttftSet      bool
 	once         sync.Once
+	Metadata     map[string]any
 }
 
 type usageExecutor interface {
@@ -73,6 +75,7 @@ func NewUsageReporter(ctx context.Context, provider, model string, auth *cliprox
 		reasoning:   usage.ReasoningEffortFromContext(ctx),
 		serviceTier: usage.ServiceTierFromContext(ctx),
 		generate:    usage.GenerateFromContext(ctx),
+		Metadata:    make(map[string]any),
 	}
 	if auth != nil {
 		reporter.authID = auth.ID
@@ -280,6 +283,7 @@ func (r *UsageReporter) buildRecordForModel(model string, detail usage.Detail, f
 		Failed:              failed,
 		Fail:                fail,
 		Detail:              detail,
+		Metadata:            maps.Clone(r.Metadata),
 	}
 }
 

--- a/internal/runtime/executor/kiro_executor.go
+++ b/internal/runtime/executor/kiro_executor.go
@@ -2052,9 +2052,9 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 				if u, ok := metering["usage"].(float64); ok {
 					usageVal = u
 				}
+				usageInfo.Credits = usageVal
 				log.Infof("kiro: parseEventStream received meteringEvent: usage=%.2f %s", usageVal, unit)
-				// Store metering info for potential billing/statistics purposes
-				// Note: This is separate from token counts - it's AWS billing units
+				// Note: credits are separate from token counts - it's AWS billing units
 			} else {
 				// Try direct fields
 				unit := ""
@@ -2066,6 +2066,7 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 					usageVal = u
 				}
 				if unit != "" || usageVal > 0 {
+					usageInfo.Credits = usageVal
 					log.Infof("kiro: parseEventStream received meteringEvent (direct): usage=%.2f %s", usageVal, unit)
 				}
 			}
@@ -3503,6 +3504,9 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 	}
 
 	finalizeKiroUsageTotal(&totalUsage)
+
+	// Surface upstream billing credits in the usage output.
+	totalUsage.Credits = upstreamCreditUsage
 
 	// Log upstream usage information if received
 	if hasUpstreamUsage {

--- a/internal/runtime/executor/kiro_executor.go
+++ b/internal/runtime/executor/kiro_executor.go
@@ -52,6 +52,11 @@ const (
 	// kiroIDEAgentMode is the agent mode header value for Kiro IDE requests
 	kiroIDEAgentMode = "vibe"
 
+	// kiroUsageMetaCredits is the Record.Metadata key under which Kiro surfaces
+	// upstream billing credits (meteringEvent usage) to usage sinks. The key is
+	// owned here rather than in the shared usage package.
+	kiroUsageMetaCredits = "credits"
+
 	// Socket retry configuration constants
 	// Maximum number of retry attempts for socket/network errors
 	kiroSocketMaxRetries = 3
@@ -64,6 +69,19 @@ const (
 	// Streaming read timeout (how long to wait between chunks)
 	kiroStreamingReadTimeout = 300 * time.Second
 )
+
+// publishKiroUsage emits a usage record, surfacing Kiro-specific billing credits
+// through Record.Metadata. Centralizing it keeps the credits key and its
+// zero-value guard in one place instead of at every publish site.
+func publishKiroUsage(ctx context.Context, reporter *usageReporter, detail usage.Detail) {
+	if reporter == nil {
+		return
+	}
+	if reporter.reporter != nil && detail.Credits != 0 {
+		reporter.reporter.Metadata[kiroUsageMetaCredits] = detail.Credits
+	}
+	reporter.publish(ctx, detail)
+}
 
 // retryableHTTPStatusCodes defines HTTP status codes that are considered retryable.
 // Based on kiro2Api reference: 502 (Bad Gateway), 503 (Service Unavailable), 504 (Gateway Timeout)
@@ -1009,7 +1027,7 @@ func (e *KiroExecutor) executeWithRetry(ctx context.Context, auth *cliproxyauth.
 			finalizeKiroUsageTotal(&usageInfo)
 
 			appendAPIResponseChunk(ctx, e.cfg, []byte(content))
-			reporter.publish(ctx, usageInfo)
+			publishKiroUsage(ctx, reporter, usageInfo)
 
 			// Record success for rate limiting
 			rateLimiter.MarkTokenSuccess(tokenKey)
@@ -2509,7 +2527,7 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 
 	// Ensure usage is published even on early return
 	defer func() {
-		reporter.publish(ctx, totalUsage)
+		publishKiroUsage(ctx, reporter, totalUsage)
 	}()
 
 	for {
@@ -4326,7 +4344,7 @@ func (e *KiroExecutor) handleWebSearchStream(
 			if accumulatedOutputLen > 0 && totalUsage.OutputTokens == 0 {
 				totalUsage.OutputTokens = 1
 			}
-			reporter.publish(ctx, totalUsage)
+			publishKiroUsage(ctx, reporter, totalUsage)
 		}()
 
 		// Send message_start event to client (aligned with streamToChannel pattern)

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response.go
@@ -50,6 +50,7 @@ type claudeResponsesUsageTokens struct {
 	OutputTokens             int64
 	CacheCreationInputTokens int64
 	CacheReadInputTokens     int64
+	Credits                  float64
 	HasUsage                 bool
 }
 
@@ -71,6 +72,9 @@ func (u *claudeResponsesUsageTokens) Merge(usage gjson.Result) {
 	}
 	if cacheReadInputTokens := usage.Get("cache_read_input_tokens"); cacheReadInputTokens.Exists() {
 		u.CacheReadInputTokens = cacheReadInputTokens.Int()
+	}
+	if credits := usage.Get("credits"); credits.Exists() {
+		u.Credits = credits.Float()
 	}
 }
 
@@ -600,6 +604,9 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 			if totalTokens > 0 || st.Usage.HasUsage {
 				completed, _ = sjson.SetBytes(completed, "response.usage.total_tokens", totalTokens)
 			}
+			if st.Usage.Credits != 0 {
+				completed, _ = sjson.SetBytes(completed, "response.usage.credits", st.Usage.Credits)
+			}
 		}
 		out = append(out, emitEvent("response.completed", completed))
 	}
@@ -872,6 +879,9 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 	out, _ = sjson.SetBytes(out, "usage.input_tokens_details.cached_tokens", cachedTokens)
 	out, _ = sjson.SetBytes(out, "usage.output_tokens", outputTokens)
 	out, _ = sjson.SetBytes(out, "usage.total_tokens", totalTokens)
+	if usageTokens.Credits != 0 {
+		out, _ = sjson.SetBytes(out, "usage.credits", usageTokens.Credits)
+	}
 	if reasoningBuf.Len() > 0 {
 		// Rough estimate similar to chat completions
 		reasoningTokens := int64(len(reasoningBuf.String()) / 4)

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
@@ -422,7 +422,7 @@ func TestConvertClaudeResponseToOpenAIResponses_HiddenServerToolsDoNotCreateOutp
 func TestConvertClaudeResponseToOpenAIResponses_ReportsCacheTokens(t *testing.T) {
 	chunks := [][]byte{
 		[]byte(`data: {"type":"message_start","message":{"id":"msg_123","usage":{"input_tokens":13,"output_tokens":1,"cache_read_input_tokens":100,"cache_creation_input_tokens":7}}}`),
-		[]byte(`data: {"type":"message_delta","usage":{"output_tokens":4,"cache_read_input_tokens":22000,"cache_creation_input_tokens":31}}`),
+		[]byte(`data: {"type":"message_delta","usage":{"output_tokens":4,"cache_read_input_tokens":22000,"cache_creation_input_tokens":31,"credits":0.1847}}`),
 		[]byte(`data: {"type":"message_stop"}`),
 	}
 
@@ -452,6 +452,9 @@ func TestConvertClaudeResponseToOpenAIResponses_ReportsCacheTokens(t *testing.T)
 	if got := completed.Get("response.usage.total_tokens").Int(); got != 22048 {
 		t.Fatalf("response usage total_tokens = %d, want %d", got, 22048)
 	}
+	if got := completed.Get("response.usage.credits").Float(); got != 0.1847 {
+		t.Fatalf("response usage credits = %v, want %v", got, 0.1847)
+	}
 }
 
 func TestConvertClaudeResponseToOpenAIResponsesNonStream_ThinkingIncludesSignature(t *testing.T) {
@@ -479,7 +482,7 @@ func TestConvertClaudeResponseToOpenAIResponsesNonStream_ThinkingIncludesSignatu
 func TestConvertClaudeResponseToOpenAIResponsesNonStream_ReportsCacheTokens(t *testing.T) {
 	raw := []byte(strings.Join([]string{
 		`data: {"type":"message_start","message":{"id":"msg_nonstream","usage":{"input_tokens":13,"output_tokens":1,"cache_read_input_tokens":22000,"cache_creation_input_tokens":31}}}`,
-		`data: {"type":"message_delta","usage":{"output_tokens":4}}`,
+		`data: {"type":"message_delta","usage":{"output_tokens":4,"credits":0.1847}}`,
 		`data: {"type":"message_stop"}`,
 	}, "\n"))
 
@@ -497,6 +500,9 @@ func TestConvertClaudeResponseToOpenAIResponsesNonStream_ReportsCacheTokens(t *t
 	}
 	if got := root.Get("usage.total_tokens").Int(); got != 22048 {
 		t.Fatalf("non-stream usage total_tokens = %d, want %d", got, 22048)
+	}
+	if got := root.Get("usage.credits").Float(); got != 0.1847 {
+		t.Fatalf("non-stream usage credits = %v, want %v", got, 0.1847)
 	}
 }
 

--- a/internal/translator/kiro/claude/kiro_claude_response.go
+++ b/internal/translator/kiro/claude/kiro_claude_response.go
@@ -123,6 +123,9 @@ func buildClaudeUsage(usageInfo usage.Detail) map[string]interface{} {
 	if usageInfo.CacheCreationTokens != 0 {
 		payload["cache_creation_input_tokens"] = usageInfo.CacheCreationTokens
 	}
+	if usageInfo.Credits != 0 {
+		payload["credits"] = usageInfo.Credits
+	}
 	return payload
 }
 

--- a/internal/translator/kiro/claude/kiro_claude_response_test.go
+++ b/internal/translator/kiro/claude/kiro_claude_response_test.go
@@ -29,6 +29,49 @@ func TestBuildClaudeResponseIncludesCacheUsageFields(t *testing.T) {
 	assertJSONNumber(t, usagePayload, "cache_creation_input_tokens", 17)
 }
 
+func TestBuildClaudeResponseIncludesCredits(t *testing.T) {
+	response := BuildClaudeResponse("ok", nil, "claude-opus-4-7", usage.Detail{
+		InputTokens:  7982,
+		OutputTokens: 52,
+		Credits:      0.1847,
+	}, "end_turn")
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(response, &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	usagePayload, ok := payload["usage"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("usage payload missing or wrong type: %#v", payload["usage"])
+	}
+	credits, ok := usagePayload["credits"].(float64)
+	if !ok {
+		t.Fatalf("credits missing or wrong type: %#v", usagePayload["credits"])
+	}
+	if credits != 0.1847 {
+		t.Fatalf("credits = %v, want %v", credits, 0.1847)
+	}
+}
+
+func TestBuildClaudeResponseOmitsZeroCredits(t *testing.T) {
+	response := BuildClaudeResponse("ok", nil, "claude-opus-4-7", usage.Detail{
+		InputTokens:  10,
+		OutputTokens: 2,
+	}, "end_turn")
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(response, &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	usagePayload, ok := payload["usage"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("usage payload missing or wrong type: %#v", payload["usage"])
+	}
+	if _, exists := usagePayload["credits"]; exists {
+		t.Fatalf("credits should be omitted when zero, got: %#v", usagePayload["credits"])
+	}
+}
+
 func assertJSONNumber(t *testing.T, payload map[string]interface{}, key string, want int64) {
 	t.Helper()
 	got, ok := payload[key].(float64)

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -49,6 +49,7 @@ type Record struct {
 	Failed      bool
 	Fail        Failure
 	Detail      Detail
+	Metadata    map[string]any
 	// ResponseHeaders stores a snapshot of upstream response headers for usage sinks.
 	ResponseHeaders http.Header
 }

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -69,6 +69,8 @@ type Detail struct {
 	CacheCreationTokens int64
 	TotalTokens         int64
 	ResponseServiceTier string
+	// Credits holds upstream billing credits (e.g. Kiro meteringEvent usage).
+	Credits float64
 }
 
 type requestedModelAliasContextKey struct{}

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -1291,6 +1291,9 @@ type UsageRecord struct {
 	Failure UsageFailure
 	// Detail contains token usage counters.
 	Detail UsageDetail
+	// Metadata carries provider-specific usage extensions (e.g. billing units)
+	// that do not belong in the token accounting Detail.
+	Metadata map[string]any
 	// ResponseHeaders contains selected upstream response headers.
 	ResponseHeaders http.Header
 }


### PR DESCRIPTION
## Summary

Kiro's upstream `meteringEvent` carries billing **credits** (AWS billing units), but these were only parsed and logged — they never reached the usage output returned to clients or usage sinks. This PR wires those credits all the way through so they show up alongside token counts.

### What changed

- **Canonical usage model**: Added a `Credits float64` field to `usage.Detail` and a `Metadata map[string]any` to the SDK `Record` and plugin `UsageRecord` types, so provider-specific billing extensions ride along without polluting token accounting.
- **Kiro executor**: Populate `Credits` from the `meteringEvent` (both metering-nested and direct-field parse paths, plus the finalized upstream credit total). A new `publishKiroUsage` helper centralizes the credits key + zero-value guard instead of duplicating it at every publish site.
- **Usage pipeline**: `UsageReporter` now carries `Metadata` and clones it into each record; `usageAdapter.HandleUsage` forwards it to plugin sinks.
- **Output translators**: Emit `credits` in the `usage` object for both the Kiro→Claude and Claude→OpenAI-Responses (stream + non-stream) formats. Zero credits are omitted.

### Example output

The `usage` object now includes `credits`:

\`\`\`json
"usage": {
  "credits": 0.01047506087893864,
  "input_tokens": 822,
  "output_tokens": 8
}
\`\`\`

## Testing

- \`go build ./cmd/server\` — compiles clean
- \`go test ./internal/translator/kiro/claude/ ./internal/translator/claude/openai/responses/\` — pass
- Added unit tests covering credits emission and zero-credit omission for both the Claude and OpenAI-Responses output formats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)