### PR TITLE
perf(kiro): cache provider-scoped model catalog to avoid per-account fetches

### DIFF
--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -115,12 +115,36 @@ type Service struct {
 	homePluginSyncMu    sync.Mutex
 	homePluginSyncKey   string
 	homePluginSyncFetch func(context.Context, sdkpluginstore.PluginSyncRequest) (sdkpluginstore.PluginSyncResponse, error)
+
+	// kiroModelsCache caches the provider-scoped Kiro model catalog so that a fleet
+	// of Kiro accounts does not each trigger a ListAvailableModels call on every
+	// registration cycle (startup, config reload, catalog refresh).
+	kiroModelsCache kiroModelsCache
+}
+
+// kiroModelsCache is a TTL cache for the Kiro model catalog. The catalog is
+// provider-scoped (identical for every account; profileArn only routes billing), so
+// all Kiro auths share a single cached fetch. The mutex is held across the fetch so a
+// burst of accounts registering at once collapses into a single upstream call: the
+// first caller fetches while the rest wait, then they return the now-fresh cache. The
+// base (pre-agentic) model list is cached; agentic variants are derived per read
+// because they depend on a runtime flag, not the auth.
+type kiroModelsCache struct {
+	mu     sync.Mutex
+	models []*ModelInfo
+	expiry time.Time
 }
 
 const (
 	modelRegistrationMaxWorkersPerCategory         = 5
 	modelRegistrationMaxWorkersOpenAICompatibility = 20
 )
+
+// kiroModelsCacheTTL bounds how long a fetched Kiro model catalog is reused across
+// registration cycles before the next fetch is allowed. The catalog changes rarely,
+// so a modest TTL removes the per-account request amplification while keeping the
+// list reasonably fresh.
+const kiroModelsCacheTTL = 30 * time.Minute
 
 const (
 	modelRegistrationPhaseConfigAPIKey = iota
@@ -2964,8 +2988,11 @@ func applyOAuthModelAliasEntries(aliases []config.OAuthModelAlias, models []*Mod
 	return out
 }
 
-// fetchKiroModels attempts to dynamically fetch Kiro models from the API.
-// If dynamic fetch fails, it falls back to static registry.GetKiroModels().
+// fetchKiroModels returns the Kiro model list for an auth. The provider-scoped base
+// catalog is fetched through a TTL cache that coalesces concurrent callers, so a fleet
+// of Kiro accounts triggers at most one ListAvailableModels call per TTL instead of one
+// per account per registration cycle. If the fetch fails, it falls back to the static
+// registry.GetKiroModels().
 func (s *Service) fetchKiroModels(a *coreauth.Auth) []*ModelInfo {
 	if a == nil {
 		log.Debug("kiro: auth is nil, using static models")
@@ -2979,43 +3006,78 @@ func (s *Service) fetchKiroModels(a *coreauth.Auth) []*ModelInfo {
 		return registry.GetKiroModels()
 	}
 
-	// Create KiroAuth instance
-	kAuth := kiroauth.NewKiroAuth(s.cfg)
-	if kAuth == nil {
-		log.Warn("kiro: failed to create KiroAuth instance, using static models")
+	base, ok := s.kiroModelsCache.get(func() ([]*ModelInfo, error) {
+		return s.fetchKiroBaseModelsFromAPI(tokenData)
+	})
+	if !ok {
 		return registry.GetKiroModels()
 	}
 
-	// Use timeout context for API call
+	// Generate agentic variants (only when kiro-system-prompt-inject-enable is on).
+	// This depends on a runtime flag rather than the account, so it is derived on
+	// every read instead of being cached.
+	return generateKiroAgenticVariants(base)
+}
+
+// get returns the provider-scoped Kiro base (pre-agentic) model list, invoking fetch
+// at most once per TTL. Concurrent callers coalesce onto a single fetch by waiting on
+// the mutex; when they acquire it the cache is already fresh. It returns ok=false when
+// nothing is cached and fetch fails or returns no models, so the caller can fall back
+// to the static catalog. Failed or empty fetches are not cached, allowing a retry.
+func (c *kiroModelsCache) get(fetch func() ([]*ModelInfo, error)) ([]*ModelInfo, bool) {
+	if c == nil || fetch == nil {
+		return nil, false
+	}
+
+	// The lock is intentionally held across fetch() so a burst of concurrent callers
+	// collapses into a single upstream call: latecomers block here and then read the
+	// now-fresh cache below. Do not narrow this to only guard the cache fields.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.models != nil && time.Now().Before(c.expiry) {
+		return c.models, true
+	}
+
+	models, err := fetch()
+	if err != nil {
+		log.Warnf("kiro: failed to fetch dynamic models: %v, using static models", err)
+		return nil, false
+	}
+	if len(models) == 0 {
+		// Do not cache a failed/empty catalog so a later caller can retry.
+		return nil, false
+	}
+
+	c.models = models
+	c.expiry = time.Now().Add(kiroModelsCacheTTL)
+	return models, true
+}
+
+// fetchKiroBaseModelsFromAPI performs the single upstream ListAvailableModels call and
+// converts the response to base ModelInfo entries (without agentic variants).
+func (s *Service) fetchKiroBaseModelsFromAPI(tokenData *kiroauth.KiroTokenData) ([]*ModelInfo, error) {
+	kAuth := kiroauth.NewKiroAuth(s.cfg)
+	if kAuth == nil {
+		return nil, errors.New("failed to create KiroAuth instance")
+	}
+
+	// Use timeout context for the credential-bound API call.
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	// Attempt to fetch dynamic models
 	apiModels, err := kAuth.ListAvailableModels(ctx, tokenData)
 	if err != nil {
-		log.Warnf("kiro: failed to fetch dynamic models: %v, using static models", err)
-		return registry.GetKiroModels()
+		return nil, err
 	}
-
 	if len(apiModels) == 0 {
 		log.Debug("kiro: API returned no models, using static models")
-		return registry.GetKiroModels()
+		return nil, nil
 	}
 
-	// Convert API models to ModelInfo
 	models := convertKiroAPIModels(apiModels)
-
-	baseCount := len(models)
-
-	// Generate agentic variants (only when kiro-system-prompt-inject-enable is on).
-	models = generateKiroAgenticVariants(models)
-
-	if len(models) > baseCount {
-		log.Infof("kiro: fetched %d models from API (+%d agentic variants)", baseCount, len(models)-baseCount)
-	} else {
-		log.Infof("kiro: fetched %d models from API", baseCount)
-	}
-	return models
+	log.Infof("kiro: fetched %d models from API", len(models))
+	return models, nil
 }
 
 // extractKiroTokenData extracts KiroTokenData from auth attributes and metadata.

--- a/sdk/cliproxy/service_kiro_models_cache_test.go
+++ b/sdk/cliproxy/service_kiro_models_cache_test.go
@@ -1,0 +1,135 @@
+package cliproxy
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestKiroModelsCacheCoalescesConcurrentFetches verifies that a burst of concurrent
+// callers (simulating a fleet of Kiro accounts registering at once) triggers exactly
+// one upstream fetch, and every caller receives the shared result.
+func TestKiroModelsCacheCoalescesConcurrentFetches(t *testing.T) {
+	c := &kiroModelsCache{}
+
+	var calls int32
+	release := make(chan struct{})
+	fetch := func() ([]*ModelInfo, error) {
+		atomic.AddInt32(&calls, 1)
+		<-release // hold the flight open so callers pile up behind singleflight
+		return []*ModelInfo{{ID: "kiro-model"}}, nil
+	}
+
+	const callers = 50
+	var wg sync.WaitGroup
+	results := make([][]*ModelInfo, callers)
+	oks := make([]bool, callers)
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx], oks[idx] = c.get(fetch)
+		}(i)
+	}
+
+	// Give the goroutines time to block on singleflight before releasing.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected exactly 1 upstream fetch, got %d", got)
+	}
+	for i := 0; i < callers; i++ {
+		if !oks[i] || len(results[i]) != 1 || results[i][0].ID != "kiro-model" {
+			t.Fatalf("caller %d got unexpected result ok=%v models=%v", i, oks[i], results[i])
+		}
+	}
+}
+
+// TestKiroModelsCacheServesWithinTTL verifies a cached result is reused without a
+// second fetch while the TTL is still valid, and refreshed after it expires.
+func TestKiroModelsCacheServesWithinTTL(t *testing.T) {
+	c := &kiroModelsCache{}
+
+	var calls int32
+	fetch := func() ([]*ModelInfo, error) {
+		atomic.AddInt32(&calls, 1)
+		return []*ModelInfo{{ID: "kiro-model"}}, nil
+	}
+
+	if _, ok := c.get(fetch); !ok {
+		t.Fatal("first get should succeed")
+	}
+	if _, ok := c.get(fetch); !ok {
+		t.Fatal("second get should succeed from cache")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected 1 fetch within TTL, got %d", got)
+	}
+
+	// Force expiry and confirm a refresh happens.
+	c.mu.Lock()
+	c.expiry = time.Now().Add(-time.Second)
+	c.mu.Unlock()
+
+	if _, ok := c.get(fetch); !ok {
+		t.Fatal("get after expiry should succeed")
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("expected refresh after TTL expiry, got %d fetches", got)
+	}
+}
+
+// TestKiroModelsCacheDoesNotCacheFailures verifies that fetch errors are not cached,
+// so a later caller retries and can succeed.
+func TestKiroModelsCacheDoesNotCacheFailures(t *testing.T) {
+	c := &kiroModelsCache{}
+
+	var calls int32
+	fetch := func() ([]*ModelInfo, error) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			return nil, errors.New("boom")
+		}
+		return []*ModelInfo{{ID: "kiro-model"}}, nil
+	}
+
+	if _, ok := c.get(fetch); ok {
+		t.Fatal("first get should fail and report ok=false")
+	}
+	models, ok := c.get(fetch)
+	if !ok || len(models) != 1 {
+		t.Fatalf("second get should retry and succeed, ok=%v models=%v", ok, models)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("expected 2 fetches (failure then retry), got %d", got)
+	}
+}
+
+// TestKiroModelsCacheDoesNotCacheEmpty verifies that a successful-but-empty fetch is
+// not cached, allowing a later caller to retry.
+func TestKiroModelsCacheDoesNotCacheEmpty(t *testing.T) {
+	c := &kiroModelsCache{}
+
+	var calls int32
+	fetch := func() ([]*ModelInfo, error) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			return nil, nil // empty catalog
+		}
+		return []*ModelInfo{{ID: "kiro-model"}}, nil
+	}
+
+	if _, ok := c.get(fetch); ok {
+		t.Fatal("empty fetch should report ok=false")
+	}
+	if _, ok := c.get(fetch); !ok {
+		t.Fatal("second get should retry and succeed")
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("expected 2 fetches (empty then retry), got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

When managing many Kiro accounts, model registration called `ListAvailableModels` **once per account** on **every** registration cycle — startup, config reload, and the 3-hour catalog refresh. With N accounts this amplified into N upstream requests per cycle (the `kiro: fetched N models from API` log line fires per account).

The Kiro model catalog is **provider-scoped** — identical for every account; `profileArn` only routes billing. So this PR caches the catalog once and shares it across all Kiro auths.

## What changed

- Add a small TTL cache (`kiroModelsCache`) on `Service` for the Kiro base (pre-agentic) model list.
- `fetchKiroModels` now: cache lookup → single upstream `ListAvailableModels` (`fetchKiroBaseModelsFromAPI`) → per-read agentic variant generation.
- Coalescing is done by holding the mutex across the fetch: a concurrent burst of accounts collapses into one upstream call (latecomers block, then read the fresh cache). The TTL (30 min) collapses repeat fetches across registration cycles.
- Agentic variants are derived **per read**, not cached, because they depend on the `kiro-system-prompt-inject-enable` runtime flag rather than the account.
- Failed and empty fetches are **not** cached, so a later caller can retry (and still falls back to the static `registry.GetKiroModels()`).

## Result

N Kiro accounts trigger **at most one** `ListAvailableModels` call per TTL, instead of one per account per registration cycle.

## Notes / scope

- Scoped to Kiro only. The same per-account fetch amplification exists for `cursor`, `github-copilot`, `kilo`, `qoder`, and `antigravity` — if this approach is acceptable, it can be extended in a follow-up.
- The TTL is a constant (30 min). Happy to make it configurable if maintainers prefer.
- The shared cached slice is only consumed by non-mutating helpers (`generateKiroAgenticVariants`, `applyExcludedModels`, `applyModelPrefixes` all build new slices / clone before edits), so sharing is safe.

## Testing

- New `service_kiro_models_cache_test.go` covering: concurrent coalescing (50 callers → 1 fetch), TTL reuse + expiry refresh, failures not cached, empty results not cached. All pass under `-race`.
- `gofmt -w .`, `go build ./cmd/server`, and `go test ./sdk/cliproxy/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)