### PR TITLE
fix(qoder): resolve configured model aliases at execution time

### DIFF
--- a/internal/runtime/executor/qoder_executor.go
+++ b/internal/runtime/executor/qoder_executor.go
@@ -72,13 +72,13 @@ func (e *QoderExecutor) ExecuteStream(ctx context.Context, authRecord *cliproxya
 	}
 
 	// Map model name — strip provider prefix so qoder/auto → auto
-	model, _ := chatReq["model"].(string)
-	qoderModel := strings.TrimPrefix(model, "qoder/")
-	if mapped, ok := qoderauth.ModelMap[qoderModel]; ok {
-		qoderModel = mapped
-	} else if _, cached := storage.GetModelConfig(qoderModel); !cached {
-		// Not in static map and not in dynamic model cache — reject early.
-		return nil, fmt.Errorf("unsupported qoder model: %q (received %q)", qoderModel, model)
+	model := req.Model
+	if model == "" {
+		model, _ = chatReq["model"].(string)
+	}
+	qoderModel, err := validateQoderModel(model, storage)
+	if err != nil {
+		return nil, err
 	}
 	reporter := helps.NewExecutorUsageReporter(ctx, e, qoderModel, authRecord)
 	defer reporter.TrackFailure(ctx, &err)
@@ -1062,4 +1062,17 @@ func FetchQoderUsage(ctx context.Context, auth *cliproxyauth.Auth, cfg *config.C
 		info.UserQuota.Used, info.UserQuota.Total, info.UserQuota.Unit,
 		info.TotalUsagePercentage*100)
 	return &info
+}
+
+func validateQoderModel(rawModel string, storage *qoderauth.QoderTokenStorage) (string, error) {
+	qoderModel := strings.TrimPrefix(rawModel, "qoder/")
+	if mapped, ok := qoderauth.ModelMap[qoderModel]; ok {
+		return mapped, nil
+	}
+	if storage != nil {
+		if _, cached := storage.GetModelConfig(qoderModel); cached {
+			return qoderModel, nil
+		}
+	}
+	return "", fmt.Errorf("unsupported qoder model: %q", qoderModel)
 }

--- a/internal/runtime/executor/qoder_executor_test.go
+++ b/internal/runtime/executor/qoder_executor_test.go
@@ -961,3 +961,64 @@ func TestExecute_TranslateNonStream_UsesTranslatedRequestPayload(t *testing.T) {
 		t.Error("TranslateNonStream must return valid JSON")
 	}
 }
+
+
+func TestValidateQoderModel(t *testing.T) {
+	storage := &qoder.QoderTokenStorage{}
+	storage.SetModelConfigs(map[string]json.RawMessage{
+		"custom-qoder-model": json.RawMessage(`{"type":"custom"}`),
+	})
+
+	tests := []struct {
+		name         string
+		rawModel     string
+		want         string
+		wantErr      bool
+		errSubstring string
+	}{
+		{
+			name:     "ModelMap hit with prefix",
+			rawModel: "qoder/auto",
+			want:     "auto",
+		},
+		{
+			name:     "ModelMap hit without prefix",
+			rawModel: "auto",
+			want:     "auto",
+		},
+		{
+			name:     "Storage config hit with prefix",
+			rawModel: "qoder/custom-qoder-model",
+			want:     "custom-qoder-model",
+		},
+		{
+			name:     "Storage config hit without prefix",
+			rawModel: "custom-qoder-model",
+			want:     "custom-qoder-model",
+		},
+		{
+			name:         "Unsupported model error",
+			rawModel:     "qoder/nonexistent",
+			wantErr:      true,
+			errSubstring: `unsupported qoder model: "nonexistent"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateQoderModel(tt.rawModel, storage)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateQoderModel(%q) error = %v, wantErr %v", tt.rawModel, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				if err == nil || !strings.Contains(err.Error(), tt.errSubstring) {
+					t.Errorf("validateQoderModel(%q) error = %v, want substring %q", tt.rawModel, err, tt.errSubstring)
+				}
+				return
+			}
+			if got != tt.want {
+				t.Errorf("validateQoderModel(%q) = %q, want %q", tt.rawModel, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/qoder_executor_test.go
+++ b/internal/runtime/executor/qoder_executor_test.go
@@ -962,6 +962,85 @@ func TestExecute_TranslateNonStream_UsesTranslatedRequestPayload(t *testing.T) {
 	}
 }
 
+func TestQoderExecutorExecutionModelSelection(t *testing.T) {
+	tests := []struct {
+		name          string
+		reqModel      string
+		payloadModel  string
+		wantModel     string
+		wantErr       string
+		wantTransport bool
+	}{
+		{
+			name:          "resolved request model overrides unresolved payload alias",
+			reqModel:      "qoder/auto",
+			payloadModel:  "configured-alias",
+			wantModel:     "auto",
+			wantTransport: true,
+		},
+		{
+			name:          "empty request model preserves payload fallback",
+			payloadModel:  "qoder/auto",
+			wantModel:     "auto",
+			wantTransport: true,
+		},
+		{
+			name:         "unknown resolved request model is rejected before transport",
+			reqModel:     "qoder/unknown-resolved-target",
+			payloadModel: "qoder/auto",
+			wantErr:      `unsupported qoder model: "unknown-resolved-target"`,
+		},
+	}
+
+	for _, mode := range []string{"stream", "non-stream"} {
+		t.Run(mode, func(t *testing.T) {
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					transportCalls := 0
+					ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", qoderRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+						transportCalls++
+						if got := req.Header.Get("X-Model-Key"); got != tt.wantModel {
+							t.Errorf("X-Model-Key = %q, want %q", got, tt.wantModel)
+						}
+						return qoderSSEHTTPResponse(req, http.StatusOK, "data: [DONE]\n\n"), nil
+					}))
+					executor := NewQoderExecutor(&config.Config{})
+					authRecord := &cliproxyauth.Auth{Storage: testQoderStorageWithModelConfig()}
+					req := cliproxyexecutor.Request{
+						Model:   tt.reqModel,
+						Payload: []byte(fmt.Sprintf(`{"model":%q,"messages":[{"role":"user","content":"hi"}]}`, tt.payloadModel)),
+					}
+
+					var err error
+					if mode == "stream" {
+						var result *cliproxyexecutor.StreamResult
+						result, err = executor.ExecuteStream(ctx, authRecord, req, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI})
+						if err == nil {
+							for chunk := range result.Chunks {
+								if chunk.Err != nil {
+									t.Fatalf("stream chunk error = %v", chunk.Err)
+								}
+							}
+						}
+					} else {
+						_, err = executor.Execute(ctx, authRecord, req, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI})
+					}
+
+					if tt.wantErr != "" {
+						if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+							t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+						}
+					} else if err != nil {
+						t.Fatalf("execution error = %v", err)
+					}
+					if got := transportCalls > 0; got != tt.wantTransport {
+						t.Fatalf("transport called = %v (%d calls), want %v", got, transportCalls, tt.wantTransport)
+					}
+				})
+			}
+		})
+	}
+}
 
 func TestValidateQoderModel(t *testing.T) {
 	storage := &qoder.QoderTokenStorage{}


### PR DESCRIPTION
## Summary

- Qoder executor parsed the model name from the request payload (`chatReq["model"]`) instead of using `req.Model`, which the conductor has already resolved through `applyOAuthModelAlias` (`sdk/cliproxy/auth/conductor_execution.go`).
- As a result, configured `oauth-model-alias` entries for qoder (e.g. `.kimi` → `qoder/kmodel_latest`) appeared in `/v1/models` and routed correctly, but every request to an aliased model failed with `unsupported qoder model: ".kimi"`.
- Fix: take the model from `req.Model` (payload value only as a fallback), so qoder consumes the centrally resolved upstream name like every other executor; keep validation against `qoderauth.ModelMap`/`ModelConfigs` unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/runtime/executor/...` — incl. table-driven `TestValidateQoderModel` (ModelMap hit, storage config hit, unsupported model rejection)
- [x] live-verified against a running instance: aliases `qoder/.kimi`, `qoder/.glm`, `qoder/.qwen`, `qoder/.minimax`, `qoder/.deepseek-flash` and original names `qoder/kmodel_latest`, `qoder/qmodel_38max` all return successful tool-call completions (previously HTTP 500 `unsupported qoder model`)
