### PR TITLE
fix(cursor): cold-continue OpenAI tool results

### DIFF
--- a/internal/runtime/executor/cursor_executor.go
+++ b/internal/runtime/executor/cursor_executor.go
@@ -48,7 +48,8 @@ type CursorExecutor struct {
 	cfg           *config.Config
 	mu            sync.Mutex
 	sessions      map[string]*cursorSession
-	checkpoints   map[string]*savedCheckpoint // keyed by conversationId
+	checkpoints   map[string]*savedCheckpoint  // keyed by conversationId
+	stateOwners   map[string]*cursorStateOwner // rejects writes from retired conversation owners
 	openStream    func(string) (cursorStream, error)
 	processFrames cursorFrameProcessor
 }
@@ -59,6 +60,11 @@ type savedCheckpoint struct {
 	blobStore map[string][]byte // blobs referenced by the checkpoint
 	authID    string            // auth that produced this checkpoint (checkpoint is auth-specific)
 	updatedAt time.Time
+}
+
+type cursorStateOwner struct {
+	cancel context.CancelFunc
+	stream cursorStream
 }
 
 type cursorStream interface {
@@ -83,16 +89,18 @@ type cursorFrameProcessor func(
 ) error
 
 type cursorSession struct {
-	stream       cursorStream
-	blobStore    map[string][]byte
-	mcpTools     []cursorproto.McpToolDef
-	pending      []pendingMcpExec
-	cancel       context.CancelFunc // cancels the session-scoped heartbeat (NOT tied to HTTP request)
-	createdAt    time.Time
-	authID       string                                                                // auth file ID that created this session (for multi-account isolation)
-	toolResultCh chan []toolResultInfo                                                 // receives tool results from the next HTTP request
-	resumeOutCh  chan cliproxyexecutor.StreamChunk                                     // output channel for resumed response
-	switchOutput func(ch chan cliproxyexecutor.StreamChunk, outputCtx context.Context) // switch output channel/request context
+	stream         cursorStream
+	blobStore      map[string][]byte
+	mcpTools       []cursorproto.McpToolDef
+	pending        []pendingMcpExec
+	cancel         context.CancelFunc // cancels the session-scoped heartbeat (NOT tied to HTTP request)
+	createdAt      time.Time
+	authID         string                                                                // auth file ID that created this session (for multi-account isolation)
+	toolResultCh   chan []toolResultInfo                                                 // receives tool results from the next HTTP request
+	resumeOutCh    chan cliproxyexecutor.StreamChunk                                     // output channel for resumed response
+	switchOutput   func(ch chan cliproxyexecutor.StreamChunk, outputCtx context.Context) // switch output channel/request context
+	conversationID string
+	owner          *cursorStateOwner
 }
 
 type pendingMcpExec struct {
@@ -109,6 +117,7 @@ func NewCursorExecutor(cfg *config.Config) *CursorExecutor {
 		cfg:         cfg,
 		sessions:    make(map[string]*cursorSession),
 		checkpoints: make(map[string]*savedCheckpoint),
+		stateOwners: make(map[string]*cursorStateOwner),
 		openStream: func(accessToken string) (cursorStream, error) {
 			return openCursorH2Stream(accessToken)
 		},
@@ -169,6 +178,99 @@ func (e *CursorExecutor) findSessionByConversationLocked(convId string) string {
 		}
 	}
 	return ""
+}
+
+// retireConversationState atomically makes all existing owners for a
+// conversation stale before releasing their streams. A late checkpoint write
+// from a canceled processor is rejected after its ownership token is removed.
+func (e *CursorExecutor) retireConversationState(conversationID string) {
+	var retired []*cursorSession
+	var owner *cursorStateOwner
+	suffix := ":" + conversationID
+
+	e.mu.Lock()
+	owner = e.stateOwners[conversationID]
+	delete(e.stateOwners, conversationID)
+	for key, session := range e.sessions {
+		if strings.HasSuffix(key, suffix) {
+			delete(e.sessions, key)
+			retired = append(retired, session)
+		}
+	}
+	delete(e.checkpoints, conversationID)
+	e.mu.Unlock()
+
+	if owner != nil {
+		if owner.cancel != nil {
+			owner.cancel()
+		}
+		if owner.stream != nil {
+			owner.stream.Close()
+		}
+	}
+	for _, session := range retired {
+		if owner != nil && session.owner == owner {
+			continue
+		}
+		if session.cancel != nil {
+			session.cancel()
+		}
+		if session.stream != nil {
+			session.stream.Close()
+		}
+	}
+}
+
+func (e *CursorExecutor) beginConversationStream(conversationID string) *cursorStateOwner {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	owner := &cursorStateOwner{}
+	e.stateOwners[conversationID] = owner
+	return owner
+}
+
+func (e *CursorExecutor) releaseConversationStream(conversationID string, owner *cursorStateOwner) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.stateOwners[conversationID] == owner {
+		delete(e.stateOwners, conversationID)
+	}
+}
+
+func (e *CursorExecutor) attachConversationStream(conversationID string, owner *cursorStateOwner, cancel context.CancelFunc, stream cursorStream) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.stateOwners[conversationID] != owner {
+		return false
+	}
+	owner.cancel = cancel
+	owner.stream = stream
+	return true
+}
+
+func (e *CursorExecutor) publishConversationSession(conversationID, sessionKey string, owner *cursorStateOwner, session *cursorSession, replace bool) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.stateOwners[conversationID] != owner {
+		return false
+	}
+	if _, exists := e.sessions[sessionKey]; exists && !replace {
+		return false
+	}
+	session.conversationID = conversationID
+	session.owner = owner
+	e.sessions[sessionKey] = session
+	return true
+}
+
+func (e *CursorExecutor) saveCheckpoint(conversationID string, owner *cursorStateOwner, checkpoint *savedCheckpoint) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.stateOwners[conversationID] != owner {
+		return false
+	}
+	e.checkpoints[conversationID] = checkpoint
+	return true
 }
 
 // cursorStatusErr implements the StatusError and RetryAfter interfaces so the
@@ -328,6 +430,7 @@ func (e *CursorExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	conversationID := deriveConversationId(apiKeyFromContext(ctx), sessionID, parsed.SystemPrompt)
 	openAICompatible := isOpenAICompatibleSourceFormat(from)
 	if openAICompatible && len(parsed.ToolResults) > 0 {
+		e.retireConversationState(conversationID)
 		log.Infof("cursor: using cold continuation for %d non-stream tool result(s)", len(parsed.ToolResults))
 		flattenConversationIntoUserText(parsed)
 	}
@@ -488,24 +591,7 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	needsTranslate := from.String() != "" && from.String() != "openai"
 
 	if coldToolContinuation {
-		e.mu.Lock()
-		if session, hasSession := e.sessions[sessionKey]; hasSession {
-			delete(e.sessions, sessionKey)
-			session.cancel()
-			if session.stream != nil {
-				session.stream.Close()
-			}
-		} else if oldKey := e.findSessionByConversationLocked(conversationId); oldKey != "" {
-			oldSession := e.sessions[oldKey]
-			oldSession.cancel()
-			if oldSession.stream != nil {
-				oldSession.stream.Close()
-			}
-			delete(e.sessions, oldKey)
-		}
-		// A checkpoint created before an MCP call cannot contain its result.
-		delete(e.checkpoints, checkpointKey)
-		e.mu.Unlock()
+		e.retireConversationState(conversationId)
 		log.Infof("cursor: using cold continuation for %d tool result(s)", len(parsed.ToolResults))
 	}
 
@@ -552,6 +638,13 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		delete(e.sessions, oldKey)
 	}
 	e.mu.Unlock()
+	streamOwner := e.beginConversationStream(conversationId)
+	workerOwnsState := false
+	defer func() {
+		if !workerOwnsState {
+			e.releaseConversationStream(conversationId, streamOwner)
+		}
+	}()
 
 	// Look up saved checkpoint for this conversation (keyed by conversationId only).
 	// Checkpoint is auth-specific: if auth changed (e.g. quota exhaustion failover),
@@ -605,10 +698,18 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		stream.Close()
 		return nil, fmt.Errorf("cursor: failed to send request: %w", err)
 	}
-
 	// The Cursor stream lives only for this HTTP request when serving an
 	// OpenAI-compatible client. Native Claude tool calls can still retain it.
-	sessionCtx, sessionCancel := context.WithCancel(context.Background())
+	sessionParent := context.Background()
+	if openAICompatible {
+		sessionParent = ctx
+	}
+	sessionCtx, sessionCancel := context.WithCancel(sessionParent)
+	if !e.attachConversationStream(conversationId, streamOwner, sessionCancel, stream) {
+		sessionCancel()
+		stream.Close()
+		return nil, context.Canceled
+	}
 	go cursorH2Heartbeat(sessionCtx, stream)
 
 	chunks := make(chan cliproxyexecutor.StreamChunk, 64)
@@ -706,7 +807,9 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		return true
 	}
 
+	workerOwnsState = true
 	go func() {
+		defer e.releaseConversationStream(conversationId, streamOwner)
 		var resumeOutCh chan cliproxyexecutor.StreamChunk
 		_ = resumeOutCh
 		thinkingActive := false
@@ -764,8 +867,7 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				resumeOut := make(chan cliproxyexecutor.StreamChunk, 64)
 				log.Debugf("cursor: saving session %s for MCP tool resume (tool=%s)", sessionKey, exec.ToolName)
 				outMu.Lock()
-				e.mu.Lock()
-				e.sessions[sessionKey] = &cursorSession{
+				session := &cursorSession{
 					stream:       stream,
 					blobStore:    params.BlobStore,
 					mcpTools:     params.McpTools,
@@ -785,7 +887,12 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 						outMu.Unlock()
 					},
 				}
-				e.mu.Unlock()
+				if !e.publishConversationSession(conversationId, sessionKey, streamOwner, session, true) {
+					outMu.Unlock()
+					sessionCancel()
+					stream.Close()
+					return
+				}
 				resumeOutCh = resumeOut
 
 				// Publish and close under the output lock. An immediate resume can
@@ -803,16 +910,17 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			toolResultCh,
 			usage,
 			func(cpData []byte) {
-				// Save checkpoint keyed by conversationId, tagged with authID for migration detection
-				e.mu.Lock()
-				e.checkpoints[checkpointKey] = &savedCheckpoint{
+				checkpoint := &savedCheckpoint{
 					data:      cpData,
 					blobStore: params.BlobStore,
 					authID:    authID,
 					updatedAt: time.Now(),
 				}
-				e.mu.Unlock()
-				log.Debugf("cursor: saved checkpoint (%d bytes) for conv=%s auth=%s", len(cpData), checkpointKey, authID)
+				if e.saveCheckpoint(checkpointKey, streamOwner, checkpoint) {
+					log.Debugf("cursor: saved checkpoint (%d bytes) for conv=%s auth=%s", len(cpData), checkpointKey, authID)
+				} else {
+					log.Debugf("cursor: ignored checkpoint from retired stream for conv=%s auth=%s", checkpointKey, authID)
+				}
 			},
 		)
 		streamCoalescer.close()
@@ -910,13 +1018,7 @@ func (e *CursorExecutor) resumeWithToolResults(
 		}
 	}
 	restoreSession := func() {
-		restored := false
-		e.mu.Lock()
-		if _, exists := e.sessions[sessionKey]; !exists {
-			e.sessions[sessionKey] = session
-			restored = true
-		}
-		e.mu.Unlock()
+		restored := e.publishConversationSession(session.conversationID, sessionKey, session.owner, session, false)
 		if !restored {
 			// A concurrent request replaced this session while ownership was in
 			// transit. It is no longer safe to restore, so release its resources.
@@ -1522,32 +1624,33 @@ func parseOpenAIRequest(payload []byte) *parsedOpenAIRequest {
 func flattenConversationIntoUserText(parsed *parsedOpenAIRequest) {
 	var buf strings.Builder
 
-	// Flatten turns into readable context
-	for _, turn := range parsed.Turns {
-		if turn.UserText != "" {
-			buf.WriteString("USER: ")
-			buf.WriteString(turn.UserText)
-			buf.WriteString("\n\n")
+	// Render from the original messages so assistant tool calls and tool results
+	// retain their exact chronological relationship. Cursor imposes no smaller
+	// request limit here, so results remain complete.
+	for _, message := range parsed.Messages {
+		role := message.Get("role").String()
+		switch role {
+		case "system":
+			continue
+		case "user":
+			writeCursorTranscriptEntry(&buf, "USER", extractTextContent(message.Get("content")))
+		case "assistant":
+			writeCursorTranscriptEntry(&buf, "ASSISTANT", extractTextContent(message.Get("content")))
+			for _, toolCall := range message.Get("tool_calls").Array() {
+				entry, _ := json.Marshal(map[string]string{
+					"id":        toolCall.Get("id").String(),
+					"name":      toolCall.Get("function.name").String(),
+					"arguments": toolCall.Get("function.arguments").String(),
+				})
+				writeCursorTranscriptEntry(&buf, "ASSISTANT_TOOL_CALL", string(entry))
+			}
+		case "tool":
+			entry, _ := json.Marshal(map[string]string{
+				"tool_call_id": message.Get("tool_call_id").String(),
+				"content":      extractTextContent(message.Get("content")),
+			})
+			writeCursorTranscriptEntry(&buf, "TOOL_RESULT", string(entry))
 		}
-		if turn.AssistantText != "" {
-			buf.WriteString("ASSISTANT: ")
-			buf.WriteString(turn.AssistantText)
-			buf.WriteString("\n\n")
-		}
-	}
-
-	// Flatten tool results
-	for _, tr := range parsed.ToolResults {
-		buf.WriteString("TOOL_RESULT (call_id: ")
-		buf.WriteString(tr.ToolCallId)
-		buf.WriteString("): ")
-		// Truncate very large tool results to avoid overwhelming the context
-		content := tr.Content
-		if len(content) > 8000 {
-			content = content[:8000] + "\n... [truncated]"
-		}
-		buf.WriteString(content)
-		buf.WriteString("\n\n")
 	}
 
 	if buf.Len() > 0 {
@@ -1555,16 +1658,21 @@ func flattenConversationIntoUserText(parsed *parsedOpenAIRequest) {
 		buf.WriteString("Continue your response based on this context.\n\n")
 	}
 
-	// Prepend flattened history to the current UserText
-	if parsed.UserText != "" {
-		parsed.UserText = buf.String() + "Current request: " + parsed.UserText
-	} else {
-		parsed.UserText = buf.String() + "Continue from the conversation above."
-	}
+	parsed.UserText = buf.String() + "Continue from the conversation above."
 
 	// Clear turns and tool results since they're now in UserText
 	parsed.Turns = nil
 	parsed.ToolResults = nil
+}
+
+func writeCursorTranscriptEntry(buf *strings.Builder, label, content string) {
+	if content == "" {
+		return
+	}
+	buf.WriteString(label)
+	buf.WriteString(": ")
+	buf.WriteString(content)
+	buf.WriteString("\n\n")
 }
 
 func extractTextContent(content gjson.Result) string {

--- a/internal/runtime/executor/cursor_executor.go
+++ b/internal/runtime/executor/cursor_executor.go
@@ -302,20 +302,20 @@ func (e *CursorExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (
 func (e *CursorExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	log.Debugf("cursor Execute: model=%s sourceFormat=%s payloadLen=%d", req.Model, opts.SourceFormat, len(req.Payload))
 	defer func() {
-		if r := recover(); r != nil {
-			log.Errorf("cursor Execute PANIC: %v", r)
-			err = fmt.Errorf("cursor: internal panic: %v", r)
+		if recovered := recover(); recovered != nil {
+			log.Errorf("cursor Execute PANIC: %v", recovered)
+			err = fmt.Errorf("cursor: internal panic: %v", recovered)
 		}
 		if err != nil {
 			log.Warnf("cursor Execute error: %v", err)
 		}
 	}()
+
 	accessToken := cursorAccessToken(auth)
 	if accessToken == "" {
 		return resp, fmt.Errorf("cursor: access token not found")
 	}
 
-	// Translate input to OpenAI format if needed (e.g. Claude /v1/messages format)
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("openai")
 	payload := req.Payload
@@ -324,36 +324,42 @@ func (e *CursorExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	}
 
 	parsed := parseOpenAIRequest(payload)
-	ccSessId := extractClaudeCodeSessionId(req.Payload)
-	conversationId := deriveConversationId(apiKeyFromContext(ctx), ccSessId, parsed.SystemPrompt)
-	params := buildRunRequestParams(parsed, conversationId, req.Model)
+	sessionID := extractClaudeCodeSessionId(req.Payload)
+	conversationID := deriveConversationId(apiKeyFromContext(ctx), sessionID, parsed.SystemPrompt)
+	openAICompatible := isOpenAICompatibleSourceFormat(from)
+	if openAICompatible && len(parsed.ToolResults) > 0 {
+		log.Infof("cursor: using cold continuation for %d non-stream tool result(s)", len(parsed.ToolResults))
+		flattenConversationIntoUserText(parsed)
+	}
+	params := buildRunRequestParams(parsed, conversationID, req.Model)
 
 	requestBytes := cursorproto.EncodeRunRequest(params)
 	framedRequest := cursorproto.FrameConnectMessage(requestBytes, 0)
-
 	stream, err := e.openStream(accessToken)
 	if err != nil {
 		return resp, err
 	}
 	defer stream.Close()
-
-	// Send the request frame
-	if err := stream.Write(framedRequest); err != nil {
+	if err = stream.Write(framedRequest); err != nil {
 		return resp, fmt.Errorf("cursor: failed to send request: %w", err)
 	}
 
-	// Start heartbeat
 	sessionCtx, sessionCancel := context.WithCancel(ctx)
 	defer sessionCancel()
 	go cursorH2Heartbeat(sessionCtx, stream)
 
-	// Collect full text from streaming response, keeping thinking separate so
-	// it can be reported as `reasoning_content` instead of polluting `content`.
 	var fullText strings.Builder
 	var thinkingText strings.Builder
+	var toolCalls []pendingMcpExec
 	usage := &cursorTokenUsage{}
 	usage.setInputEstimate(len(payload))
-	if streamErr := e.processFrames(sessionCtx, stream, params.BlobStore, nil,
+	var onMcpExec func(pendingMcpExec)
+	if openAICompatible {
+		onMcpExec = func(toolCall pendingMcpExec) {
+			toolCalls = append(toolCalls, toolCall)
+		}
+	}
+	if streamErr := e.processFrames(sessionCtx, stream, params.BlobStore, params.McpTools,
 		func(text string, isThinking bool) {
 			if isThinking {
 				thinkingText.WriteString(text)
@@ -361,26 +367,58 @@ func (e *CursorExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 				fullText.WriteString(text)
 			}
 		},
-		nil,
+		onMcpExec,
 		nil,
 		usage,
-		nil, // onCheckpoint - non-streaming doesn't persist
+		nil,
 	); streamErr != nil {
 		return resp, classifyCursorError(fmt.Errorf("cursor: stream error: %w", streamErr))
 	}
 
-	id := "chatcmpl-" + uuid.New().String()[:28]
-	created := time.Now().Unix()
-	inputTok, outputTok := usage.get()
-	reasoningField := ""
-	if thinkingText.Len() > 0 {
-		reasoningField = fmt.Sprintf(`,"reasoning_content":%s`, jsonString(thinkingText.String()))
+	message := map[string]any{
+		"role":    "assistant",
+		"content": fullText.String(),
 	}
-	openaiResp := fmt.Sprintf(`{"id":"%s","object":"chat.completion","created":%d,"model":"%s","choices":[{"index":0,"message":{"role":"assistant","content":%s%s},"finish_reason":"stop"}],"usage":{"prompt_tokens":%d,"completion_tokens":%d,"total_tokens":%d}}`,
-		id, created, parsed.Model, jsonString(fullText.String()), reasoningField, inputTok, outputTok, inputTok+outputTok)
-
-	// Translate response back to source format if needed
-	result := []byte(openaiResp)
+	if thinkingText.Len() > 0 {
+		message["reasoning_content"] = thinkingText.String()
+	}
+	finishReason := "stop"
+	if len(toolCalls) > 0 {
+		finishReason = "tool_calls"
+		serialized := make([]map[string]any, 0, len(toolCalls))
+		for _, toolCall := range toolCalls {
+			serialized = append(serialized, map[string]any{
+				"id":   toolCall.ToolCallId,
+				"type": "function",
+				"function": map[string]any{
+					"name":      toolCall.ToolName,
+					"arguments": toolCall.Args,
+				},
+			})
+		}
+		message["tool_calls"] = serialized
+	}
+	inputTokens, outputTokens := usage.get()
+	body := map[string]any{
+		"id":      "chatcmpl-" + uuid.New().String()[:28],
+		"object":  "chat.completion",
+		"created": time.Now().Unix(),
+		"model":   parsed.Model,
+		"choices": []map[string]any{{
+			"index":         0,
+			"message":       message,
+			"finish_reason": finishReason,
+		}},
+		"usage": map[string]int64{
+			"prompt_tokens":     inputTokens,
+			"completion_tokens": outputTokens,
+			"total_tokens":      inputTokens + outputTokens,
+		},
+	}
+	result, marshalErr := json.Marshal(body)
+	if marshalErr != nil {
+		return resp, fmt.Errorf("cursor: encode non-stream response: %w", marshalErr)
+	}
 	if from.String() != "" && from.String() != "openai" {
 		var param any
 		result = sdktranslator.TranslateNonStream(ctx, to, from, req.Model, bytes.Clone(opts.OriginalRequest), payload, result, &param)
@@ -389,11 +427,13 @@ func (e *CursorExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	return resp, nil
 }
 
-// ExecuteStream handles streaming requests.
-// It supports MCP tool call sessions: when Cursor returns an MCP tool call,
-// the H2 stream is kept alive. When Claude Code returns the tool result in
-// the next request, the result is sent back on the same stream (session resume).
-// This mirrors the activeSessions/resumeWithToolResults pattern in cursor-fetch.ts.
+func isOpenAICompatibleSourceFormat(format sdktranslator.Format) bool {
+	return format.String() == "" || format.String() == "openai"
+}
+
+// ExecuteStream handles streaming requests. Native Claude requests can resume
+// a parked MCP/H2 session; OpenAI-compatible tool results use a fresh request
+// rebuilt from the complete client transcript.
 func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	log.Debugf("cursor ExecuteStream: model=%s sourceFormat=%s payloadLen=%d", req.Model, opts.SourceFormat, len(req.Payload))
 	defer func() {
@@ -410,10 +450,10 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		return nil, fmt.Errorf("cursor: access token not found")
 	}
 
-	// Extract session_id from metadata BEFORE translation (translation strips metadata)
-	ccSessionId := extractClaudeCodeSessionId(req.Payload)
-	if ccSessionId == "" && len(opts.OriginalRequest) > 0 {
-		ccSessionId = extractClaudeCodeSessionId(opts.OriginalRequest)
+	// Extract session_id before translation, which strips metadata.
+	sessionID := extractClaudeCodeSessionId(req.Payload)
+	if sessionID == "" && len(opts.OriginalRequest) > 0 {
+		sessionID = extractClaudeCodeSessionId(opts.OriginalRequest)
 	}
 
 	// Translate input to OpenAI format if needed
@@ -434,26 +474,48 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	log.Debugf("cursor: parsed request: model=%s userText=%d chars, turns=%d, tools=%d, toolResults=%d",
 		parsed.Model, len(parsed.UserText), len(parsed.Turns), len(parsed.Tools), len(parsed.ToolResults))
 
-	conversationId := deriveConversationId(apiKeyFromContext(ctx), ccSessionId, parsed.SystemPrompt)
+	conversationId := deriveConversationId(apiKeyFromContext(ctx), sessionID, parsed.SystemPrompt)
 	authID := auth.ID // e.g. "cursor.json" or "cursor-account2.json"
 	log.Debugf("cursor: conversationId=%s authID=%s", conversationId, authID)
 
-	// Session key includes authID (H2 stream is auth-specific, not transferable).
-	// Checkpoint key uses conversationId only — allows detecting auth migration.
+	// Native Claude requests retain the current resumable-H2 behavior. OpenAI
+	// clients may cross a gateway boundary between the tool call and its result,
+	// so their continuation is rebuilt from the complete transcript instead.
+	openAICompatible := isOpenAICompatibleSourceFormat(from)
+	coldToolContinuation := openAICompatible && len(parsed.ToolResults) > 0
 	sessionKey := authID + ":" + conversationId
 	checkpointKey := conversationId
 	needsTranslate := from.String() != "" && from.String() != "openai"
 
-	// Check if we can resume an existing session with tool results
-	if len(parsed.ToolResults) > 0 {
+	if coldToolContinuation {
+		e.mu.Lock()
+		if session, hasSession := e.sessions[sessionKey]; hasSession {
+			delete(e.sessions, sessionKey)
+			session.cancel()
+			if session.stream != nil {
+				session.stream.Close()
+			}
+		} else if oldKey := e.findSessionByConversationLocked(conversationId); oldKey != "" {
+			oldSession := e.sessions[oldKey]
+			oldSession.cancel()
+			if oldSession.stream != nil {
+				oldSession.stream.Close()
+			}
+			delete(e.sessions, oldKey)
+		}
+		// A checkpoint created before an MCP call cannot contain its result.
+		delete(e.checkpoints, checkpointKey)
+		e.mu.Unlock()
+		log.Infof("cursor: using cold continuation for %d tool result(s)", len(parsed.ToolResults))
+	}
+
+	// Native Claude requests retain the existing same-stream resume path.
+	if len(parsed.ToolResults) > 0 && !coldToolContinuation {
 		e.mu.Lock()
 		session, hasSession := e.sessions[sessionKey]
 		if hasSession {
 			delete(e.sessions, sessionKey)
 		}
-		// If no session found for current auth, check for stale sessions from
-		// a different auth on the same conversation (quota failover scenario).
-		// Clean them up since the H2 stream belongs to the old account.
 		if !hasSession {
 			if oldKey := e.findSessionByConversationLocked(conversationId); oldKey != "" {
 				oldSession := e.sessions[oldKey]
@@ -500,35 +562,34 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 
 	params := buildRunRequestParams(parsed, conversationId, req.Model)
 
-	if hasCheckpoint && saved.data != nil && saved.authID == authID {
-		// Same auth — use checkpoint normally
+	if coldToolContinuation {
+		flattenConversationIntoUserText(parsed)
+		params = buildRunRequestParams(parsed, conversationId, req.Model)
+	} else if hasCheckpoint && saved.data != nil && saved.authID == authID {
+		// Same auth — use checkpoint normally.
 		log.Debugf("cursor: using saved checkpoint (%d bytes) for conv=%s auth=%s", len(saved.data), checkpointKey, authID)
 		params.RawCheckpoint = saved.data
-		// Merge saved blobStore into params
 		if params.BlobStore == nil {
 			params.BlobStore = make(map[string][]byte)
 		}
-		for k, v := range saved.blobStore {
-			if _, exists := params.BlobStore[k]; !exists {
-				params.BlobStore[k] = v
+		for key, value := range saved.blobStore {
+			if _, exists := params.BlobStore[key]; !exists {
+				params.BlobStore[key] = value
 			}
 		}
 	} else if hasCheckpoint && saved.data != nil && saved.authID != authID {
-		// Auth changed (quota failover) — checkpoint is not portable across accounts.
-		// Discard and flatten conversation history into userText.
+		// Auth changed (quota failover) — checkpoints are not portable.
 		log.Infof("cursor: auth migrated (%s → %s) for conv=%s, discarding checkpoint and flattening context", saved.authID, authID, checkpointKey)
 		e.mu.Lock()
 		delete(e.checkpoints, checkpointKey)
 		e.mu.Unlock()
-		if len(parsed.ToolResults) > 0 || len(parsed.Turns) > 0 {
+		if len(parsed.Turns) > 0 {
 			flattenConversationIntoUserText(parsed)
 			params = buildRunRequestParams(parsed, conversationId, req.Model)
 		}
-	} else if len(parsed.ToolResults) > 0 || len(parsed.Turns) > 0 {
-		// Fallback: no checkpoint available (cold resume / proxy restart).
-		// Flatten the full conversation history (including tool interactions) into userText.
-		// Cursor's turns encoding is not reliably read by the model, but userText always works.
-		log.Debugf("cursor: no checkpoint, flattening %d turns + %d tool results into userText", len(parsed.Turns), len(parsed.ToolResults))
+	} else if len(parsed.Turns) > 0 {
+		// Cursor reliably reads UserText, while structured turns may be ignored.
+		log.Debugf("cursor: no checkpoint, flattening %d turns into user text", len(parsed.Turns))
 		flattenConversationIntoUserText(parsed)
 		params = buildRunRequestParams(parsed, conversationId, req.Model)
 	}
@@ -545,9 +606,8 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		return nil, fmt.Errorf("cursor: failed to send request: %w", err)
 	}
 
-	// Use a session-scoped context for the heartbeat that is NOT tied to the HTTP request.
-	// This ensures the heartbeat survives across request boundaries during MCP tool execution.
-	// Mirrors the TS plugin's setInterval-based heartbeat that lives independently of HTTP responses.
+	// The Cursor stream lives only for this HTTP request when serving an
+	// OpenAI-compatible client. Native Claude tool calls can still retain it.
 	sessionCtx, sessionCancel := context.WithCancel(context.Background())
 	go cursorH2Heartbeat(sessionCtx, stream)
 
@@ -557,14 +617,15 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 
 	var streamParam any
 
-	// Tool result channel for inline mode. processH2SessionFrames blocks on it
-	// when mcpArgs is received, while continuing to handle KV/heartbeat.
-	toolResultCh := make(chan []toolResultInfo, 1)
+	// OpenAI-compatible tool results use a fresh request with the full transcript.
+	// A nil channel tells the frame processor to finish immediately after emitting
+	// an MCP tool call instead of parking this H2 connection.
+	var toolResultCh chan []toolResultInfo
+	if !openAICompatible {
+		toolResultCh = make(chan []toolResultInfo, 1)
+	}
 
-	// Switchable output: initially writes to `chunks`. After mcpArgs, the
-	// onMcpExec callback closes `chunks` (ending the first HTTP response),
-	// then processH2SessionFrames blocks on toolResultCh. When results arrive,
-	// it switches to `resumeOutCh` (created by resumeWithToolResults).
+	// Switchable output starts with the current HTTP response channel.
 	var outMu sync.Mutex
 	currentOut := chunks
 	currentOutputCtx := ctx
@@ -690,6 +751,12 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				sendChunkSwitchable(toolCallJSON, "")
 				sendChunkSwitchable(`{}`, `"tool_calls"`)
 				sendDoneSwitchable()
+
+				if openAICompatible {
+					closeCurrentOutput()
+					log.Debugf("cursor: ended H2 stream after MCP tool call (tool=%s)", exec.ToolName)
+					return
+				}
 
 				// Publish the resumable session before closing the current output.
 				// Channel closure lets the client submit its tool result immediately;

--- a/internal/runtime/executor/cursor_executor_test.go
+++ b/internal/runtime/executor/cursor_executor_test.go
@@ -113,6 +113,58 @@ func TestCursorExecuteReturnsReasoningAndUsage(t *testing.T) {
 	}
 }
 
+func TestCursorExecuteToolResultUsesColdContinuation(t *testing.T) {
+	clientID := normalizeToolCallID("call non-stream")
+	processCount := 0
+	e := newCursorExecutorHarness(func(_ context.Context, _ cursorStream, _ map[string][]byte, _ anyMCPTools, onText func(string, bool), onMcpExec func(pendingMcpExec), toolResultCh <-chan []toolResultInfo, _ *cursorTokenUsage, _ func([]byte)) error {
+		if onMcpExec == nil {
+			return errors.New("OpenAI non-stream request did not install an MCP callback")
+		}
+		if toolResultCh != nil {
+			return errors.New("OpenAI non-stream request parked an H2 tool session")
+		}
+		processCount++
+		if processCount == 1 {
+			onMcpExec(pendingMcpExec{ToolCallId: clientID, ToolName: "read", Args: `{"path":"README.md"}`})
+			return nil
+		}
+		onText("after tool", false)
+		return nil
+	})
+
+	first, err := e.Execute(context.Background(), cursorTestAuth(), cursorTestRequest(false), cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("first Execute() error = %v", err)
+	}
+	if got := gjson.GetBytes(first.Payload, "choices.0.finish_reason").String(); got != "tool_calls" {
+		t.Fatalf("first finish_reason = %q, want tool_calls", got)
+	}
+	if got := gjson.GetBytes(first.Payload, "choices.0.message.tool_calls.0.id").String(); got != clientID {
+		t.Fatalf("tool call ID = %q, want %q", got, clientID)
+	}
+	if got := gjson.GetBytes(first.Payload, "choices.0.message.tool_calls.0.function.name").String(); got != "read" {
+		t.Fatalf("tool name = %q, want read", got)
+	}
+	if got := gjson.GetBytes(first.Payload, "choices.0.message.tool_calls.0.function.arguments").String(); got != `{"path":"README.md"}` {
+		t.Fatalf("tool arguments = %q", got)
+	}
+
+	secondPayload := []byte(`{"model":"cursor-test-model","messages":[{"role":"user","content":"hello"},{"role":"assistant","tool_calls":[{"id":"` + clientID + `","type":"function","function":{"name":"read","arguments":"{\"path\":\"README.md\"}"}}]},{"role":"tool","tool_call_id":"` + clientID + `","content":"file contents"}]}`)
+	second, err := e.Execute(context.Background(), cursorTestAuth(), cliproxyexecutor.Request{Model: "cursor-test-model", Payload: secondPayload}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("second Execute() error = %v", err)
+	}
+	if got := gjson.GetBytes(second.Payload, "choices.0.finish_reason").String(); got != "stop" {
+		t.Fatalf("second finish_reason = %q, want stop", got)
+	}
+	if got := gjson.GetBytes(second.Payload, "choices.0.message.content").String(); got != "after tool" {
+		t.Fatalf("second content = %q, want after tool", got)
+	}
+	if processCount != 2 {
+		t.Fatalf("processor calls = %d, want 2", processCount)
+	}
+}
+
 func TestCursorExecuteReasoningOnlyErrorIsFailure(t *testing.T) {
 	boom := errors.New("upstream reset")
 	e := newCursorExecutorHarness(func(_ context.Context, _ cursorStream, _ map[string][]byte, _ anyMCPTools, onText func(string, bool), _ func(pendingMcpExec), _ <-chan []toolResultInfo, _ *cursorTokenUsage, _ func([]byte)) error {
@@ -281,6 +333,31 @@ func TestParseOpenAIToolCallIDDoesNotDoubleNormalize(t *testing.T) {
 	}
 	if got := parsed.ToolResults[0].ToolCallId; got != clientID {
 		t.Fatalf("tool_call_id = %q, want exact client ID %q", got, clientID)
+	}
+}
+
+func TestFlattenConversationIntoUserTextPreservesToolResult(t *testing.T) {
+	parsed := parseOpenAIRequest([]byte(`{
+		"messages": [
+			{"role":"user","content":"Read the project file."},
+			{"role":"assistant","content":"I will read it.","tool_calls":[{"id":"call_read","type":"function","function":{"name":"read","arguments":"{\"path\":\"README.md\"}"}}]},
+			{"role":"tool","tool_call_id":"call_read","content":"project contents"}
+		]
+	}`))
+
+	flattenConversationIntoUserText(parsed)
+	for _, want := range []string{
+		"USER: Read the project file.",
+		"ASSISTANT: I will read it.",
+		"TOOL_RESULT (call_id: call_read): project contents",
+		"Continue your response based on this context.",
+	} {
+		if !strings.Contains(parsed.UserText, want) {
+			t.Fatalf("flattened transcript is missing %q: %q", want, parsed.UserText)
+		}
+	}
+	if len(parsed.Turns) != 0 || len(parsed.ToolResults) != 0 {
+		t.Fatal("flattenConversationIntoUserText() retained structured history")
 	}
 }
 
@@ -486,20 +563,26 @@ func TestCursorResumeRejectsUnmatchedToolResultAndRestoresSession(t *testing.T) 
 	}
 }
 
-func TestCursorToolBoundaryImmediateResumeUsesPublishedSession(t *testing.T) {
+func TestCursorOpenAIToolResultUsesColdContinuation(t *testing.T) {
 	clientID := normalizeToolCallID("call immediate")
-	e := newCursorExecutorHarness(func(ctx context.Context, _ cursorStream, _ map[string][]byte, _ anyMCPTools, _ func(string, bool), onMcpExec func(pendingMcpExec), toolResultCh <-chan []toolResultInfo, _ *cursorTokenUsage, _ func([]byte)) error {
-		onMcpExec(pendingMcpExec{ToolCallId: clientID, ToolName: "read", Args: `{}`})
-		select {
-		case results := <-toolResultCh:
-			if len(results) != 1 || results[0].ToolCallId != clientID {
-				return errors.New("immediate resume delivered wrong tool result")
-			}
-		case <-ctx.Done():
-			return ctx.Err()
+	var processMu sync.Mutex
+	processCount := 0
+	e := newCursorExecutorHarness(func(_ context.Context, _ cursorStream, _ map[string][]byte, _ anyMCPTools, onText func(string, bool), onMcpExec func(pendingMcpExec), toolResultCh <-chan []toolResultInfo, _ *cursorTokenUsage, _ func([]byte)) error {
+		if toolResultCh != nil {
+			return errors.New("OpenAI request parked an H2 tool session")
 		}
+		processMu.Lock()
+		processCount++
+		current := processCount
+		processMu.Unlock()
+		if current == 1 {
+			onMcpExec(pendingMcpExec{ToolCallId: clientID, ToolName: "read", Args: `{}`})
+			return nil
+		}
+		onText("after tool", false)
 		return nil
 	})
+
 	var openMu sync.Mutex
 	openCount := 0
 	e.openStream = func(string) (cursorStream, error) {
@@ -508,43 +591,41 @@ func TestCursorToolBoundaryImmediateResumeUsesPublishedSession(t *testing.T) {
 		openMu.Unlock()
 		return newFakeCursorStream(), nil
 	}
-	first, err := e.ExecuteStream(context.Background(), cursorTestAuth(), cursorTestRequest(true), cliproxyexecutor.Options{})
+
+	openAI := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("openai")}
+	first, err := e.ExecuteStream(context.Background(), cursorTestAuth(), cursorTestRequest(true), openAI)
 	if err != nil {
 		t.Fatal(err)
 	}
-	secondPayload := []byte(`{"model":"cursor-test-model","stream":true,"messages":[{"role":"user","content":"hello"},{"role":"assistant","tool_calls":[{"id":"` + clientID + `","type":"function","function":{"name":"read","arguments":"{}"}}]},{"role":"tool","tool_call_id":"` + clientID + `","content":"ok"}]}`)
-	type outcome struct {
-		body string
-		err  error
+	firstBody := cursorStreamPayload(collectCursorStream(t, first))
+	if !strings.Contains(firstBody, `"finish_reason":"tool_calls"`) || strings.Contains(firstBody, `"finish_reason":"stop"`) {
+		t.Fatalf("first OpenAI tool boundary is invalid:\n%s", firstBody)
 	}
-	resumed := make(chan outcome, 1)
-	go func() {
-		for range first.Chunks {
-		}
-		second, errResume := e.ExecuteStream(context.Background(), cursorTestAuth(), cliproxyexecutor.Request{Model: "cursor-test-model", Payload: secondPayload}, cliproxyexecutor.Options{})
-		if errResume != nil {
-			resumed <- outcome{err: errResume}
-			return
-		}
-		var chunks []cliproxyexecutor.StreamChunk
-		for chunk := range second.Chunks {
-			chunks = append(chunks, chunk)
-		}
-		resumed <- outcome{body: cursorStreamPayload(chunks)}
-	}()
-	select {
-	case got := <-resumed:
-		if got.err != nil {
-			t.Fatal(got.err)
-		}
-		openMu.Lock()
-		gotOpenCount := openCount
-		openMu.Unlock()
-		if gotOpenCount != 1 {
-			t.Fatalf("immediate resume cold-started a second Cursor stream: opens=%d body=%s", gotOpenCount, got.body)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("immediate close-triggered resume hung")
+	e.mu.Lock()
+	parkedSessions := len(e.sessions)
+	e.mu.Unlock()
+	if parkedSessions != 0 {
+		t.Fatalf("OpenAI tool call parked %d H2 session(s)", parkedSessions)
+	}
+
+	secondPayload := []byte(`{"model":"cursor-test-model","stream":true,"messages":[{"role":"user","content":"hello"},{"role":"assistant","tool_calls":[{"id":"` + clientID + `","type":"function","function":{"name":"read","arguments":"{}"}}]},{"role":"tool","tool_call_id":"` + clientID + `","content":"file contents"}]}`)
+	second, err := e.ExecuteStream(context.Background(), cursorTestAuth(), cliproxyexecutor.Request{Model: "cursor-test-model", Payload: secondPayload}, openAI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondBody := cursorStreamPayload(collectCursorStream(t, second))
+	if !strings.Contains(secondBody, `"content":"after tool"`) || !strings.Contains(secondBody, `"finish_reason":"stop"`) {
+		t.Fatalf("cold continuation did not complete normally:\n%s", secondBody)
+	}
+
+	openMu.Lock()
+	gotOpenCount := openCount
+	openMu.Unlock()
+	processMu.Lock()
+	gotProcessCount := processCount
+	processMu.Unlock()
+	if gotOpenCount != 2 || gotProcessCount != 2 {
+		t.Fatalf("cold continuation opens=%d processor calls=%d, want 2 and 2", gotOpenCount, gotProcessCount)
 	}
 }
 

--- a/internal/runtime/executor/cursor_executor_test.go
+++ b/internal/runtime/executor/cursor_executor_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	cursorproto "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/cursor/proto"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
@@ -349,7 +350,8 @@ func TestFlattenConversationIntoUserTextPreservesToolResult(t *testing.T) {
 	for _, want := range []string{
 		"USER: Read the project file.",
 		"ASSISTANT: I will read it.",
-		"TOOL_RESULT (call_id: call_read): project contents",
+		`ASSISTANT_TOOL_CALL: {"arguments":"{\"path\":\"README.md\"}","id":"call_read","name":"read"}`,
+		`TOOL_RESULT: {"content":"project contents","tool_call_id":"call_read"}`,
 		"Continue your response based on this context.",
 	} {
 		if !strings.Contains(parsed.UserText, want) {
@@ -358,6 +360,147 @@ func TestFlattenConversationIntoUserTextPreservesToolResult(t *testing.T) {
 	}
 	if len(parsed.Turns) != 0 || len(parsed.ToolResults) != 0 {
 		t.Fatal("flattenConversationIntoUserText() retained structured history")
+	}
+}
+
+func TestFlattenConversationIntoUserTextPreservesToolCallOrderAndCompleteUTF8Result(t *testing.T) {
+	largeResult := strings.Repeat("🙂", 3000)
+	payload := []byte(`{"messages":[` +
+		`{"role":"user","content":"run both"},` +
+		`{"role":"assistant","tool_calls":[` +
+		`{"id":"call_first","type":"function","function":{"name":"first","arguments":"{\"n\":1}"}},` +
+		`{"id":"call_second","type":"function","function":{"name":"second","arguments":"{\"n\":2}"}}]},` +
+		`{"role":"tool","tool_call_id":"call_first","content":` + jsonString(largeResult) + `},` +
+		`{"role":"tool","tool_call_id":"call_second","content":"done"}` +
+		`]}`)
+	parsed := parseOpenAIRequest(payload)
+
+	flattenConversationIntoUserText(parsed)
+
+	first := strings.Index(parsed.UserText, `"id":"call_first"`)
+	second := strings.Index(parsed.UserText, `"id":"call_second"`)
+	firstResult := strings.Index(parsed.UserText, `"tool_call_id":"call_first"`)
+	secondResult := strings.Index(parsed.UserText, `"tool_call_id":"call_second"`)
+	if first < 0 || second <= first || firstResult <= second || secondResult <= firstResult {
+		t.Fatalf("tool call/result order was not preserved: first=%d second=%d firstResult=%d secondResult=%d", first, second, firstResult, secondResult)
+	}
+	if !strings.Contains(parsed.UserText, largeResult) || !strings.Contains(parsed.UserText, `"name":"first"`) || !strings.Contains(parsed.UserText, `"arguments":"{\"n\":1}"`) {
+		t.Fatal("flattened transcript lost tool metadata or complete UTF-8 result")
+	}
+	if !utf8.ValidString(parsed.UserText) || strings.Contains(parsed.UserText, "[truncated]") {
+		t.Fatal("flattened transcript truncated or corrupted UTF-8")
+	}
+}
+
+func TestCursorExecuteColdContinuationRetiresAllConversationState(t *testing.T) {
+	payload := []byte(`{"model":"cursor-test-model","messages":[{"role":"user","content":"hello"},{"role":"assistant","tool_calls":[{"id":"call-1","type":"function","function":{"name":"read","arguments":"{}"}}]},{"role":"tool","tool_call_id":"call-1","content":"result"}]}`)
+	parsed := parseOpenAIRequest(payload)
+	conversationID := deriveConversationId("", "", parsed.SystemPrompt)
+	firstStream := newFakeCursorStream()
+	secondStream := newFakeCursorStream()
+	canceled := 0
+	e := newCursorExecutorHarness(func(_ context.Context, _ cursorStream, _ map[string][]byte, _ anyMCPTools, onText func(string, bool), _ func(pendingMcpExec), _ <-chan []toolResultInfo, _ *cursorTokenUsage, _ func([]byte)) error {
+		onText("continued", false)
+		return nil
+	})
+	e.sessions["old-auth:"+conversationID] = &cursorSession{stream: firstStream, cancel: func() { canceled++ }}
+	e.sessions["cursor-test:"+conversationID] = &cursorSession{stream: secondStream, cancel: func() { canceled++ }}
+	e.checkpoints[conversationID] = &savedCheckpoint{data: []byte("stale")}
+
+	if _, err := e.Execute(context.Background(), cursorTestAuth(), cliproxyexecutor.Request{Model: "cursor-test-model", Payload: payload}, cliproxyexecutor.Options{}); err != nil {
+		t.Fatal(err)
+	}
+	e.mu.Lock()
+	sessions := len(e.sessions)
+	_, checkpointExists := e.checkpoints[conversationID]
+	e.mu.Unlock()
+	if sessions != 0 || checkpointExists || canceled != 2 {
+		t.Fatalf("retired state: sessions=%d checkpoint=%v canceled=%d", sessions, checkpointExists, canceled)
+	}
+	for index, stream := range []*fakeCursorStream{firstStream, secondStream} {
+		select {
+		case <-stream.dead:
+		default:
+			t.Fatalf("retired stream %d remained open", index)
+		}
+	}
+}
+
+func TestCursorConversationOwnershipRejectsRetiredCheckpointWriter(t *testing.T) {
+	e := NewCursorExecutor(nil)
+	conversationID := "conversation"
+	retiredOwner := e.beginConversationStream(conversationID)
+	currentOwner := e.beginConversationStream(conversationID)
+	if e.saveCheckpoint(conversationID, retiredOwner, &savedCheckpoint{data: []byte("stale")}) {
+		t.Fatal("retired owner saved a checkpoint")
+	}
+	if !e.saveCheckpoint(conversationID, currentOwner, &savedCheckpoint{data: []byte("current")}) {
+		t.Fatal("current owner could not save checkpoint")
+	}
+	e.releaseConversationStream(conversationID, retiredOwner)
+	e.mu.Lock()
+	ownerAfterStaleRelease := e.stateOwners[conversationID]
+	e.mu.Unlock()
+	if ownerAfterStaleRelease != currentOwner {
+		t.Fatal("retired owner released the current owner")
+	}
+	e.retireConversationState(conversationID)
+	if e.saveCheckpoint(conversationID, currentOwner, &savedCheckpoint{data: []byte("late")}) {
+		t.Fatal("owner saved a checkpoint after transactional retirement")
+	}
+}
+
+func TestCursorConversationRetirementWinsAgainstClaimedSessionRestoreAndPublication(t *testing.T) {
+	e := NewCursorExecutor(nil)
+	conversationID := "conversation"
+	sessionKey := "cursor-test:" + conversationID
+	stream := newFakeCursorStream()
+	canceled := make(chan struct{})
+	owner := e.beginConversationStream(conversationID)
+	if !e.attachConversationStream(conversationID, owner, func() { close(canceled) }, stream) {
+		t.Fatal("could not attach current conversation owner")
+	}
+	session := &cursorSession{
+		stream:         stream,
+		cancel:         owner.cancel,
+		conversationID: conversationID,
+		owner:          owner,
+	}
+
+	claimed := make(chan struct{})
+	attemptRestore := make(chan struct{})
+	restored := make(chan bool, 1)
+	go func() {
+		close(claimed)
+		<-attemptRestore
+		restored <- e.publishConversationSession(conversationID, sessionKey, owner, session, false)
+	}()
+	<-claimed
+	e.retireConversationState(conversationID)
+	close(attemptRestore)
+	if <-restored {
+		t.Fatal("claimed session was restored after retirement")
+	}
+	if e.publishConversationSession(conversationID, sessionKey, owner, session, true) {
+		t.Fatal("retired processor published a later tool session")
+	}
+	if e.saveCheckpoint(conversationID, owner, &savedCheckpoint{data: []byte("late")}) {
+		t.Fatal("retired processor published a later checkpoint")
+	}
+	select {
+	case <-canceled:
+	default:
+		t.Fatal("claimed in-flight session was not canceled by retirement")
+	}
+	select {
+	case <-stream.dead:
+	default:
+		t.Fatal("claimed in-flight stream was not closed by retirement")
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if len(e.sessions) != 0 || e.stateOwners[conversationID] != nil || e.checkpoints[conversationID] != nil {
+		t.Fatal("conversation state reappeared after retirement")
 	}
 }
 
@@ -448,13 +591,79 @@ func TestCursorExecuteStreamCancellationBeforeFirstChunkReturns(t *testing.T) {
 	}
 }
 
+func TestCursorExecuteStreamOpenAICancellationAfterFirstChunkStopsSession(t *testing.T) {
+	processorExited := make(chan struct{})
+	stream := newFakeCursorStream()
+	e := newCursorExecutorHarness(func(ctx context.Context, _ cursorStream, _ map[string][]byte, _ anyMCPTools, onText func(string, bool), _ func(pendingMcpExec), _ <-chan []toolResultInfo, _ *cursorTokenUsage, _ func([]byte)) error {
+		onText("first", false)
+		<-ctx.Done()
+		close(processorExited)
+		return ctx.Err()
+	})
+	e.openStream = func(string) (cursorStream, error) { return stream, nil }
+	ctx, cancel := context.WithCancel(context.Background())
+	result, err := e.ExecuteStream(ctx, cursorTestAuth(), cursorTestRequest(true), cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	select {
+	case <-processorExited:
+	case <-time.After(time.Second):
+		t.Fatal("OpenAI frame processor survived client cancellation after first chunk")
+	}
+	collectCursorStream(t, result)
+	select {
+	case <-stream.dead:
+	case <-time.After(time.Second):
+		t.Fatal("OpenAI upstream stream remained open after client cancellation")
+	}
+}
+
+func TestCursorExecuteStreamClaudeCancellationRetainsSessionLifetime(t *testing.T) {
+	release := make(chan struct{})
+	processorExited := make(chan struct{})
+	e := newCursorExecutorHarness(func(ctx context.Context, _ cursorStream, _ map[string][]byte, _ anyMCPTools, onText func(string, bool), _ func(pendingMcpExec), _ <-chan []toolResultInfo, _ *cursorTokenUsage, _ func([]byte)) error {
+		onText("first", false)
+		select {
+		case <-ctx.Done():
+			return errors.New("native Claude session inherited client cancellation")
+		case <-release:
+			close(processorExited)
+			return nil
+		}
+	})
+	payload := []byte(`{"model":"cursor-test-model","max_tokens":128,"stream":true,"messages":[{"role":"user","content":"hello"}]}`)
+	ctx, cancel := context.WithCancel(context.Background())
+	result, err := e.ExecuteStream(ctx, cursorTestAuth(), cliproxyexecutor.Request{Model: "cursor-test-model", Payload: payload}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude"), OriginalRequest: payload})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	select {
+	case <-processorExited:
+		t.Fatal("native Claude session stopped with the client context")
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(release)
+	collectCursorStream(t, result)
+	select {
+	case <-processorExited:
+	case <-time.After(time.Second):
+		t.Fatal("native Claude processor did not finish after release")
+	}
+}
+
 func TestCursorResumeCancellationRestoresSession(t *testing.T) {
 	e := NewCursorExecutor(nil)
 	sessionKey := "cursor-test:conversation"
+	owner := e.beginConversationStream("conversation")
 	session := &cursorSession{
-		toolResultCh: make(chan []toolResultInfo, 1),
-		resumeOutCh:  make(chan cliproxyexecutor.StreamChunk, 1),
-		cancel:       func() {},
+		toolResultCh:   make(chan []toolResultInfo, 1),
+		resumeOutCh:    make(chan cliproxyexecutor.StreamChunk, 1),
+		cancel:         func() {},
+		conversationID: "conversation",
+		owner:          owner,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -527,13 +736,16 @@ func TestCursorResumeInvalidSessionIsDiscarded(t *testing.T) {
 func TestCursorResumeRejectsUnmatchedToolResultAndRestoresSession(t *testing.T) {
 	e := NewCursorExecutor(nil)
 	sessionKey := "cursor-test:pending-session"
+	owner := e.beginConversationStream("pending-session")
 	switched := false
 	session := &cursorSession{
-		pending:      []pendingMcpExec{{ToolCallId: "call-good"}},
-		toolResultCh: make(chan []toolResultInfo, 1),
-		resumeOutCh:  make(chan cliproxyexecutor.StreamChunk, 1),
-		cancel:       func() {},
-		switchOutput: func(chan cliproxyexecutor.StreamChunk, context.Context) { switched = true },
+		pending:        []pendingMcpExec{{ToolCallId: "call-good"}},
+		toolResultCh:   make(chan []toolResultInfo, 1),
+		resumeOutCh:    make(chan cliproxyexecutor.StreamChunk, 1),
+		cancel:         func() {},
+		conversationID: "pending-session",
+		owner:          owner,
+		switchOutput:   func(chan cliproxyexecutor.StreamChunk, context.Context) { switched = true },
 	}
 	_, err := e.resumeWithToolResults(
 		context.Background(),


### PR DESCRIPTION
## Summary

- end an OpenAI-compatible Cursor H2 request after emitting an MCP tool call instead of parking it across HTTP requests
- cold-continue the next tool-result request from the complete client transcript and discard the pre-tool checkpoint
- return conventional OpenAI `tool_calls` from non-stream requests and cold-continue their results as well
- preserve the existing same-H2 resume path for native Claude requests

## Problem

Cursor's native MCP flow can wait for a tool result on the same H2 stream. OpenAI-compatible clients, however, send that result in a new HTTP request, often through another gateway. Retaining the upstream H2 stream across that boundary was unstable in practice: a continuation could wait for minutes and then emit another tool call instead of consuming the result.

The complete OpenAI transcript already contains the assistant tool call and returned tool result, so it is the reliable continuation boundary.

## Implementation

For OpenAI chat-completions requests only:

1. emit the tool call and close the current response without publishing a resumable H2 session
2. when a subsequent request contains tool results, remove any stale session/checkpoint
3. flatten the complete user/assistant/tool transcript into the new Cursor request
4. start a fresh Cursor stream

Native Claude requests keep the existing transactional same-stream resume behavior unchanged.

## Test plan

- [x] `gofmt -w internal/runtime/executor/cursor_executor.go internal/runtime/executor/cursor_executor_test.go`
- [x] `go build -o /tmp/cliproxyapi-plus-pr ./cmd/server`
- [x] `go test ./...`
- [x] `go test -race ./internal/runtime/executor -run 'Test(CursorOpenAIToolResultUsesColdContinuation|CursorExecuteToolResultUsesColdContinuation|CursorExecuteStreamClaudeThinkingToolBoundaryAndResume|FlattenConversationIntoUserTextPreservesToolResult)' -count=10`

Executor tests cover:

- streaming OpenAI tool boundary -> fresh-stream continuation
- non-stream OpenAI `tool_calls` -> fresh-stream continuation
- full transcript/tool-result preservation
- no parked OpenAI H2 session
- unchanged native Claude same-H2 resume

## Manual validation

Against a live Cursor upstream, both paths completed normally:

- streaming: tool call in 1.687 s, tool-result continuation in 2.702 s
- non-stream: tool call in 1.404 s, tool-result continuation in 2.692 s
- a 20-tool-result OpenAI chain completed with no timeout, RST, panic, or 5xx
