### PR TITLE
fix(kiro): recover native invoke tool calls and keep trailing system tools

### DIFF
--- a/internal/config/oauth_model_alias_defaults.go
+++ b/internal/config/oauth_model_alias_defaults.go
@@ -6,6 +6,8 @@ import "strings"
 // These aliases expose standard Claude IDs for Kiro-prefixed upstream models.
 func defaultKiroAliases() []OAuthModelAlias {
 	return []OAuthModelAlias{
+		// Sonnet 5
+		{Name: "kiro-claude-sonnet-5", Alias: "claude-sonnet-5", Fork: true},
 		// Sonnet 4.6
 		{Name: "kiro-claude-sonnet-4-6", Alias: "claude-sonnet-4-6", Fork: true},
 		// Sonnet 4.5
@@ -14,6 +16,8 @@ func defaultKiroAliases() []OAuthModelAlias {
 		// Sonnet 4
 		{Name: "kiro-claude-sonnet-4", Alias: "claude-sonnet-4-20250514", Fork: true},
 		{Name: "kiro-claude-sonnet-4", Alias: "claude-sonnet-4", Fork: true},
+		// Opus 4.8
+		{Name: "kiro-claude-opus-4-8", Alias: "claude-opus-4-8", Fork: true},
 		// Opus 4.7
 		{Name: "kiro-claude-opus-4-7", Alias: "claude-opus-4-7", Fork: true},
 		// Opus 4.6
@@ -24,6 +28,8 @@ func defaultKiroAliases() []OAuthModelAlias {
 		// Haiku 4.5
 		{Name: "kiro-claude-haiku-4-5", Alias: "claude-haiku-4-5-20251001", Fork: true},
 		{Name: "kiro-claude-haiku-4-5", Alias: "claude-haiku-4-5", Fork: true},
+		// Fable 5
+		{Name: "kiro-claude-fable-5", Alias: "claude-fable-5", Fork: true},
 	}
 }
 

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -753,6 +753,11 @@ func GetKiroModels() []*ModelInfo {
 		description string
 	}{
 		{
+			id:          "kiro-claude-sonnet-5",
+			displayName: "Claude Sonnet 5",
+			description: "Claude Sonnet 5 via Kiro",
+		},
+		{
 			id:          "kiro-claude-sonnet-4-6",
 			displayName: "Claude Sonnet 4.6",
 			description: "Claude Sonnet 4.6 via Kiro",
@@ -766,6 +771,11 @@ func GetKiroModels() []*ModelInfo {
 			id:          "kiro-claude-sonnet-4",
 			displayName: "Claude Sonnet 4",
 			description: "Claude Sonnet 4 via Kiro",
+		},
+		{
+			id:          "kiro-claude-opus-4-8",
+			displayName: "Claude Opus 4.8",
+			description: "Claude Opus 4.8 via Kiro",
 		},
 		{
 			id:          "kiro-claude-opus-4-7",
@@ -786,6 +796,11 @@ func GetKiroModels() []*ModelInfo {
 			id:          "kiro-claude-haiku-4-5",
 			displayName: "Claude Haiku 4.5",
 			description: "Claude Haiku 4.5 via Kiro",
+		},
+		{
+			id:          "kiro-claude-fable-5",
+			displayName: "Claude Fable 5",
+			description: "Claude Fable 5 via Kiro",
 		},
 	}
 

--- a/internal/runtime/executor/kiro_executor.go
+++ b/internal/runtime/executor/kiro_executor.go
@@ -2195,6 +2195,12 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 	cleanedContent, embeddedToolUses := kiroclaude.ParseEmbeddedToolCalls(contentStr, processedIDs)
 	toolUses = append(toolUses, embeddedToolUses...)
 
+	// Parse Kiro IDE native <invoke name="..."> tool calls from content.
+	// The model frequently emits these as inline text instead of structured
+	// toolUseEvent when using the AI_EDITOR origin.
+	cleanedContent, invokeToolUses := kiroclaude.ParseInvokeToolCalls(cleanedContent, processedIDs)
+	toolUses = append(toolUses, invokeToolUses...)
+
 	// Deduplicate all tool uses
 	toolUses = kiroclaude.DeduplicateToolUses(toolUses)
 
@@ -2208,6 +2214,11 @@ func (e *KiroExecutor) parseEventStream(body io.Reader) (string, []kiroclaude.Ki
 			stopReason = "end_turn"
 			log.Debugf("kiro: parseEventStream using fallback stop_reason: end_turn")
 		}
+	} else if len(toolUses) > 0 && stopReason == "end_turn" {
+		// Upstream reported end_turn but we recovered tool calls from the text
+		// (native invoke format). The client must run the tools, so report tool_use.
+		stopReason = "tool_use"
+		log.Debugf("kiro: parseEventStream overriding end_turn -> tool_use (recovered %d tool uses from text)", len(toolUses))
 	}
 
 	// Log warning if response was truncated due to max_tokens
@@ -2434,6 +2445,12 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 	processedIDs := make(map[string]bool)
 	var currentToolUse *kiroclaude.ToolUseState
 
+	// Invoke parser recovers Kiro IDE native <invoke name="..."> tool calls that
+	// the model emits as inline text (common with the AI_EDITOR origin). Shares
+	// the dedup map so the same call is not emitted via both text and structured
+	// channels.
+	invokeParser := kiroclaude.NewInvokeStreamParser(processedIDs)
+
 	// NOTE: Duplicate content filtering removed - it was causing legitimate repeated
 	// content (like consecutive newlines) to be incorrectly filtered out.
 	// The previous implementation compared lastContentEvent == contentDelta which
@@ -2505,6 +2522,46 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 	messageStartSent := false
 	isTextBlockOpen := false
 	var outputLen int
+
+	// emitInvokeToolUse emits a recovered native <invoke> tool call as a Claude
+	// tool_use content block, closing any open text block first. It mirrors the
+	// structured toolUseEvent emission path so the two look identical downstream.
+	emitInvokeToolUse := func(tu kiroclaude.KiroToolUse) {
+		if isTextBlockOpen && contentBlockIndex >= 0 {
+			blockStop := kiroclaude.BuildClaudeContentBlockStopEvent(contentBlockIndex)
+			sseData := sdktranslator.TranslateStream(ctx, sdktranslator.FromString("kiro"), targetFormat, model, originalReq, claudeBody, blockStop, &translatorParam)
+			for _, chunk := range sseData {
+				enqueueTranslatedSSE(out, chunk)
+			}
+			isTextBlockOpen = false
+		}
+
+		hasToolUses = true
+		contentBlockIndex++
+		blockStart := kiroclaude.BuildClaudeContentBlockStartEvent(contentBlockIndex, "tool_use", tu.ToolUseID, tu.Name)
+		sseData := sdktranslator.TranslateStream(ctx, sdktranslator.FromString("kiro"), targetFormat, model, originalReq, claudeBody, blockStart, &translatorParam)
+		for _, chunk := range sseData {
+			enqueueTranslatedSSE(out, chunk)
+		}
+
+		if tu.Input != nil {
+			if inputJSON, err := json.Marshal(tu.Input); err == nil {
+				inputDelta := kiroclaude.BuildClaudeInputJsonDeltaEvent(string(inputJSON), contentBlockIndex)
+				sseData = sdktranslator.TranslateStream(ctx, sdktranslator.FromString("kiro"), targetFormat, model, originalReq, claudeBody, inputDelta, &translatorParam)
+				for _, chunk := range sseData {
+					enqueueTranslatedSSE(out, chunk)
+				}
+			} else {
+				log.Debugf("kiro: failed to marshal invoke tool input: %v", err)
+			}
+		}
+
+		blockStop := kiroclaude.BuildClaudeContentBlockStopEvent(contentBlockIndex)
+		sseData = sdktranslator.TranslateStream(ctx, sdktranslator.FromString("kiro"), targetFormat, model, originalReq, claudeBody, blockStop, &translatorParam)
+		for _, chunk := range sseData {
+			enqueueTranslatedSSE(out, chunk)
+		}
+	}
 
 	// Ensure usage is published even on early return
 	defer func() {
@@ -3048,29 +3105,39 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 					isThinkingBlockOpen = false
 				}
 				if contentDelta != "" {
+					// Recover native <invoke> tool calls from the text stream. feedText
+					// is the content with invoke markup removed; feedTools holds any
+					// calls completed by this delta.
+					feedText, feedTools := invokeParser.Feed(contentDelta)
+
 					// When official reasoning events have been seen, strip any
 					// stray thinking tag strings so they don't leak into output.
-					emitText := contentDelta
+					emitText := feedText
 					if hasOfficialReasoningEvent {
 						emitText = strings.ReplaceAll(emitText, kirocommon.ThinkingStartTag, "")
 						emitText = strings.ReplaceAll(emitText, kirocommon.ThinkingEndTag, "")
 					}
-					if emitText == "" {
-						continue
-					}
-					if !isTextBlockOpen {
-						contentBlockIndex++
-						isTextBlockOpen = true
-						blockStart := kiroclaude.BuildClaudeContentBlockStartEvent(contentBlockIndex, "text", "", "")
-						sseData := sdktranslator.TranslateStream(ctx, sdktranslator.FromString("kiro"), targetFormat, model, originalReq, claudeBody, blockStart, &translatorParam)
+					if emitText != "" {
+						if !isTextBlockOpen {
+							contentBlockIndex++
+							isTextBlockOpen = true
+							blockStart := kiroclaude.BuildClaudeContentBlockStartEvent(contentBlockIndex, "text", "", "")
+							sseData := sdktranslator.TranslateStream(ctx, sdktranslator.FromString("kiro"), targetFormat, model, originalReq, claudeBody, blockStart, &translatorParam)
+							for _, chunk := range sseData {
+								enqueueTranslatedSSE(out, chunk)
+							}
+						}
+						claudeEvent := kiroclaude.BuildClaudeStreamEvent(emitText, contentBlockIndex)
+						sseData := sdktranslator.TranslateStream(ctx, sdktranslator.FromString("kiro"), targetFormat, model, originalReq, claudeBody, claudeEvent, &translatorParam)
 						for _, chunk := range sseData {
 							enqueueTranslatedSSE(out, chunk)
 						}
 					}
-					claudeEvent := kiroclaude.BuildClaudeStreamEvent(emitText, contentBlockIndex)
-					sseData := sdktranslator.TranslateStream(ctx, sdktranslator.FromString("kiro"), targetFormat, model, originalReq, claudeBody, claudeEvent, &translatorParam)
-					for _, chunk := range sseData {
-						enqueueTranslatedSSE(out, chunk)
+
+					// Emit recovered tool calls as tool_use blocks (after the text that
+					// preceded them).
+					for _, tu := range feedTools {
+						emitInvokeToolUse(tu)
 					}
 				}
 			}
@@ -3440,6 +3507,31 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 		}
 	}
 
+	// Flush any invoke-buffered content. A complete invoke would already have
+	// been emitted by Feed; whatever remains is incomplete markup, surfaced as
+	// plain text so no content is silently dropped.
+	if leftover, flushTools := invokeParser.Flush(); leftover != "" || len(flushTools) > 0 {
+		if leftover != "" {
+			if !isTextBlockOpen {
+				contentBlockIndex++
+				isTextBlockOpen = true
+				blockStart := kiroclaude.BuildClaudeContentBlockStartEvent(contentBlockIndex, "text", "", "")
+				sseData := sdktranslator.TranslateStream(ctx, sdktranslator.FromString("kiro"), targetFormat, model, originalReq, claudeBody, blockStart, &translatorParam)
+				for _, chunk := range sseData {
+					enqueueTranslatedSSE(out, chunk)
+				}
+			}
+			claudeEvent := kiroclaude.BuildClaudeStreamEvent(leftover, contentBlockIndex)
+			sseData := sdktranslator.TranslateStream(ctx, sdktranslator.FromString("kiro"), targetFormat, model, originalReq, claudeBody, claudeEvent, &translatorParam)
+			for _, chunk := range sseData {
+				enqueueTranslatedSSE(out, chunk)
+			}
+		}
+		for _, tu := range flushTools {
+			emitInvokeToolUse(tu)
+		}
+	}
+
 	// Close thinking block if still open at stream end
 	if isThinkingBlockOpen && thinkingBlockIndex >= 0 {
 		blockStop := kiroclaude.BuildClaudeThinkingBlockStopEvent(thinkingBlockIndex)
@@ -3521,6 +3613,11 @@ func (e *KiroExecutor) streamToChannel(ctx context.Context, body io.Reader, out 
 			stopReason = "end_turn"
 			log.Debugf("kiro: streamToChannel using fallback stop_reason: end_turn")
 		}
+	} else if hasToolUses && stopReason == "end_turn" {
+		// Upstream reported end_turn but tool calls were recovered from the text
+		// (native invoke format). The client must run the tools, so report tool_use.
+		stopReason = "tool_use"
+		log.Debugf("kiro: streamToChannel overriding end_turn -> tool_use (recovered tool uses from text)")
 	}
 
 	// Log warning if response was truncated due to max_tokens

--- a/internal/translator/kiro/claude/kiro_claude_request.go
+++ b/internal/translator/kiro/claude/kiro_claude_request.go
@@ -643,13 +643,55 @@ func convertClaudeToolsToKiro(tools gjson.Result) []KiroToolWrapper {
 }
 
 // processMessages processes Claude messages and builds Kiro history
+// normalizeInArraySystemMessages rewrites role:"system" entries inside the
+// messages array as user messages, wrapping their text in <system-reminder>
+// tags (the same convention Claude Code uses for system notes inside user
+// turns). The top-level "system" request field is handled separately and is
+// not affected. Non-text blocks in a system message are dropped, matching how
+// the Claude API treats system message content as plain text.
+func normalizeInArraySystemMessages(messages []gjson.Result) []gjson.Result {
+	for i, msg := range messages {
+		if msg.Get("role").String() != "system" {
+			continue
+		}
+		var text strings.Builder
+		content := msg.Get("content")
+		if content.IsArray() {
+			for _, part := range content.Array() {
+				if part.Get("type").String() == "text" {
+					text.WriteString(part.Get("text").String())
+				}
+			}
+		} else {
+			text.WriteString(content.String())
+		}
+		converted, err := json.Marshal(map[string]interface{}{
+			"role": "user",
+			"content": []map[string]string{
+				{"type": "text", "text": "<system-reminder>\n" + text.String() + "\n</system-reminder>"},
+			},
+		})
+		if err != nil {
+			continue
+		}
+		messages[i] = gjson.ParseBytes(converted)
+	}
+	return messages
+}
+
 func processMessages(messages gjson.Result, modelID, origin string) ([]KiroHistoryMessage, *KiroUserInputMessage, []KiroToolResult) {
 	var history []KiroHistoryMessage
 	var currentUserMsg *KiroUserInputMessage
 	var currentToolResults []KiroToolResult
 
-	// Merge adjacent messages with the same role
-	messagesArray := kirocommon.MergeAdjacentMessages(messages.Array())
+	// Claude Code's mid-conversation-system beta (mid-conversation-system-2026-04-07)
+	// can place role:"system" messages inside the messages array, including as the
+	// final message. Kiro has no system role, so rewrite them as user messages
+	// before merging. Critically, a trailing system message must still produce a
+	// current user message — otherwise no tool specs are attached to
+	// currentMessage.userInputMessageContext and the model, seeing no tools,
+	// hallucinates text-format tool calls instead of emitting toolUseEvents.
+	messagesArray := kirocommon.MergeAdjacentMessages(normalizeInArraySystemMessages(messages.Array()))
 
 	// FIX: Kiro API requires history to start with a user message.
 	// Some clients (e.g., OpenClaw) send conversations starting with an assistant message,

--- a/internal/translator/kiro/claude/kiro_claude_request_test.go
+++ b/internal/translator/kiro/claude/kiro_claude_request_test.go
@@ -106,6 +106,54 @@ func TestBuildKiroPayload_NoToolsNoHistoryToolUse(t *testing.T) {
 	}
 }
 
+// TestBuildKiroPayload_TrailingSystemMessageKeepsTools reproduces the case
+// observed in production: Claude Code's mid-conversation-system beta appends a
+// role:"system" message as the FINAL entry of the messages array. Without
+// normalization the system message is skipped, no current user message is
+// produced, and the converted tools are silently dropped from the payload —
+// the model then hallucinates text-format tool calls.
+//
+// Expected behavior: the trailing system message is carried as user content
+// and the client-declared tools land on
+// currentMessage.userInputMessageContext.tools.
+func TestBuildKiroPayload_TrailingSystemMessageKeepsTools(t *testing.T) {
+	claudeReq := `{
+		"model": "claude-opus-4-8",
+		"max_tokens": 1024,
+		"tools": [
+			{"name": "Grep", "description": "search", "input_schema": {"type": "object", "properties": {"pattern": {"type": "string"}}}}
+		],
+		"messages": [
+			{"role": "user", "content": "investigate the revision conflict"},
+			{"role": "system", "content": "Available agent types for the Agent tool: ..."}
+		]
+	}`
+
+	out, _ := BuildKiroPayload([]byte(claudeReq), "claude-opus-4-8", "arn:test", "test", true, false, http.Header{}, nil)
+	if len(out) == 0 {
+		t.Fatal("expected non-empty payload")
+	}
+
+	tools := gjson.GetBytes(out, "conversationState.currentMessage.userInputMessage.userInputMessageContext.tools")
+	if !tools.IsArray() || len(tools.Array()) != 1 {
+		t.Fatalf("expected exactly 1 tool on currentMessage, got: %s", tools.Raw)
+	}
+	if got := tools.Array()[0].Get("toolSpecification.name").String(); got != "Grep" {
+		t.Fatalf("expected tool named 'Grep', got %q", got)
+	}
+
+	content := gjson.GetBytes(out, "conversationState.currentMessage.userInputMessage.content").String()
+	if !strings.Contains(content, "investigate the revision conflict") {
+		t.Fatalf("expected user text in current message content, got: %q", content)
+	}
+	if !strings.Contains(content, "Available agent types for the Agent tool") {
+		t.Fatalf("expected system message text carried into current message content, got: %q", content)
+	}
+	if !strings.Contains(content, "<system-reminder>") {
+		t.Fatalf("expected system text wrapped in <system-reminder> tags, got: %q", content)
+	}
+}
+
 // TestSynthesizeToolSpecsFromHistory_Dedup ensures repeated tool names yield a
 // single stub.
 func TestSynthesizeToolSpecsFromHistory_Dedup(t *testing.T) {

--- a/internal/translator/kiro/claude/kiro_claude_tools.go
+++ b/internal/translator/kiro/claude/kiro_claude_tools.go
@@ -4,6 +4,7 @@ package claude
 
 import (
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -531,4 +532,359 @@ func DeduplicateToolUses(toolUses []KiroToolUse) []KiroToolUse {
 	}
 
 	return unique
+}
+
+// Kiro IDE native tool-call format
+// ---------------------------------
+// When the request uses the AI_EDITOR origin, the Kiro-backed model frequently
+// emits tool calls as inline text in Claude's XML function-calling format
+// instead of structured toolUseEvent events:
+//
+//	<invoke name="grepSearch">
+//	<parameter name="query">foo|bar</parameter>
+//	<parameter name="includePattern">apps/**</parameter>
+//	</invoke>
+//
+// It also uses Kiro IDE's own tool names (grepSearch, readFile, fileSearch,
+// readMultipleFiles, listDirectory, fsRead, ...) rather than the tool names the
+// client actually declared (Read, Grep, Glob, Bash, ...). If left as plain text
+// the client never sees a tool_use block, so no tool ever runs and the model
+// starts hallucinating fake tool results. The helpers below recover these calls
+// by parsing the invoke XML and mapping the native names onto the client's
+// canonical tools.
+
+var (
+	// invokeOpenPattern matches the invoke opening tag and captures the tool name.
+	// The antml: namespace prefix is tolerated for compatibility.
+	invokeOpenPattern = regexp.MustCompile(`<(?:antml:)?invoke\s+name="([^"]+)"\s*>`)
+	// invokeCloseTag is the literal closing tag (with and without namespace).
+	invokeCloseTag      = "</invoke>"
+	invokeCloseTagAntml = "</antml:invoke>"
+	// invokeStartTag / invokeStartTagAntml are the prefixes used for cross-chunk
+	// boundary detection while streaming.
+	invokeStartTag      = "<invoke"
+	invokeStartTagAntml = "<antml:invoke"
+	// parameterPattern matches a single <parameter name="k">value</parameter>.
+	parameterPattern = regexp.MustCompile(`(?s)<(?:antml:)?parameter\s+name="([^"]+)"\s*>(.*?)</(?:antml:)?parameter>`)
+)
+
+// parseInvokeBlock parses a single complete <invoke ...>...</invoke> block and
+// returns the native tool name plus its parameters. Parameter values are
+// JSON-decoded when possible so arrays (paths) and numbers (depth) keep their
+// types; otherwise they remain strings. Returns ok=false when the block is
+// malformed (missing name or unparseable opening tag).
+func parseInvokeBlock(block string) (name string, params map[string]interface{}, ok bool) {
+	m := invokeOpenPattern.FindStringSubmatch(block)
+	if m == nil {
+		return "", nil, false
+	}
+	name = m[1]
+
+	params = make(map[string]interface{})
+	for _, pm := range parameterPattern.FindAllStringSubmatch(block, -1) {
+		key := pm[1]
+		raw := strings.TrimSpace(pm[2])
+		// Preserve arrays/objects/numbers/bools by attempting a JSON decode first.
+		var decoded interface{}
+		if raw != "" && json.Unmarshal([]byte(raw), &decoded) == nil {
+			params[key] = decoded
+		} else {
+			params[key] = raw
+		}
+	}
+	return name, params, true
+}
+
+// firstStringParam returns the first usable string value for the given keys.
+// It accepts either a plain string or a single-element array (for paths).
+func firstStringParam(params map[string]interface{}, keys ...string) string {
+	for _, k := range keys {
+		v, exists := params[k]
+		if !exists {
+			continue
+		}
+		switch t := v.(type) {
+		case string:
+			if t != "" {
+				return t
+			}
+		case []interface{}:
+			for _, item := range t {
+				if s, ok := item.(string); ok && s != "" {
+					return s
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// intParam returns the integer value of a parameter, tolerating JSON numbers
+// and numeric strings. Returns 0 when absent or unparseable.
+func intParam(params map[string]interface{}, keys ...string) int {
+	for _, k := range keys {
+		v, exists := params[k]
+		if !exists {
+			continue
+		}
+		switch t := v.(type) {
+		case float64:
+			return int(t)
+		case string:
+			var n int
+			if _, err := fmt.Sscanf(t, "%d", &n); err == nil {
+				return n
+			}
+		}
+	}
+	return 0
+}
+
+// mapKiroNativeTool maps a Kiro IDE native tool call onto the client's
+// canonical Claude tool name and input. Unknown native tools are passed through
+// unchanged so the client can surface a meaningful "unknown tool" error.
+func mapKiroNativeTool(name string, params map[string]interface{}) (string, map[string]interface{}) {
+	switch name {
+	case "readFile", "fsRead":
+		return "Read", map[string]interface{}{
+			"file_path": firstStringParam(params, "path", "file_path", "filePath"),
+		}
+	case "readMultipleFiles":
+		return "Read", map[string]interface{}{
+			"file_path": firstStringParam(params, "paths", "path", "file_path"),
+		}
+	case "grepSearch":
+		input := map[string]interface{}{
+			"pattern": firstStringParam(params, "query", "pattern"),
+		}
+		if glob := firstStringParam(params, "includePattern", "include", "glob"); glob != "" {
+			input["glob"] = glob
+		}
+		return "Grep", input
+	case "fileSearch":
+		return "Glob", map[string]interface{}{
+			"pattern": firstStringParam(params, "query", "pattern"),
+		}
+	case "listDirectory":
+		path := firstStringParam(params, "path", "dir", "directory")
+		if path == "" {
+			path = "."
+		}
+		command := "ls " + path
+		if intParam(params, "depth") > 1 {
+			command = "ls -R " + path
+		}
+		return "Bash", map[string]interface{}{"command": command}
+	case "writeFile", "fsWrite", "createFile":
+		return "Write", map[string]interface{}{
+			"file_path": firstStringParam(params, "path", "file_path", "filePath"),
+			"content":   firstStringParam(params, "content", "fileText", "text", "file_text"),
+		}
+	case "strReplace", "strReplaceEditor", "editFile", "replaceInFile":
+		return "Edit", map[string]interface{}{
+			"file_path":  firstStringParam(params, "path", "file_path", "filePath"),
+			"old_string": firstStringParam(params, "oldStr", "old_string", "old_str"),
+			"new_string": firstStringParam(params, "newStr", "new_string", "new_str"),
+		}
+	case "executeBash", "runCommand", "executeCommand", "bash", "shell":
+		return "Bash", map[string]interface{}{
+			"command": firstStringParam(params, "command", "cmd"),
+		}
+	default:
+		// Unrecognized native tool: pass through with original name/params.
+		return name, params
+	}
+}
+
+// buildInvokeToolUse converts a parsed native invoke block into a KiroToolUse,
+// applying the native->client tool name mapping and deduplication.
+func buildInvokeToolUse(block string, processedIDs map[string]bool) *KiroToolUse {
+	nativeName, params, ok := parseInvokeBlock(block)
+	if !ok {
+		return nil
+	}
+	clientName, input := mapKiroNativeTool(nativeName, params)
+
+	inputJSON, _ := json.Marshal(input)
+	dedupeKey := clientName + ":" + string(inputJSON)
+	if processedIDs != nil {
+		if processedIDs[dedupeKey] {
+			log.Debugf("kiro: skipping duplicate invoke tool call: %s", clientName)
+			return nil
+		}
+		processedIDs[dedupeKey] = true
+	}
+
+	toolUseID := "toolu_" + uuid.New().String()[:12]
+	log.Infof("kiro: extracted invoke tool call: %s -> %s (ID: %s)", nativeName, clientName, toolUseID)
+	return &KiroToolUse{
+		ToolUseID: toolUseID,
+		Name:      clientName,
+		Input:     input,
+	}
+}
+
+// findInvokeClose returns the index just past the end of the first invoke
+// closing tag at or after from. The boolean reports whether one was found.
+func findInvokeClose(s string, from int) (int, bool) {
+	idx := -1
+	if i := strings.Index(s[from:], invokeCloseTag); i >= 0 {
+		idx = from + i + len(invokeCloseTag)
+	}
+	if i := strings.Index(s[from:], invokeCloseTagAntml); i >= 0 {
+		if end := from + i + len(invokeCloseTagAntml); idx == -1 || end < idx {
+			idx = end
+		}
+	}
+	if idx < 0 {
+		return 0, false
+	}
+	return idx, true
+}
+
+// findInvokeOpen returns the index of the first invoke opening tag ("<invoke"
+// or "<antml:invoke") at or after from. The boolean reports whether one was found.
+func findInvokeOpen(s string, from int) (int, bool) {
+	idx := -1
+	if i := strings.Index(s[from:], invokeStartTag); i >= 0 {
+		idx = from + i
+	}
+	if i := strings.Index(s[from:], invokeStartTagAntml); i >= 0 {
+		if idx == -1 || from+i < idx {
+			idx = from + i
+		}
+	}
+	if idx < 0 {
+		return 0, false
+	}
+	return idx, true
+}
+
+// pendingInvokeSuffix returns the length of the trailing partial invoke-start
+// tag (e.g. "<inv", "<antml:in") that should be held back for the next chunk.
+func pendingInvokeSuffix(s string) int {
+	a := PendingTagSuffix(s, invokeStartTag)
+	b := PendingTagSuffix(s, invokeStartTagAntml)
+	if b > a {
+		return b
+	}
+	return a
+}
+
+// ParseInvokeToolCalls extracts complete <invoke name="...">...</invoke> blocks
+// from a full (non-streaming) response body. It returns the text with the
+// invoke blocks removed and the recovered tool calls (mapped to client tools).
+// Incomplete/trailing invoke markup is left in the text unchanged.
+func ParseInvokeToolCalls(text string, processedIDs map[string]bool) (string, []KiroToolUse) {
+	if !strings.Contains(text, invokeStartTag) && !strings.Contains(text, invokeStartTagAntml) {
+		return text, nil
+	}
+
+	var toolUses []KiroToolUse
+	var clean strings.Builder
+
+	remaining := text
+	for {
+		open, hasOpen := findInvokeOpen(remaining, 0)
+		if !hasOpen {
+			clean.WriteString(remaining)
+			break
+		}
+		// Emit text before the invoke block.
+		clean.WriteString(remaining[:open])
+
+		closeIdx, hasClose := findInvokeClose(remaining, open)
+		if !hasClose {
+			// No closing tag yet (truncated response) - keep the rest as text.
+			clean.WriteString(remaining[open:])
+			break
+		}
+
+		block := remaining[open:closeIdx]
+		if tu := buildInvokeToolUse(block, processedIDs); tu != nil {
+			toolUses = append(toolUses, *tu)
+		}
+		remaining = remaining[closeIdx:]
+	}
+
+	return clean.String(), toolUses
+}
+
+// InvokeStreamParser incrementally recovers <invoke> tool calls from a stream
+// of content deltas. Text outside invoke blocks is passed through as ordinary
+// text; complete invoke blocks are converted into tool calls. Partial tags at
+// chunk boundaries are buffered until the closing tag arrives.
+type InvokeStreamParser struct {
+	buf          strings.Builder
+	processedIDs map[string]bool
+}
+
+// NewInvokeStreamParser creates a streaming invoke parser. processedIDs is
+// shared with the structured tool-use dedup map so the same call is not emitted
+// twice across the text and structured channels.
+func NewInvokeStreamParser(processedIDs map[string]bool) *InvokeStreamParser {
+	return &InvokeStreamParser{processedIDs: processedIDs}
+}
+
+// Feed consumes one content delta and returns any plain text that is safe to
+// emit now plus any tool calls completed by this delta.
+func (p *InvokeStreamParser) Feed(delta string) (string, []KiroToolUse) {
+	p.buf.WriteString(delta)
+
+	var textOut strings.Builder
+	var toolUses []KiroToolUse
+
+	for {
+		s := p.buf.String()
+		open, hasOpen := findInvokeOpen(s, 0)
+		if !hasOpen {
+			// No invoke tag. Hold back a trailing partial tag, emit the rest.
+			hold := pendingInvokeSuffix(s)
+			if hold > 0 {
+				textOut.WriteString(s[:len(s)-hold])
+				p.buf.Reset()
+				p.buf.WriteString(s[len(s)-hold:])
+			} else {
+				textOut.WriteString(s)
+				p.buf.Reset()
+			}
+			break
+		}
+
+		// Emit text before the invoke block.
+		if open > 0 {
+			textOut.WriteString(s[:open])
+		}
+
+		closeIdx, hasClose := findInvokeClose(s, open)
+		if !hasClose {
+			// Invoke not complete yet - keep buffering from the open tag.
+			p.buf.Reset()
+			p.buf.WriteString(s[open:])
+			break
+		}
+
+		block := s[open:closeIdx]
+		if tu := buildInvokeToolUse(block, p.processedIDs); tu != nil {
+			toolUses = append(toolUses, *tu)
+		}
+		p.buf.Reset()
+		p.buf.WriteString(s[closeIdx:])
+	}
+
+	return textOut.String(), toolUses
+}
+
+// Flush emits any buffered content at end of stream. An incomplete invoke is
+// surfaced as plain text so no content is silently dropped.
+func (p *InvokeStreamParser) Flush() (string, []KiroToolUse) {
+	s := p.buf.String()
+	p.buf.Reset()
+	if s == "" {
+		return "", nil
+	}
+	// A complete invoke could in theory sit in the buffer if the closing tag was
+	// the very last thing buffered; Feed already handles those, so whatever
+	// remains here is incomplete markup -> emit as text.
+	return s, nil
 }

--- a/internal/translator/kiro/claude/kiro_claude_tools_test.go
+++ b/internal/translator/kiro/claude/kiro_claude_tools_test.go
@@ -1,0 +1,333 @@
+package claude
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseInvokeBlock(t *testing.T) {
+	tests := []struct {
+		name       string
+		block      string
+		wantName   string
+		wantParams map[string]interface{}
+		wantOK     bool
+	}{
+		{
+			name: "simple string params",
+			block: `<invoke name="grepSearch">
+<parameter name="query">卸载|uninstall</parameter>
+<parameter name="includePattern">apps/desktop/**/*.{ts,tsx}</parameter>
+</invoke>`,
+			wantName: "grepSearch",
+			wantParams: map[string]interface{}{
+				"query":          "卸载|uninstall",
+				"includePattern": "apps/desktop/**/*.{ts,tsx}",
+			},
+			wantOK: true,
+		},
+		{
+			name: "json array param",
+			block: `<invoke name="readMultipleFiles">
+<parameter name="paths">["a.ts","b.ts"]</parameter>
+</invoke>`,
+			wantName: "readMultipleFiles",
+			wantParams: map[string]interface{}{
+				"paths": []interface{}{"a.ts", "b.ts"},
+			},
+			wantOK: true,
+		},
+		{
+			name: "numeric param",
+			block: `<invoke name="listDirectory">
+<parameter name="path">src</parameter>
+<parameter name="depth">2</parameter>
+</invoke>`,
+			wantName: "listDirectory",
+			wantParams: map[string]interface{}{
+				"path":  "src",
+				"depth": float64(2),
+			},
+			wantOK: true,
+		},
+		{
+			name: "antml namespace prefix",
+			block: `<antml:invoke name="readFile">
+<antml:parameter name="path">main.go</antml:parameter>
+</antml:invoke>`,
+			wantName:   "readFile",
+			wantParams: map[string]interface{}{"path": "main.go"},
+			wantOK:     true,
+		},
+		{
+			name:     "missing name",
+			block:    `<invoke><parameter name="x">y</parameter></invoke>`,
+			wantName: "",
+			wantOK:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, params, ok := parseInvokeBlock(tt.block)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if name != tt.wantName {
+				t.Fatalf("name = %q, want %q", name, tt.wantName)
+			}
+			if !reflect.DeepEqual(params, tt.wantParams) {
+				t.Fatalf("params = %#v, want %#v", params, tt.wantParams)
+			}
+		})
+	}
+}
+
+func TestMapKiroNativeTool(t *testing.T) {
+	tests := []struct {
+		name       string
+		nativeName string
+		params     map[string]interface{}
+		wantName   string
+		wantInput  map[string]interface{}
+	}{
+		{
+			name:       "readFile -> Read",
+			nativeName: "readFile",
+			params:     map[string]interface{}{"path": "a.ts"},
+			wantName:   "Read",
+			wantInput:  map[string]interface{}{"file_path": "a.ts"},
+		},
+		{
+			name:       "fsRead -> Read",
+			nativeName: "fsRead",
+			params:     map[string]interface{}{"path": "a.ts"},
+			wantName:   "Read",
+			wantInput:  map[string]interface{}{"file_path": "a.ts"},
+		},
+		{
+			name:       "readMultipleFiles -> Read (first path)",
+			nativeName: "readMultipleFiles",
+			params:     map[string]interface{}{"paths": []interface{}{"a.ts", "b.ts"}},
+			wantName:   "Read",
+			wantInput:  map[string]interface{}{"file_path": "a.ts"},
+		},
+		{
+			name:       "grepSearch -> Grep with glob",
+			nativeName: "grepSearch",
+			params:     map[string]interface{}{"query": "foo", "includePattern": "apps/**"},
+			wantName:   "Grep",
+			wantInput:  map[string]interface{}{"pattern": "foo", "glob": "apps/**"},
+		},
+		{
+			name:       "grepSearch -> Grep without glob",
+			nativeName: "grepSearch",
+			params:     map[string]interface{}{"query": "foo"},
+			wantName:   "Grep",
+			wantInput:  map[string]interface{}{"pattern": "foo"},
+		},
+		{
+			name:       "fileSearch -> Glob",
+			nativeName: "fileSearch",
+			params:     map[string]interface{}{"query": "*.vue"},
+			wantName:   "Glob",
+			wantInput:  map[string]interface{}{"pattern": "*.vue"},
+		},
+		{
+			name:       "listDirectory -> Bash ls",
+			nativeName: "listDirectory",
+			params:     map[string]interface{}{"path": "src"},
+			wantName:   "Bash",
+			wantInput:  map[string]interface{}{"command": "ls src"},
+		},
+		{
+			name:       "listDirectory depth>1 -> Bash ls -R",
+			nativeName: "listDirectory",
+			params:     map[string]interface{}{"path": "src", "depth": float64(3)},
+			wantName:   "Bash",
+			wantInput:  map[string]interface{}{"command": "ls -R src"},
+		},
+		{
+			name:       "writeFile -> Write",
+			nativeName: "writeFile",
+			params:     map[string]interface{}{"path": "a.ts", "content": "hello"},
+			wantName:   "Write",
+			wantInput:  map[string]interface{}{"file_path": "a.ts", "content": "hello"},
+		},
+		{
+			name:       "strReplaceEditor -> Edit",
+			nativeName: "strReplaceEditor",
+			params:     map[string]interface{}{"path": "a.ts", "oldStr": "x", "newStr": "y"},
+			wantName:   "Edit",
+			wantInput:  map[string]interface{}{"file_path": "a.ts", "old_string": "x", "new_string": "y"},
+		},
+		{
+			name:       "executeBash -> Bash",
+			nativeName: "executeBash",
+			params:     map[string]interface{}{"command": "ls -la"},
+			wantName:   "Bash",
+			wantInput:  map[string]interface{}{"command": "ls -la"},
+		},
+		{
+			name:       "unknown passes through",
+			nativeName: "someCustomTool",
+			params:     map[string]interface{}{"a": "b"},
+			wantName:   "someCustomTool",
+			wantInput:  map[string]interface{}{"a": "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotInput := mapKiroNativeTool(tt.nativeName, tt.params)
+			if gotName != tt.wantName {
+				t.Fatalf("name = %q, want %q", gotName, tt.wantName)
+			}
+			if !reflect.DeepEqual(gotInput, tt.wantInput) {
+				t.Fatalf("input = %#v, want %#v", gotInput, tt.wantInput)
+			}
+		})
+	}
+}
+
+func TestParseInvokeToolCalls(t *testing.T) {
+	t.Run("extracts invoke and cleans text", func(t *testing.T) {
+		text := "Let me search.\n\n<invoke name=\"grepSearch\">\n<parameter name=\"query\">foo</parameter>\n</invoke>\n"
+		clean, toolUses := ParseInvokeToolCalls(text, nil)
+		if len(toolUses) != 1 {
+			t.Fatalf("expected 1 tool use, got %d", len(toolUses))
+		}
+		if toolUses[0].Name != "Grep" {
+			t.Fatalf("tool name = %q, want Grep", toolUses[0].Name)
+		}
+		if toolUses[0].Input["pattern"] != "foo" {
+			t.Fatalf("pattern = %#v, want foo", toolUses[0].Input["pattern"])
+		}
+		if strings.Contains(clean, "invoke") {
+			t.Fatalf("clean text still contains invoke markup: %q", clean)
+		}
+		if !strings.Contains(clean, "Let me search.") {
+			t.Fatalf("clean text lost leading content: %q", clean)
+		}
+	})
+
+	t.Run("multiple invokes", func(t *testing.T) {
+		text := `a<invoke name="readFile"><parameter name="path">x</parameter></invoke>b<invoke name="fileSearch"><parameter name="query">y</parameter></invoke>c`
+		clean, toolUses := ParseInvokeToolCalls(text, nil)
+		if len(toolUses) != 2 {
+			t.Fatalf("expected 2 tool uses, got %d", len(toolUses))
+		}
+		if toolUses[0].Name != "Read" || toolUses[1].Name != "Glob" {
+			t.Fatalf("names = %q,%q want Read,Glob", toolUses[0].Name, toolUses[1].Name)
+		}
+		if clean != "abc" {
+			t.Fatalf("clean = %q, want %q", clean, "abc")
+		}
+	})
+
+	t.Run("no invoke returns input unchanged", func(t *testing.T) {
+		text := "plain text with no tool calls"
+		clean, toolUses := ParseInvokeToolCalls(text, nil)
+		if clean != text {
+			t.Fatalf("clean = %q, want unchanged %q", clean, text)
+		}
+		if len(toolUses) != 0 {
+			t.Fatalf("expected 0 tool uses, got %d", len(toolUses))
+		}
+	})
+
+	t.Run("dedupes identical calls", func(t *testing.T) {
+		text := `<invoke name="readFile"><parameter name="path">x</parameter></invoke><invoke name="readFile"><parameter name="path">x</parameter></invoke>`
+		_, toolUses := ParseInvokeToolCalls(text, map[string]bool{})
+		if len(toolUses) != 1 {
+			t.Fatalf("expected 1 deduped tool use, got %d", len(toolUses))
+		}
+	})
+
+	t.Run("incomplete invoke left as text", func(t *testing.T) {
+		text := `before <invoke name="readFile"><parameter name="path">x</parameter>`
+		clean, toolUses := ParseInvokeToolCalls(text, nil)
+		if len(toolUses) != 0 {
+			t.Fatalf("expected 0 tool uses for incomplete invoke, got %d", len(toolUses))
+		}
+		if !strings.Contains(clean, "<invoke") {
+			t.Fatalf("incomplete invoke should remain as text, got %q", clean)
+		}
+	})
+}
+
+func TestInvokeStreamParser(t *testing.T) {
+	t.Run("single chunk", func(t *testing.T) {
+		p := NewInvokeStreamParser(nil)
+		text, tools := p.Feed(`hi <invoke name="readFile"><parameter name="path">x</parameter></invoke>`)
+		if text != "hi " {
+			t.Fatalf("text = %q, want %q", text, "hi ")
+		}
+		if len(tools) != 1 || tools[0].Name != "Read" {
+			t.Fatalf("tools = %#v", tools)
+		}
+	})
+
+	t.Run("across chunk boundaries", func(t *testing.T) {
+		p := NewInvokeStreamParser(nil)
+		var allText strings.Builder
+		var allTools []KiroToolUse
+		chunks := []string{
+			"searching <inv",
+			`oke name="grepSea`,
+			`rch"><parameter name="qu`,
+			`ery">foo|bar</par`,
+			`ameter></inv`,
+			`oke> done`,
+		}
+		for _, c := range chunks {
+			text, tools := p.Feed(c)
+			allText.WriteString(text)
+			allTools = append(allTools, tools...)
+		}
+		text, tools := p.Flush()
+		allText.WriteString(text)
+		allTools = append(allTools, tools...)
+
+		if len(allTools) != 1 {
+			t.Fatalf("expected 1 tool, got %d (%#v)", len(allTools), allTools)
+		}
+		if allTools[0].Name != "Grep" || allTools[0].Input["pattern"] != "foo|bar" {
+			t.Fatalf("tool = %#v", allTools[0])
+		}
+		got := allText.String()
+		if strings.Contains(got, "invoke") {
+			t.Fatalf("text leaked invoke markup: %q", got)
+		}
+		if !strings.Contains(got, "searching") || !strings.Contains(got, "done") {
+			t.Fatalf("text missing surrounding content: %q", got)
+		}
+	})
+
+	t.Run("incomplete invoke flushed as text", func(t *testing.T) {
+		p := NewInvokeStreamParser(nil)
+		p.Feed(`start <invoke name="readFile"><parameter name="path">x`)
+		text, tools := p.Flush()
+		if len(tools) != 0 {
+			t.Fatalf("expected 0 tools, got %d", len(tools))
+		}
+		if !strings.Contains(text, "<invoke") {
+			t.Fatalf("incomplete invoke should be flushed as text, got %q", text)
+		}
+	})
+
+	t.Run("text only passes through", func(t *testing.T) {
+		p := NewInvokeStreamParser(nil)
+		text, tools := p.Feed("just some normal content")
+		if text != "just some normal content" {
+			t.Fatalf("text = %q", text)
+		}
+		if len(tools) != 0 {
+			t.Fatalf("expected 0 tools, got %d", len(tools))
+		}
+	})
+}


### PR DESCRIPTION
## Summary

The Kiro-backed model (AI_EDITOR origin) frequently emits tool calls as inline text in Claude's XML `<invoke name="...">` format — using Kiro IDE's own tool names — instead of structured `toolUseEvent` events. Left as plain text, the client never sees a `tool_use` block, so no tool runs and the model starts hallucinating fake tool results. This PR recovers those calls and fixes the upstream condition that triggers them.

## Changes

**Native `<invoke>` tool-call recovery** (`kiro_claude_tools.go`, `kiro_executor.go`)
- Parse `<invoke>` / `<parameter>` blocks (`antml:` namespace tolerated), preserving JSON types for array/number params.
- Map native names onto the client's canonical Claude tools:
  - `readFile`/`fsRead`/`readMultipleFiles` → `Read`
  - `grepSearch` → `Grep` (with `includePattern` → `glob`)
  - `fileSearch` → `Glob`
  - `listDirectory` → `Bash` (`ls` / `ls -R`)
  - `writeFile`/`fsWrite`/`createFile` → `Write`
  - `strReplaceEditor`/`editFile` → `Edit`
  - `executeBash`/`runCommand` → `Bash`
  - unknown tools pass through unchanged.
- Wired into both the buffered (`parseEventStream`) and streaming (`streamToChannel`) paths. `InvokeStreamParser` buffers partial tags across chunk boundaries and flushes incomplete markup as text so nothing is dropped.
- Override `end_turn` → `tool_use` when calls are recovered, so the client actually runs them. Dedup is shared with the structured tool-use path.

**Trailing in-array system message normalization** (`kiro_claude_request.go`)
- Claude Code's mid-conversation-system beta (`mid-conversation-system-2026-04-07`) can place `role:"system"` messages inside the messages array, including as the final entry. Kiro has no system role, so these are rewritten as user content wrapped in `<system-reminder>` tags before merging.
- Critically, a trailing system message must still produce a current user message — otherwise no tool specs attach to `currentMessage.userInputMessageContext` and the model, seeing no tools, hallucinates text-format tool calls (the root cause of the recovery above).

**New Kiro model aliases + definitions** (`oauth_model_alias_defaults.go`, `model_definitions.go`)
- Claude Sonnet 5, Opus 4.8, Fable 5.

## Testing

- `gofmt -l internal/` — clean
- `go build ./cmd/server` — passes
- `go test ./internal/translator/kiro/... ./internal/runtime/executor/... ./internal/config/... ./internal/registry/...` — passes
- New unit tests: `kiro_claude_tools_test.go` (parse/map/stream), plus `TestBuildKiroPayload_TrailingSystemMessageKeepsTools`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)