### PR TITLE
fix(auth): treat empty upstream completions as retriable failures

### DIFF
--- a/internal/pluginhost/executor_route.go
+++ b/internal/pluginhost/executor_route.go
@@ -108,35 +108,111 @@ func (h *Host) ExecutePluginExecutorStream(ctx context.Context, pluginID string,
 	if err != nil {
 		return nil, err
 	}
-	return wrapStreamEmptyCompletion(streamResult), nil
+	return wrapStreamEmptyCompletion(ctx, streamResult), nil
 }
 
 // wrapStreamEmptyCompletion wraps a plugin stream so that a terminal but empty
 // completion (no content, no tool calls) surfaces as an empty-completion error
 // instead of a clean stream end, mirroring the conductor's aggregate-at-close
-// judgment. Chunks are forwarded immediately; the aggregate is only judged once
-// the upstream stream closes.
-func wrapStreamEmptyCompletion(streamResult *coreexecutor.StreamResult) *coreexecutor.StreamResult {
+// judgment. Recognized protocol framing is buffered only until meaningful output
+// appears or the stream closes; unrecognized streams remain pass-through.
+func wrapStreamEmptyCompletion(ctx context.Context, streamResult *coreexecutor.StreamResult) *coreexecutor.StreamResult {
+	if streamResult == nil || streamResult.Chunks == nil {
+		return streamResult
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	src := streamResult.Chunks
 	wrapped := make(chan coreexecutor.StreamChunk)
 	go func() {
 		defer close(wrapped)
-		var aggregate []byte
-		for chunk := range src {
-			if chunk.Err != nil {
-				wrapped <- chunk
+		buffered := make([]coreexecutor.StreamChunk, 0, 1)
+		var detector coreauth.StreamBootstrapDetector
+		forwarding := false
+		forward := func(chunk coreexecutor.StreamChunk) bool {
+			select {
+			case <-ctx.Done():
+				return false
+			case wrapped <- chunk:
+				return true
+			}
+		}
+		flush := func() bool {
+			for _, chunk := range buffered {
+				if !forward(chunk) {
+					return false
+				}
+			}
+			buffered = nil
+			return true
+		}
+
+		for {
+			var (
+				chunk coreexecutor.StreamChunk
+				ok    bool
+			)
+			select {
+			case <-ctx.Done():
+				return
+			case chunk, ok = <-src:
+			}
+			if !ok {
+				if !forwarding && len(buffered) == 0 {
+					_ = forward(coreexecutor.StreamChunk{Err: &coreauth.Error{
+						Code:      "empty_stream",
+						Message:   "upstream stream closed before first payload",
+						Retryable: true,
+					}})
+					return
+				}
+				if !forwarding && coreauth.IsEmptyCompletionPayload(streamChunkPayload(buffered)) {
+					_ = forward(coreexecutor.StreamChunk{Err: coreauth.EmptyCompletionError()})
+					return
+				}
+				_ = flush()
+				return
+			}
+			if forwarding {
+				if !forward(chunk) {
+					return
+				}
+				if chunk.Err != nil {
+					return
+				}
 				continue
 			}
-			if len(chunk.Payload) > 0 {
-				aggregate = append(aggregate, chunk.Payload...)
+
+			buffered = append(buffered, chunk)
+			if chunk.Err != nil {
+				// Before any semantic output, protocol framing is not client-visible.
+				// Surface the upstream failure first so the HTTP layer can still
+				// choose an error response instead of committing a successful stream.
+				buffered = buffered[:0]
+				forwarding = true
+				if !forward(chunk) {
+					return
+				}
+				return
 			}
-			wrapped <- chunk
-		}
-		if coreauth.IsEmptyCompletionPayload(aggregate) {
-			wrapped <- coreexecutor.StreamChunk{Err: coreauth.EmptyCompletionError()}
+			if detector.Observe(chunk.Payload) {
+				forwarding = true
+				if !flush() {
+					return
+				}
+			}
 		}
 	}()
 	return &coreexecutor.StreamResult{Chunks: wrapped, Headers: streamResult.Headers}
+}
+
+func streamChunkPayload(chunks []coreexecutor.StreamChunk) []byte {
+	var payload []byte
+	for _, chunk := range chunks {
+		payload = append(payload, chunk.Payload...)
+	}
+	return payload
 }
 
 // CountPluginExecutor executes a count-tokens request with the named plugin executor without changing the requested model.

--- a/internal/pluginhost/executor_route.go
+++ b/internal/pluginhost/executor_route.go
@@ -88,7 +88,14 @@ func (h *Host) ExecutePluginExecutor(ctx context.Context, pluginID string, req c
 	if errAdapter != nil {
 		return coreexecutor.Response{}, errAdapter
 	}
-	return adapter.Execute(ctx, (*coreauth.Auth)(nil), req, opts)
+	resp, err := adapter.Execute(ctx, (*coreauth.Auth)(nil), req, opts)
+	if err != nil {
+		return coreexecutor.Response{}, err
+	}
+	if coreauth.IsEmptyCompletionPayload(resp.Payload) {
+		return coreexecutor.Response{}, coreauth.EmptyCompletionError()
+	}
+	return resp, nil
 }
 
 // ExecutePluginExecutorStream executes a streaming request with the named plugin executor without changing the requested model.
@@ -97,7 +104,39 @@ func (h *Host) ExecutePluginExecutorStream(ctx context.Context, pluginID string,
 	if errAdapter != nil {
 		return nil, errAdapter
 	}
-	return adapter.ExecuteStream(ctx, (*coreauth.Auth)(nil), req, opts)
+	streamResult, err := adapter.ExecuteStream(ctx, (*coreauth.Auth)(nil), req, opts)
+	if err != nil {
+		return nil, err
+	}
+	return wrapStreamEmptyCompletion(streamResult), nil
+}
+
+// wrapStreamEmptyCompletion wraps a plugin stream so that a terminal but empty
+// completion (no content, no tool calls) surfaces as an empty-completion error
+// instead of a clean stream end, mirroring the conductor's aggregate-at-close
+// judgment. Chunks are forwarded immediately; the aggregate is only judged once
+// the upstream stream closes.
+func wrapStreamEmptyCompletion(streamResult *coreexecutor.StreamResult) *coreexecutor.StreamResult {
+	src := streamResult.Chunks
+	wrapped := make(chan coreexecutor.StreamChunk)
+	go func() {
+		defer close(wrapped)
+		var aggregate []byte
+		for chunk := range src {
+			if chunk.Err != nil {
+				wrapped <- chunk
+				continue
+			}
+			if len(chunk.Payload) > 0 {
+				aggregate = append(aggregate, chunk.Payload...)
+			}
+			wrapped <- chunk
+		}
+		if coreauth.IsEmptyCompletionPayload(aggregate) {
+			wrapped <- coreexecutor.StreamChunk{Err: coreauth.EmptyCompletionError()}
+		}
+	}()
+	return &coreexecutor.StreamResult{Chunks: wrapped, Headers: streamResult.Headers}
 }
 
 // CountPluginExecutor executes a count-tokens request with the named plugin executor without changing the requested model.

--- a/internal/pluginhost/executor_route_stream_test.go
+++ b/internal/pluginhost/executor_route_stream_test.go
@@ -1,0 +1,242 @@
+package pluginhost
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestWrapStreamEmptyCompletionWithholdsTerminalFrames(t *testing.T) {
+	src := make(chan coreexecutor.StreamChunk, 2)
+	src <- coreexecutor.StreamChunk{Payload: []byte("data: {\"type\":\"response.completed\",\"response\":{\"output\":[],\"usage\":{\"output_tokens\":0}}}\n\n")}
+	src <- coreexecutor.StreamChunk{Payload: []byte("data: [DONE]\n\n")}
+	close(src)
+
+	wrapped := wrapStreamEmptyCompletion(context.Background(), &coreexecutor.StreamResult{Chunks: src})
+	first, ok := <-wrapped.Chunks
+	if !ok {
+		t.Fatal("wrapped stream closed without empty_completion error")
+	}
+	if len(first.Payload) != 0 {
+		t.Fatalf("first payload = %q, want no terminal bytes before error", first.Payload)
+	}
+	var authErr *coreauth.Error
+	if !errors.As(first.Err, &authErr) || authErr.Code != "empty_completion" {
+		t.Fatalf("first error = %v, want empty_completion", first.Err)
+	}
+	if _, ok = <-wrapped.Chunks; ok {
+		t.Fatal("wrapped stream emitted chunks after empty_completion error")
+	}
+}
+
+func TestWrapStreamEmptyCompletionRejectsZeroChunkStream(t *testing.T) {
+	src := make(chan coreexecutor.StreamChunk)
+	close(src)
+
+	wrapped := wrapStreamEmptyCompletion(context.Background(), &coreexecutor.StreamResult{Chunks: src})
+	first, ok := <-wrapped.Chunks
+	if !ok {
+		t.Fatal("wrapped stream closed without empty_stream error")
+	}
+	var authErr *coreauth.Error
+	if !errors.As(first.Err, &authErr) || authErr.Code != "empty_stream" || !authErr.Retryable {
+		t.Fatalf("first error = %#v, want retryable empty_stream", first.Err)
+	}
+	if len(first.Payload) != 0 {
+		t.Fatalf("first payload = %q, want error before client-visible bytes", first.Payload)
+	}
+	if _, ok = <-wrapped.Chunks; ok {
+		t.Fatal("wrapped stream emitted chunks after empty_stream error")
+	}
+}
+
+func TestWrapStreamEmptyCompletionWithholdsSplitTerminalFrames(t *testing.T) {
+	fragments := [][]byte{
+		[]byte("da"),
+		[]byte("ta: {\"type\":\"response.com"),
+		[]byte("pleted\",\"response\":{\"output\":[],\"usage\":{\"output_tokens\":0}}}\n\n"),
+		[]byte("data: [DO"),
+		[]byte("NE]\n"),
+		[]byte("\n"),
+	}
+	src := make(chan coreexecutor.StreamChunk, len(fragments))
+	for _, fragment := range fragments {
+		src <- coreexecutor.StreamChunk{Payload: fragment}
+	}
+	close(src)
+
+	wrapped := wrapStreamEmptyCompletion(context.Background(), &coreexecutor.StreamResult{Chunks: src})
+	first, ok := <-wrapped.Chunks
+	if !ok {
+		t.Fatal("wrapped split stream closed without empty_completion error")
+	}
+	if len(first.Payload) != 0 {
+		t.Fatalf("first payload = %q, want no split terminal bytes before error", first.Payload)
+	}
+	var authErr *coreauth.Error
+	if !errors.As(first.Err, &authErr) || authErr.Code != "empty_completion" {
+		t.Fatalf("first error = %v, want empty_completion", first.Err)
+	}
+	if _, ok = <-wrapped.Chunks; ok {
+		t.Fatal("wrapped stream emitted chunks after empty_completion error")
+	}
+}
+
+func TestWrapStreamEmptyCompletionForwardsSplitMeaningfulOutputInOrder(t *testing.T) {
+	fragments := [][]byte{
+		[]byte("da"),
+		[]byte("ta: {\"choices\":[{\"delta\":{\"content\":"),
+		[]byte("\"hello\"},\"finish_reason\":null}]}\n"),
+		[]byte("\n"),
+	}
+	src := make(chan coreexecutor.StreamChunk, len(fragments))
+	for _, fragment := range fragments {
+		src <- coreexecutor.StreamChunk{Payload: fragment}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	wrapped := wrapStreamEmptyCompletion(ctx, &coreexecutor.StreamResult{Chunks: src})
+	for _, fragment := range fragments {
+		assertStreamPayload(t, wrapped.Chunks, fragment)
+	}
+	close(src)
+	if _, ok := <-wrapped.Chunks; ok {
+		t.Fatal("wrapped stream emitted an unexpected trailing chunk")
+	}
+}
+
+func TestWrapStreamEmptyCompletionForwardsMeaningfulOutputInOrder(t *testing.T) {
+	emptyFrame := []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":null}]}\n\n")
+	contentFrame := []byte("data: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n")
+	src := make(chan coreexecutor.StreamChunk, 2)
+	src <- coreexecutor.StreamChunk{Payload: emptyFrame}
+	src <- coreexecutor.StreamChunk{Payload: contentFrame}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	wrapped := wrapStreamEmptyCompletion(ctx, &coreexecutor.StreamResult{Chunks: src})
+	assertStreamPayload(t, wrapped.Chunks, emptyFrame)
+	assertStreamPayload(t, wrapped.Chunks, contentFrame)
+	close(src)
+	if _, ok := <-wrapped.Chunks; ok {
+		t.Fatal("wrapped stream emitted an unexpected trailing chunk")
+	}
+}
+
+func TestWrapStreamEmptyCompletionForwardsUnrecognizedStreamPromptly(t *testing.T) {
+	firstPayload := []byte("opaque: first\n")
+	secondPayload := []byte("opaque: second\n")
+	src := make(chan coreexecutor.StreamChunk, 1)
+	src <- coreexecutor.StreamChunk{Payload: firstPayload}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	wrapped := wrapStreamEmptyCompletion(ctx, &coreexecutor.StreamResult{Chunks: src})
+	assertStreamPayload(t, wrapped.Chunks, firstPayload)
+	src <- coreexecutor.StreamChunk{Payload: secondPayload}
+	assertStreamPayload(t, wrapped.Chunks, secondPayload)
+	close(src)
+	if _, ok := <-wrapped.Chunks; ok {
+		t.Fatal("wrapped stream emitted an unexpected trailing chunk")
+	}
+}
+
+func TestWrapStreamEmptyCompletionWithholdsMetadataBeforeUpstreamError(t *testing.T) {
+	upstreamErr := errors.New("upstream failed")
+	src := make(chan coreexecutor.StreamChunk, 2)
+	src <- coreexecutor.StreamChunk{Payload: []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":null}]}\n\n")}
+	src <- coreexecutor.StreamChunk{Err: upstreamErr}
+	close(src)
+
+	wrapped := wrapStreamEmptyCompletion(context.Background(), &coreexecutor.StreamResult{Chunks: src})
+	first, ok := <-wrapped.Chunks
+	if !ok {
+		t.Fatal("wrapped stream closed without upstream error")
+	}
+	if len(first.Payload) != 0 {
+		t.Fatalf("first payload = %q, want no metadata before upstream error", first.Payload)
+	}
+	if !errors.Is(first.Err, upstreamErr) {
+		t.Fatalf("first error = %v, want %v", first.Err, upstreamErr)
+	}
+	if _, ok = <-wrapped.Chunks; ok {
+		t.Fatal("wrapped stream emitted chunks after upstream error")
+	}
+}
+
+func TestWrapStreamEmptyCompletionPreservesContentBeforeUpstreamError(t *testing.T) {
+	metadata := []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":null}]}\n\n")
+	content := []byte("data: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n")
+	upstreamErr := errors.New("upstream failed")
+	src := make(chan coreexecutor.StreamChunk, 3)
+	src <- coreexecutor.StreamChunk{Payload: metadata}
+	src <- coreexecutor.StreamChunk{Payload: content}
+	src <- coreexecutor.StreamChunk{Err: upstreamErr}
+	close(src)
+
+	wrapped := wrapStreamEmptyCompletion(context.Background(), &coreexecutor.StreamResult{Chunks: src})
+	assertStreamPayload(t, wrapped.Chunks, metadata)
+	assertStreamPayload(t, wrapped.Chunks, content)
+	errorChunk, ok := <-wrapped.Chunks
+	if !ok {
+		t.Fatal("wrapped stream closed before upstream error")
+	}
+	if !errors.Is(errorChunk.Err, upstreamErr) {
+		t.Fatalf("error = %v, want %v", errorChunk.Err, upstreamErr)
+	}
+	if _, ok = <-wrapped.Chunks; ok {
+		t.Fatal("wrapped stream emitted chunks after upstream error")
+	}
+}
+
+func TestWrapStreamEmptyCompletionPreservesNilResults(t *testing.T) {
+	if got := wrapStreamEmptyCompletion(context.Background(), nil); got != nil {
+		t.Fatalf("wrapStreamEmptyCompletion(nil) = %#v, want nil", got)
+	}
+
+	result := &coreexecutor.StreamResult{Headers: http.Header{"X-Test": []string{"value"}}}
+	if got := wrapStreamEmptyCompletion(context.Background(), result); got != result {
+		t.Fatalf("wrapStreamEmptyCompletion(nil chunks) = %#v, want original result", got)
+	}
+}
+
+func TestWrapStreamEmptyCompletionStopsWhenContextCanceled(t *testing.T) {
+	src := make(chan coreexecutor.StreamChunk, 1)
+	src <- coreexecutor.StreamChunk{Payload: []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":null}]}\n\n")}
+	ctx, cancel := context.WithCancel(context.Background())
+	wrapped := wrapStreamEmptyCompletion(ctx, &coreexecutor.StreamResult{Chunks: src})
+	cancel()
+
+	select {
+	case _, ok := <-wrapped.Chunks:
+		if ok {
+			t.Fatal("wrapped stream emitted a chunk after cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("wrapped stream did not close after cancellation")
+	}
+}
+
+func assertStreamPayload(t *testing.T, chunks <-chan coreexecutor.StreamChunk, want []byte) {
+	t.Helper()
+	select {
+	case chunk, ok := <-chunks:
+		if !ok {
+			t.Fatalf("stream closed before payload %q", want)
+		}
+		if chunk.Err != nil {
+			t.Fatalf("chunk error = %v, want payload %q", chunk.Err, want)
+		}
+		if string(chunk.Payload) != string(want) {
+			t.Fatalf("payload = %q, want %q", chunk.Payload, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for payload %q", want)
+	}
+}

--- a/internal/pluginhost/model_router_test.go
+++ b/internal/pluginhost/model_router_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"testing"
 
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -159,6 +160,87 @@ func TestHostExecutePluginExecutorByPluginIDPreservesModel(t *testing.T) {
 	}
 	if gotReq.Model != "client-model" {
 		t.Fatalf("executor request model = %q, want client-model", gotReq.Model)
+	}
+}
+
+func TestHostExecutePluginExecutorRejectsEmptyCompletion(t *testing.T) {
+	executor := &fakeExecutor{
+		identifier: "plugin-provider",
+		execute: func(ctx context.Context, req pluginapi.ExecutorRequest) (pluginapi.ExecutorResponse, error) {
+			return pluginapi.ExecutorResponse{Payload: []byte(`{"choices":[{"message":{"content":""},"finish_reason":"stop"}],"usage":{"completion_tokens":0}}`)}, nil
+		},
+	}
+	host := newRouteModelHostWithRecords(capabilityRecord{
+		id: "executor",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			Executor:              executor,
+			ExecutorInputFormats:  []string{"openai"},
+			ExecutorOutputFormats: []string{"openai"},
+		}},
+	})
+
+	_, errExecute := host.ExecutePluginExecutor(context.Background(), "executor", coreexecutor.Request{Model: "client-model", Payload: []byte(`{"model":"client-model"}`)}, coreexecutor.Options{})
+	if errExecute == nil {
+		t.Fatal("ExecutePluginExecutor() with empty completion = nil, want retriable error")
+	}
+	var authErr *coreauth.Error
+	if !errors.As(errExecute, &authErr) {
+		t.Fatalf("error = %v (%T), want *coreauth.Error", errExecute, errExecute)
+	}
+	if !authErr.Retryable || authErr.Code != "empty_completion" {
+		t.Fatalf("error = %+v, want retriable empty_completion", authErr)
+	}
+	if authErr.StatusCode() != http.StatusServiceUnavailable {
+		t.Fatalf("error status = %d, want %d", authErr.StatusCode(), http.StatusServiceUnavailable)
+	}
+}
+
+func TestHostExecutePluginExecutorStreamRejectsEmptyCompletion(t *testing.T) {
+	streamChunks := make(chan pluginapi.ExecutorStreamChunk)
+	executor := &fakeExecutor{
+		identifier: "plugin-provider",
+		executeStream: func(ctx context.Context, req pluginapi.ExecutorRequest) (pluginapi.ExecutorStreamResponse, error) {
+			return pluginapi.ExecutorStreamResponse{Chunks: streamChunks}, nil
+		},
+	}
+	host := newRouteModelHostWithRecords(capabilityRecord{
+		id: "executor",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			Executor:              executor,
+			ExecutorInputFormats:  []string{"openai"},
+			ExecutorOutputFormats: []string{"openai"},
+		}},
+	})
+
+	streamResult, errStream := host.ExecutePluginExecutorStream(context.Background(), "executor", coreexecutor.Request{Model: "client-model", Payload: []byte(`{"model":"client-model"}`)}, coreexecutor.Options{})
+	if errStream != nil {
+		t.Fatalf("ExecutePluginExecutorStream() unexpected error = %v", errStream)
+	}
+
+	go func() {
+		streamChunks <- pluginapi.ExecutorStreamChunk{Payload: []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n")}
+		streamChunks <- pluginapi.ExecutorStreamChunk{Payload: []byte("data: [DONE]\n\n")}
+		close(streamChunks)
+	}()
+
+	var aggregated []byte
+	var emptyErr error
+	for chunk := range streamResult.Chunks {
+		if chunk.Err != nil {
+			emptyErr = chunk.Err
+			break
+		}
+		aggregated = append(aggregated, chunk.Payload...)
+	}
+	if emptyErr == nil {
+		t.Fatalf("stream chunks (%q) closed clean, want empty_completion error", aggregated)
+	}
+	var authErr *coreauth.Error
+	if !errors.As(emptyErr, &authErr) {
+		t.Fatalf("error = %v (%T), want *coreauth.Error", emptyErr, emptyErr)
+	}
+	if !authErr.Retryable || authErr.Code != "empty_completion" {
+		t.Fatalf("error = %+v, want retriable empty_completion", authErr)
 	}
 }
 

--- a/internal/runtime/executor/home_codex_terminal_test.go
+++ b/internal/runtime/executor/home_codex_terminal_test.go
@@ -45,7 +45,21 @@ func TestHomeCodexTerminalStreamFailureUsesFreshDispatchOnNextRequest(t *testing
 			_ = conn.WriteJSON(map[string]any{"type": "response.created", "response": map[string]any{"id": "response-1"}})
 			_ = conn.WriteJSON(map[string]any{"type": "error", "status": http.StatusBadGateway, "error": map[string]any{"message": "terminal failure"}})
 		} else {
-			_ = conn.WriteJSON(map[string]any{"type": "response.completed", "response": map[string]any{"id": "response-2", "output": []any{}}})
+			writeCompletion := func() {
+				_ = conn.WriteJSON(map[string]any{"type": "response.completed", "response": map[string]any{
+					"id": "response-2", "object": "response", "status": "completed",
+					"output": []any{map[string]any{
+						"type": "message", "status": "completed", "role": "assistant",
+						"content": []any{map[string]any{"type": "output_text", "text": "ok"}},
+					}},
+					"usage": map[string]any{"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+				}})
+			}
+			writeCompletion()
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+			writeCompletion()
 		}
 		for {
 			if _, _, errRead := conn.ReadMessage(); errRead != nil {

--- a/internal/runtime/executor/websocket_session_target_test.go
+++ b/internal/runtime/executor/websocket_session_target_test.go
@@ -29,6 +29,8 @@ type rejectSecondBindLifecycle struct {
 	binds atomic.Int32
 }
 
+const websocketSessionTargetCompletion = `{"type":"response.completed","response":{"id":"response-1","object":"response","status":"completed","output":[{"type":"message","id":"message-1","status":"completed","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`
+
 func (l *rejectSecondBindLifecycle) Bind(func() error) error {
 	if l.binds.Add(1) > 1 {
 		return fmt.Errorf("retry lifecycle bind rejected")
@@ -249,7 +251,7 @@ func TestWebsocketRetryBindFailureClearsActiveSessionState(t *testing.T) {
 				if _, _, errRead := conn.ReadMessage(); errRead != nil {
 					return
 				}
-				completed := []byte(`{"type":"response.completed","response":{"id":"response-1","output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}`)
+				completed := []byte(websocketSessionTargetCompletion)
 				if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
 					t.Errorf("write websocket completion: %v", errWrite)
 				}
@@ -764,7 +766,7 @@ func TestAuditAccountedCodexXAIReconnectReuseAndTargetChange(t *testing.T) {
 					if _, _, errRead := conn.ReadMessage(); errRead != nil {
 						return
 					}
-					completed := []byte(`{"type":"response.completed","response":{"id":"response-1","output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}`)
+					completed := []byte(websocketSessionTargetCompletion)
 					if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
 						return
 					}
@@ -961,7 +963,7 @@ func TestAuditHomeCodex426WebsocketToHTTPFreshSelection(t *testing.T) {
 		}
 		httpFallbackCalls.Add(1)
 		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"response-1\",\"output\":[],\"usage\":{\"input_tokens\":0,\"output_tokens\":0,\"total_tokens\":0}}}\n\n"))
+		_, _ = w.Write([]byte("data: " + websocketSessionTargetCompletion + "\n\n"))
 	}))
 	defer httpFallback.Close()
 

--- a/internal/runtime/executor/websocket_session_target_test.go
+++ b/internal/runtime/executor/websocket_session_target_test.go
@@ -233,6 +233,7 @@ func TestWebsocketRetryBindFailureClearsActiveSessionState(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 			var connections atomic.Int32
+			releaseSuccessfulConnection := make(chan struct{})
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				conn, errUpgrade := upgrader.Upgrade(w, r, nil)
 				if errUpgrade != nil {
@@ -255,8 +256,14 @@ func TestWebsocketRetryBindFailureClearsActiveSessionState(t *testing.T) {
 				if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
 					t.Errorf("write websocket completion: %v", errWrite)
 				}
+				select {
+				case <-releaseSuccessfulConnection:
+				case <-time.After(5 * time.Second):
+					t.Error("timed out waiting to release successful websocket connection")
+				}
 			}))
 			defer server.Close()
+			defer close(releaseSuccessfulConnection)
 
 			lifecycle := &rejectSecondBindLifecycle{}
 			opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse, ResponseFormat: sdktranslator.FormatOpenAIResponse, ExecutionLifecycle: lifecycle, Metadata: map[string]any{cliproxyexecutor.ExecutionSessionMetadataKey: "retry-bind"}}

--- a/sdk/api/handlers/openai/openai_responses_multi_agent_test.go
+++ b/sdk/api/handlers/openai/openai_responses_multi_agent_test.go
@@ -91,11 +91,13 @@ type responsesMultiAgentCaptureExecutor struct {
 	websocketDirectCaptureExecutor
 }
 
+const responsesMultiAgentCompletion = `{"id":"resp-1","status":"completed","output":[{"type":"message","id":"msg-1","role":"assistant","content":[{"type":"output_text","text":"ok"}]}]}`
+
 func (e *responsesMultiAgentCaptureExecutor) Execute(_ context.Context, _ *coreauth.Auth, req coreexecutor.Request, _ coreexecutor.Options) (coreexecutor.Response, error) {
 	e.mu.Lock()
 	e.payloads = append(e.payloads, bytes.Clone(req.Payload))
 	e.mu.Unlock()
-	return coreexecutor.Response{Payload: []byte(`{"id":"resp-1","output":[]}`)}, nil
+	return coreexecutor.Response{Payload: []byte(responsesMultiAgentCompletion)}, nil
 }
 
 func (e *responsesMultiAgentCaptureExecutor) ExecuteStream(_ context.Context, _ *coreauth.Auth, req coreexecutor.Request, _ coreexecutor.Options) (*coreexecutor.StreamResult, error) {
@@ -103,7 +105,7 @@ func (e *responsesMultiAgentCaptureExecutor) ExecuteStream(_ context.Context, _ 
 	e.payloads = append(e.payloads, bytes.Clone(req.Payload))
 	e.mu.Unlock()
 	chunks := make(chan coreexecutor.StreamChunk, 1)
-	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"output\":[]}}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte(fmt.Sprintf("data: {\"type\":\"response.completed\",\"response\":%s}\n\n", responsesMultiAgentCompletion))}
 	close(chunks)
 	return &coreexecutor.StreamResult{Chunks: chunks}, nil
 }

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -58,6 +58,10 @@ type homeResponsesWebsocketExecutor struct {
 	mu       sync.Mutex
 }
 
+func successfulResponsesWebsocketCompletion(responseID, messageID string) []byte {
+	return []byte(fmt.Sprintf(`{"type":"response.completed","response":{"id":%q,"object":"response","status":"completed","output":[{"type":"message","id":%q,"status":"completed","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`, responseID, messageID))
+}
+
 func (*homeResponsesWebsocketExecutor) Identifier() string { return "codex" }
 
 func (*homeResponsesWebsocketExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
@@ -73,7 +77,7 @@ func (e *homeResponsesWebsocketExecutor) ExecuteStream(_ context.Context, _ *cor
 		lifecycle.Retain()
 	}
 	chunks := make(chan coreexecutor.StreamChunk, 1)
-	chunks <- coreexecutor.StreamChunk{Payload: []byte(`{"type":"response.completed","response":{"id":"home-response","output":[]}}`)}
+	chunks <- coreexecutor.StreamChunk{Payload: successfulResponsesWebsocketCompletion("home-response", "home-message")}
 	close(chunks)
 	return &coreexecutor.StreamResult{Chunks: chunks}, nil
 }
@@ -729,7 +733,7 @@ func (e *websocketBootstrapFallbackExecutor) ExecuteStream(_ context.Context, au
 		return &coreexecutor.StreamResult{Chunks: chunks}, nil
 	}
 
-	chunks <- coreexecutor.StreamChunk{Payload: []byte(`{"type":"response.completed","response":{"id":"resp-http","output":[{"type":"message","id":"out-http"}]}}`)}
+	chunks <- coreexecutor.StreamChunk{Payload: successfulResponsesWebsocketCompletion("resp-http", "out-http")}
 	close(chunks)
 	return &coreexecutor.StreamResult{Chunks: chunks}, nil
 }
@@ -798,7 +802,7 @@ func (e *websocketDirectCaptureExecutor) ExecuteStream(ctx context.Context, auth
 		return &coreexecutor.StreamResult{Chunks: chunks}, nil
 	}
 	responseID := fmt.Sprintf("resp-%d", count)
-	chunks <- coreexecutor.StreamChunk{Payload: []byte(fmt.Sprintf(`{"type":"response.completed","response":{"id":%q,"output":[{"type":"message","id":"out-%d"}]}}`, responseID, count))}
+	chunks <- coreexecutor.StreamChunk{Payload: successfulResponsesWebsocketCompletion(responseID, fmt.Sprintf("out-%d", count))}
 	close(chunks)
 	if count >= 2 && e.done != nil {
 		e.doneOnce.Do(func() {
@@ -874,7 +878,7 @@ func (e *websocketCanonicalRollbackExecutor) ExecuteStream(_ context.Context, _ 
 		close(chunks)
 		return &coreexecutor.StreamResult{Chunks: chunks}, nil
 	}
-	chunks <- coreexecutor.StreamChunk{Payload: []byte(fmt.Sprintf(`{"type":"response.completed","response":{"id":"resp-%d","output":[{"type":"message","id":"out-%d"}]}}`, call, call))}
+	chunks <- coreexecutor.StreamChunk{Payload: successfulResponsesWebsocketCompletion(fmt.Sprintf("resp-%d", call), fmt.Sprintf("out-%d", call))}
 	close(chunks)
 	return &coreexecutor.StreamResult{Chunks: chunks}, nil
 }
@@ -994,7 +998,7 @@ func (e *websocketAuthCaptureExecutor) ExecuteStream(_ context.Context, auth *co
 	e.mu.Unlock()
 
 	chunks := make(chan coreexecutor.StreamChunk, 1)
-	chunks <- coreexecutor.StreamChunk{Payload: []byte(`{"type":"response.completed","response":{"id":"resp-upstream","output":[{"type":"message","id":"out-1"}]}}`)}
+	chunks <- coreexecutor.StreamChunk{Payload: successfulResponsesWebsocketCompletion("resp-upstream", "out-1")}
 	close(chunks)
 	return &coreexecutor.StreamResult{Chunks: chunks}, nil
 }
@@ -1053,7 +1057,7 @@ func (e *websocketPinnedFailoverExecutor) ExecuteStream(_ context.Context, auth 
 	}
 
 	chunks := make(chan coreexecutor.StreamChunk, 1)
-	chunks <- coreexecutor.StreamChunk{Payload: []byte(fmt.Sprintf(`{"type":"response.completed","response":{"id":"resp-%s-%d","output":[{"type":"message","id":"out-%s-%d"}]}}`, authID, call, authID, call))}
+	chunks <- coreexecutor.StreamChunk{Payload: successfulResponsesWebsocketCompletion(fmt.Sprintf("resp-%s-%d", authID, call), fmt.Sprintf("out-%s-%d", authID, call))}
 	close(chunks)
 	return &coreexecutor.StreamResult{Chunks: chunks}, nil
 }
@@ -1104,7 +1108,7 @@ func (e *websocketCaptureExecutor) ExecuteStream(_ context.Context, _ *coreauth.
 	e.streamCalls++
 	e.payloads = append(e.payloads, bytes.Clone(req.Payload))
 	chunks := make(chan coreexecutor.StreamChunk, 1)
-	chunks <- coreexecutor.StreamChunk{Payload: []byte(`{"type":"response.completed","response":{"id":"resp-upstream","output":[{"type":"message","id":"out-1"}]}}`)}
+	chunks <- coreexecutor.StreamChunk{Payload: successfulResponsesWebsocketCompletion("resp-upstream", "out-1")}
 	close(chunks)
 	return &coreexecutor.StreamResult{Chunks: chunks}, nil
 }
@@ -1144,9 +1148,9 @@ func (e *websocketCompactionCaptureExecutor) ExecuteStream(_ context.Context, _ 
 	case 0:
 		payload = []byte(`{"type":"response.completed","response":{"id":"resp-1","output":[{"type":"function_call","id":"fc-1","call_id":"call-1","name":"tool"}]}}`)
 	case 1:
-		payload = []byte(`{"type":"response.completed","response":{"id":"resp-2","output":[{"type":"message","id":"assistant-1"}]}}`)
+		payload = successfulResponsesWebsocketCompletion("resp-2", "assistant-1")
 	default:
-		payload = []byte(`{"type":"response.completed","response":{"id":"resp-3","output":[{"type":"message","id":"assistant-2"}]}}`)
+		payload = successfulResponsesWebsocketCompletion("resp-3", "assistant-2")
 	}
 
 	chunks := make(chan coreexecutor.StreamChunk, 1)
@@ -4757,7 +4761,7 @@ func (e *websocketPinnedPrematureCloseExecutor) ExecuteStream(_ context.Context,
 	}
 
 	chunks := make(chan coreexecutor.StreamChunk, 1)
-	chunks <- coreexecutor.StreamChunk{Payload: []byte(fmt.Sprintf(`{"type":"response.completed","response":{"id":"resp-%s-%d","output":[{"type":"message","id":"out-%s-%d"}]}}`, authID, call, authID, call))}
+	chunks <- coreexecutor.StreamChunk{Payload: successfulResponsesWebsocketCompletion(fmt.Sprintf("resp-%s-%d", authID, call), fmt.Sprintf("out-%s-%d", authID, call))}
 	close(chunks)
 	return &coreexecutor.StreamResult{Chunks: chunks}, nil
 }

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -551,6 +551,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 	tried := make(map[string]struct{})
 	attempted := make(map[string]struct{})
 	unauthorizedRefreshTried := make(map[string]struct{})
+	emptyCompletionTried := make(map[string]struct{})
 	var lastErr error
 	for {
 		if !homeMode && maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
@@ -592,6 +593,13 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			return nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 		}
 		if selection != nil {
+			if _, emptyAlready := emptyCompletionTried[auth.ID]; emptyAlready {
+				selection.End("repeated_empty_completion_auth")
+				if lastErr != nil {
+					return nil, lastErr
+				}
+				return nil, errEmptyCompletion
+			}
 			if _, refreshedAlready := unauthorizedRefreshTried[auth.ID]; refreshedAlready {
 				selection.End("repeated_refresh_auth")
 				if lastErr != nil {
@@ -698,6 +706,9 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			}
 			lastErr = errStream
 			if homeMode {
+				if isEmptyCompletionError(errStream) {
+					emptyCompletionTried[auth.ID] = struct{}{}
+				}
 				homeAuthCount++
 			}
 			continue

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -382,10 +382,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				continue
 			}
 			if isEmptyCompletionPayload(resp.Payload) {
-				result.Success = false
-				result.Error = errEmptyCompletion
-				m.MarkResult(execCtx, result)
-				authErr = errEmptyCompletion
+				authErr = m.markEmptyCompletion(execCtx, &result)
 				continue
 			}
 			m.MarkResult(execCtx, result)

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -381,6 +381,13 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				authErr = errExec
 				continue
 			}
+			if isEmptyCompletionPayload(resp.Payload) {
+				result.Success = false
+				result.Error = errEmptyCompletion
+				m.MarkResult(execCtx, result)
+				authErr = errEmptyCompletion
+				continue
+			}
 			m.MarkResult(execCtx, result)
 			attemptAliasResult := resolveAttemptAliasResult(routing, auth, routeModel, upstreamModel, aliasResult)
 			rewriteForceMappedResponse(&resp, attemptAliasResult)

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -1125,9 +1125,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 				continue
 			}
 			if isEmptyCompletionPayload(resp.Payload) {
-				result.Success = false
-				result.Error = errEmptyCompletion
-				m.MarkResult(creditsCtx, result)
+				m.markEmptyCompletion(creditsCtx, &result)
 				continue
 			}
 			m.MarkResult(creditsCtx, result)

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -1124,6 +1124,12 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 				m.MarkResult(creditsCtx, result)
 				continue
 			}
+			if isEmptyCompletionPayload(resp.Payload) {
+				result.Success = false
+				result.Error = errEmptyCompletion
+				m.MarkResult(creditsCtx, result)
+				continue
+			}
 			m.MarkResult(creditsCtx, result)
 			attemptAliasResult := resolveAttemptAliasResult(routing, c.auth, routeModel, upstreamModel, aliasResult)
 			rewriteForceMappedResponse(&resp, attemptAliasResult)

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -1125,7 +1125,9 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 				continue
 			}
 			if isEmptyCompletionPayload(resp.Payload) {
-				m.markEmptyCompletion(creditsCtx, &result)
+				result.Success = false
+				result.Error = errEmptyCompletion
+				m.recordExecutionResult(creditsCtx, result, c.auth, false)
 				continue
 			}
 			m.MarkResult(creditsCtx, result)

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -166,6 +166,13 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 				}
 			}
 			result := Result{AuthID: preparedAuth.ID, Provider: selection.Provider, Model: resultModel, Success: errExecute == nil}
+			if errExecute == nil && isEmptyCompletionPayload(response.Payload) {
+				result.Success = false
+				result.Error = errEmptyCompletion
+				m.reportHomeResult(execCtx, result, preparedAuth)
+				lastErr = errEmptyCompletion
+				continue
+			}
 			if errExecute == nil {
 				m.reportHomeResult(execCtx, result, preparedAuth)
 				releaseAttempt()

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -86,6 +86,7 @@ func readStreamBootstrap(ctx context.Context, ch <-chan cliproxyexecutor.StreamC
 		return nil, true, nil
 	}
 	buffered := make([]cliproxyexecutor.StreamChunk, 0, 1)
+	var bootstrap streamBootstrapState
 	for {
 		var (
 			chunk cliproxyexecutor.StreamChunk
@@ -107,7 +108,7 @@ func readStreamBootstrap(ctx context.Context, ch <-chan cliproxyexecutor.StreamC
 			return nil, false, chunk.Err
 		}
 		buffered = append(buffered, chunk)
-		if streamBootstrapShouldForward(buffered) {
+		if bootstrap.observe(chunk.Payload) {
 			return buffered, false, nil
 		}
 	}

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -107,7 +107,7 @@ func readStreamBootstrap(ctx context.Context, ch <-chan cliproxyexecutor.StreamC
 			return nil, false, chunk.Err
 		}
 		buffered = append(buffered, chunk)
-		if len(chunk.Payload) > 0 {
+		if streamBootstrapShouldForward(buffered) {
 			return buffered, false, nil
 		}
 	}
@@ -349,8 +349,11 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			return nil, newStreamBootstrapError(bootstrapErr, streamResult.Headers)
 		}
 
-		if closed && len(buffered) == 0 {
+		if closed && (len(buffered) == 0 || isEmptyCompletion(buffered)) {
 			emptyErr := &Error{Code: "empty_stream", Message: "upstream stream closed before first payload", Retryable: true}
+			if len(buffered) > 0 {
+				emptyErr = errEmptyCompletion
+			}
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: emptyErr}
 			m.recordExecutionResult(ctx, result, auth, ephemeralResult)
 			if idx < len(execModels)-1 {

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -350,9 +350,9 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		}
 
 		if closed && (len(buffered) == 0 || isEmptyCompletion(buffered)) {
-			emptyErr := &Error{Code: "empty_stream", Message: "upstream stream closed before first payload", Retryable: true}
-			if len(buffered) > 0 {
-				emptyErr = errEmptyCompletion
+			emptyErr := errEmptyCompletion
+			if len(buffered) == 0 {
+				emptyErr = &Error{Code: "empty_stream", Message: "upstream stream closed before first payload", Retryable: true}
 			}
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: emptyErr}
 			m.recordExecutionResult(ctx, result, auth, ephemeralResult)

--- a/sdk/cliproxy/auth/empty_completion.go
+++ b/sdk/cliproxy/auth/empty_completion.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"strings"
 
@@ -73,13 +74,9 @@ type claudeChunk struct {
 type geminiPart struct {
 	Text             string          `json:"text"`
 	FunctionCall     json.RawMessage `json:"functionCall"`
-	FunctionCallAlt  json.RawMessage `json:"function_call"`
 	InlineData       json.RawMessage `json:"inlineData"`
-	InlineDataAlt    json.RawMessage `json:"inline_data"`
 	FileData         json.RawMessage `json:"fileData"`
-	FileDataAlt      json.RawMessage `json:"file_data"`
 	FunctionResponse json.RawMessage `json:"functionResponse"`
-	FunctionRespAlt  json.RawMessage `json:"function_response"`
 	Thought          json.RawMessage `json:"thought"`
 }
 
@@ -92,17 +89,14 @@ type geminiCandidate struct {
 
 type geminiUsageMetadata struct {
 	CandidatesTokenCount *int `json:"candidatesTokenCount"`
-	CandidatesTokensAlt  *int `json:"candidates_token_count"`
 }
 
 type geminiChunk struct {
-	Candidates       []geminiCandidate    `json:"candidates"`
-	UsageMetadata    *geminiUsageMetadata `json:"usageMetadata"`
-	UsageMetadataAlt *geminiUsageMetadata `json:"usage_metadata"`
-	Response         *struct {
-		Candidates       []geminiCandidate    `json:"candidates"`
-		UsageMetadata    *geminiUsageMetadata `json:"usageMetadata"`
-		UsageMetadataAlt *geminiUsageMetadata `json:"usage_metadata"`
+	Candidates    []geminiCandidate    `json:"candidates"`
+	UsageMetadata *geminiUsageMetadata `json:"usageMetadata"`
+	Response      *struct {
+		Candidates    []geminiCandidate    `json:"candidates"`
+		UsageMetadata *geminiUsageMetadata `json:"usageMetadata"`
 	} `json:"response"`
 }
 
@@ -115,6 +109,7 @@ type emptyCompletionAccum struct {
 	hasToolCalls     bool
 	completionTokens int
 	sawUsage         bool
+	blocked          bool
 }
 
 func (a *emptyCompletionAccum) evalJSON(data []byte) {
@@ -128,11 +123,21 @@ func (a *emptyCompletionAccum) evalJSON(data []byte) {
 }
 
 func (a *emptyCompletionAccum) evalOpenAI(data []byte) bool {
-	var chunk openAIChunk
-	if err := json.Unmarshal(data, &chunk); err != nil || len(chunk.Choices) == 0 {
+	// Recognize the OpenAI shape by the presence of a "choices" key, even when
+	// the array is empty (e.g. {"choices":[]}). Such prefixes must still be
+	// judged at stream close instead of being forwarded immediately.
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return false
+	}
+	if _, ok := probe["choices"]; !ok {
 		return false
 	}
 	a.recognized = true
+	var chunk openAIChunk
+	if err := json.Unmarshal(data, &chunk); err != nil {
+		return true
+	}
 	if chunk.Usage != nil && chunk.Usage.CompletionTokens != nil {
 		a.sawUsage = true
 		a.completionTokens += *chunk.Usage.CompletionTokens
@@ -253,9 +258,6 @@ func (a *emptyCompletionAccum) evalGemini(data []byte) bool {
 
 	candidates := chunk.Candidates
 	usage := chunk.UsageMetadata
-	if usage == nil {
-		usage = chunk.UsageMetadataAlt
-	}
 
 	if chunk.Response != nil {
 		if len(candidates) == 0 {
@@ -263,9 +265,6 @@ func (a *emptyCompletionAccum) evalGemini(data []byte) bool {
 		}
 		if usage == nil {
 			usage = chunk.Response.UsageMetadata
-		}
-		if usage == nil {
-			usage = chunk.Response.UsageMetadataAlt
 		}
 	}
 
@@ -279,25 +278,35 @@ func (a *emptyCompletionAccum) evalGemini(data []byte) bool {
 		if usage.CandidatesTokenCount != nil {
 			a.sawUsage = true
 			a.completionTokens += *usage.CandidatesTokenCount
-		} else if usage.CandidatesTokensAlt != nil {
-			a.sawUsage = true
-			a.completionTokens += *usage.CandidatesTokensAlt
 		}
 	}
 
 	allTerminal := true
+	blocked := false
 	for _, cand := range candidates {
-		if cand.FinishReason == nil || strings.TrimSpace(*cand.FinishReason) == "" {
+		if cand.FinishReason == nil {
 			allTerminal = false
+		} else {
+			reason := strings.TrimSpace(*cand.FinishReason)
+			if reason == "" {
+				allTerminal = false
+			} else if !strings.EqualFold(reason, "STOP") {
+				// A blocking or other terminal reason (SAFETY, RECITATION,
+				// MAX_TOKENS, BLOCKLIST, PROHIBITED_CONTENT, OTHER) is not an
+				// empty completion: the client must see the stop/block reason
+				// rather than a silent auth rotation.
+				allTerminal = false
+				blocked = true
+			}
 		}
 		if cand.Content != nil {
 			for _, part := range cand.Content.Parts {
-				if len(part.FunctionCall) > 0 || len(part.FunctionCallAlt) > 0 {
+				if len(part.FunctionCall) > 0 {
 					a.hasToolCalls = true
 				}
-				if len(part.InlineData) > 0 || len(part.InlineDataAlt) > 0 ||
-					len(part.FileData) > 0 || len(part.FileDataAlt) > 0 ||
-					len(part.FunctionResponse) > 0 || len(part.FunctionRespAlt) > 0 {
+				if len(part.InlineData) > 0 ||
+					len(part.FileData) > 0 ||
+					len(part.FunctionResponse) > 0 {
 					a.hasContent = true
 				}
 				if len(part.Thought) > 0 {
@@ -316,6 +325,9 @@ func (a *emptyCompletionAccum) evalGemini(data []byte) bool {
 	if allTerminal {
 		a.terminal = true
 	}
+	if blocked {
+		a.blocked = true
+	}
 
 	return true
 }
@@ -323,6 +335,9 @@ func (a *emptyCompletionAccum) evalGemini(data []byte) bool {
 // empty reports whether the accumulated stream is an empty completion.
 func (a *emptyCompletionAccum) empty() bool {
 	if !a.recognized || !a.terminal {
+		return false
+	}
+	if a.blocked {
 		return false
 	}
 	if a.hasContent || a.hasToolCalls {
@@ -404,4 +419,14 @@ func (a *emptyCompletionAccum) evalSSE(payload []byte) {
 		}
 		a.evalJSON(data)
 	}
+}
+
+// markEmptyCompletion records a failed retriable empty-completion result and
+// returns the error to propagate. Both the mixed and home (credits) execution
+// paths rotate on an empty completion, so the reporting is shared.
+func (m *Manager) markEmptyCompletion(ctx context.Context, result *Result) error {
+	result.Success = false
+	result.Error = errEmptyCompletion
+	m.MarkResult(ctx, *result)
+	return errEmptyCompletion
 }

--- a/sdk/cliproxy/auth/empty_completion.go
+++ b/sdk/cliproxy/auth/empty_completion.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -14,9 +15,10 @@ import (
 // retriable so the conductor marks the auth as failed, cools it down, and
 // rotates to the next auth/model.
 var errEmptyCompletion = &Error{
-	Code:      "empty_completion",
-	Message:   "upstream returned an empty completion",
-	Retryable: true,
+	Code:       "empty_completion",
+	Message:    "upstream returned an empty completion",
+	Retryable:  true,
+	HTTPStatus: http.StatusServiceUnavailable,
 }
 
 // openAIChunk is the minimal OpenAI-style SSE/JSON shape used to detect empty
@@ -100,6 +102,59 @@ type geminiChunk struct {
 	} `json:"response"`
 }
 
+// openAIResponseUsage is the usage block of the OpenAI Responses-API shape
+// (used by codex/xai executors).
+type openAIResponseUsage struct {
+	OutputTokens *int `json:"output_tokens"`
+}
+
+type openAIResponseContentPart struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type openAIResponseOutputItem struct {
+	Type      string                       `json:"type"`
+	Text      string                       `json:"text"`
+	Arguments string                       `json:"arguments"`
+	Content   []openAIResponseContentPart  `json:"content"`
+}
+
+type openAIResponseObject struct {
+	Status string                     `json:"status"`
+	Output json.RawMessage            `json:"output"`
+	Usage  *openAIResponseUsage       `json:"usage"`
+}
+
+type openAIResponseChunk struct {
+	Type      string                `json:"type"`
+	Object    string                `json:"object"`
+	Status    string                `json:"status"`
+	Output    json.RawMessage       `json:"output"`
+	Usage     *openAIResponseUsage  `json:"usage"`
+	Response  *openAIResponseObject `json:"response"`
+	Delta     string                `json:"delta"`
+	Text      string                `json:"text"`
+	Arguments string                `json:"arguments"`
+}
+
+// openAIResponseEventTypes is the conservative set of Responses-API streamed
+// event types we recognize. Unknown/partial sub-shapes are left unrecognized so
+// the stream is forwarded rather than judged empty.
+var openAIResponseEventTypes = map[string]bool{
+	"response.created":                         true,
+	"response.in_progress":                     true,
+	"response.completed":                       true,
+	"response.incomplete":                      true,
+	"response.failed":                          true,
+	"response.output_item.added":               true,
+	"response.output_item.done":                true,
+	"response.output_text.delta":               true,
+	"response.output_text.done":                true,
+	"response.function_call_arguments.delta":   true,
+	"response.function_call_arguments.done":    true,
+}
+
 // emptyCompletionAccum accumulates the properties relevant to deciding whether
 // an OpenAI-, Claude-, or Gemini-style completion is empty.
 type emptyCompletionAccum struct {
@@ -117,6 +172,9 @@ func (a *emptyCompletionAccum) evalJSON(data []byte) {
 		return
 	}
 	if a.evalClaude(data) {
+		return
+	}
+	if a.evalOpenAIResponse(data) {
 		return
 	}
 	a.evalGemini(data)
@@ -143,8 +201,16 @@ func (a *emptyCompletionAccum) evalOpenAI(data []byte) bool {
 		a.completionTokens += *chunk.Usage.CompletionTokens
 	}
 	for _, ch := range chunk.Choices {
-		if ch.FinishReason != nil && *ch.FinishReason != "" {
-			a.terminal = true
+		if ch.FinishReason != nil {
+			reason := strings.TrimSpace(*ch.FinishReason)
+			if strings.EqualFold(reason, "stop") {
+				a.terminal = true
+			} else if reason != "" {
+				// content_filter, length, and other non-stop terminal reasons
+				// are not empty completions: the client must see the reason
+				// rather than a silent auth rotation.
+				a.blocked = true
+			}
 		}
 		content := ch.Delta.Content + ch.Message.Content + ch.Delta.ReasoningContent + ch.Message.ReasoningContent
 		if strings.TrimSpace(content) != "" {
@@ -230,6 +296,102 @@ func (a *emptyCompletionAccum) evalClaude(data []byte) bool {
 	return true
 }
 
+func (a *emptyCompletionAccum) evalOpenAIResponse(data []byte) bool {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return false
+	}
+
+	var evType string
+	if raw := probe["type"]; raw != nil {
+		_ = json.Unmarshal(raw, &evType)
+	}
+	var objName string
+	if raw := probe["object"]; raw != nil {
+		_ = json.Unmarshal(raw, &objName)
+	}
+
+	if objName != "response" && !openAIResponseEventTypes[evType] {
+		return false
+	}
+	a.recognized = true
+
+	var chunk openAIResponseChunk
+	if err := json.Unmarshal(data, &chunk); err != nil {
+		return true
+	}
+
+	switch evType {
+	case "response.completed", "response.incomplete":
+		a.terminal = true
+	}
+	if (chunk.Object == "response" && (chunk.Status == "completed" || chunk.Status == "incomplete")) ||
+		(chunk.Response != nil && (chunk.Response.Status == "completed" || chunk.Response.Status == "incomplete")) {
+		a.terminal = true
+	}
+
+	if chunk.Usage != nil && chunk.Usage.OutputTokens != nil {
+		a.sawUsage = true
+		a.completionTokens += *chunk.Usage.OutputTokens
+	}
+	if chunk.Response != nil && chunk.Response.Usage != nil && chunk.Response.Usage.OutputTokens != nil {
+		a.sawUsage = true
+		a.completionTokens += *chunk.Response.Usage.OutputTokens
+	}
+
+	switch evType {
+	case "response.output_text.delta":
+		if strings.TrimSpace(chunk.Delta) != "" {
+			a.hasContent = true
+		}
+	case "response.output_text.done":
+		if strings.TrimSpace(chunk.Text) != "" {
+			a.hasContent = true
+		}
+	case "response.function_call_arguments.delta", "response.function_call_arguments.done":
+		a.hasToolCalls = true
+	}
+
+	a.evalOpenAIResponseRawOutput(chunk.Output)
+	if chunk.Response != nil {
+		a.evalOpenAIResponseRawOutput(chunk.Response.Output)
+	}
+
+	return true
+}
+
+func (a *emptyCompletionAccum) evalOpenAIResponseRawOutput(raw json.RawMessage) {
+	if len(raw) == 0 {
+		return
+	}
+	var items []openAIResponseOutputItem
+	if err := json.Unmarshal(raw, &items); err == nil {
+		a.evalOpenAIResponseOutput(items)
+		return
+	}
+	var item openAIResponseOutputItem
+	if err := json.Unmarshal(raw, &item); err == nil {
+		a.evalOpenAIResponseOutput([]openAIResponseOutputItem{item})
+	}
+}
+
+func (a *emptyCompletionAccum) evalOpenAIResponseOutput(items []openAIResponseOutputItem) {
+	for _, item := range items {
+		switch item.Type {
+		case "function_call", "web_search_call", "file_search_call", "computer_call":
+			a.hasToolCalls = true
+		}
+		if strings.TrimSpace(item.Text) != "" {
+			a.hasContent = true
+		}
+		for _, part := range item.Content {
+			if strings.TrimSpace(part.Text) != "" {
+				a.hasContent = true
+			}
+		}
+	}
+}
+
 func (a *emptyCompletionAccum) evalClaudeBlocks(blocks []claudeContentBlock) {
 	for _, b := range blocks {
 		if b.Type == "tool_use" || len(b.Input) > 0 {
@@ -248,6 +410,30 @@ func (a *emptyCompletionAccum) evalClaudeBlocks(blocks []claudeContentBlock) {
 			a.hasContent = true
 		}
 	}
+}
+
+// hasJSONKey reports whether the given JSON object contains name as a top-level
+// key. It returns false for non-object or malformed input.
+func hasJSONKey(data []byte, name string) bool {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return false
+	}
+	_, ok := probe[name]
+	return ok
+}
+
+// hasNestedResponseCandidates reports whether the payload's response object
+// contains a candidates key (the Gemini streaming wrapper shape).
+func hasNestedResponseCandidates(data []byte) bool {
+	var probe struct {
+		Response map[string]json.RawMessage `json:"response"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return false
+	}
+	_, ok := probe.Response["candidates"]
+	return ok
 }
 
 func (a *emptyCompletionAccum) evalGemini(data []byte) bool {
@@ -269,6 +455,20 @@ func (a *emptyCompletionAccum) evalGemini(data []byte) bool {
 	}
 
 	if len(candidates) == 0 {
+		// Only treat an empty candidates array as a recognized empty completion
+		// when the candidates key is actually present (e.g. a Gemini
+		// safety/empty response with zero candidate tokens, or a stream
+		// aggregate with nothing else). An absent candidates key is not a
+		// Gemini shape at all.
+		if hasJSONKey(data, "candidates") || hasNestedResponseCandidates(data) {
+			a.recognized = true
+			a.terminal = true
+			if usage != nil && usage.CandidatesTokenCount != nil {
+				a.sawUsage = true
+				a.completionTokens += *usage.CandidatesTokenCount
+			}
+			return true
+		}
 		return false
 	}
 
@@ -422,8 +622,8 @@ func (a *emptyCompletionAccum) evalSSE(payload []byte) {
 }
 
 // markEmptyCompletion records a failed retriable empty-completion result and
-// returns the error to propagate. Both the mixed and home (credits) execution
-// paths rotate on an empty completion, so the reporting is shared.
+// returns the error to propagate. The mixed duty execution path rotates on an
+// empty completion; the home (credits) path reports it via reportHomeResult.
 func (m *Manager) markEmptyCompletion(ctx context.Context, result *Result) error {
 	result.Success = false
 	result.Error = errEmptyCompletion

--- a/sdk/cliproxy/auth/empty_completion.go
+++ b/sdk/cliproxy/auth/empty_completion.go
@@ -19,8 +19,7 @@ var errEmptyCompletion = &Error{
 }
 
 // openAIChunk is the minimal OpenAI-style SSE/JSON shape used to detect empty
-// completions. Non-OpenAI payloads simply won't unmarshal into it and the
-// predicate conservatively returns false.
+// completions.
 type openAIChunk struct {
 	Choices []struct {
 		Delta struct {
@@ -40,8 +39,75 @@ type openAIChunk struct {
 	} `json:"usage"`
 }
 
+type claudeContentBlock struct {
+	Type     string          `json:"type"`
+	Text     string          `json:"text"`
+	Thinking string          `json:"thinking"`
+	Input    json.RawMessage `json:"input"`
+}
+
+type claudeChunk struct {
+	Type       string               `json:"type"`
+	StopReason *string              `json:"stop_reason"`
+	Content    []claudeContentBlock `json:"content"`
+	Usage      *struct {
+		OutputTokens *int `json:"output_tokens"`
+	} `json:"usage"`
+	Message *struct {
+		Type       string               `json:"type"`
+		StopReason *string              `json:"stop_reason"`
+		Content    []claudeContentBlock `json:"content"`
+		Usage      *struct {
+			OutputTokens *int `json:"output_tokens"`
+		} `json:"usage"`
+	} `json:"message"`
+	ContentBlock *claudeContentBlock `json:"content_block"`
+	Delta        *struct {
+		Type       string  `json:"type"`
+		Text       string  `json:"text"`
+		Thinking   string  `json:"thinking"`
+		StopReason *string `json:"stop_reason"`
+	} `json:"delta"`
+}
+
+type geminiPart struct {
+	Text             string          `json:"text"`
+	FunctionCall     json.RawMessage `json:"functionCall"`
+	FunctionCallAlt  json.RawMessage `json:"function_call"`
+	InlineData       json.RawMessage `json:"inlineData"`
+	InlineDataAlt    json.RawMessage `json:"inline_data"`
+	FileData         json.RawMessage `json:"fileData"`
+	FileDataAlt      json.RawMessage `json:"file_data"`
+	FunctionResponse json.RawMessage `json:"functionResponse"`
+	FunctionRespAlt  json.RawMessage `json:"function_response"`
+	Thought          json.RawMessage `json:"thought"`
+}
+
+type geminiCandidate struct {
+	Content *struct {
+		Parts []geminiPart `json:"parts"`
+	} `json:"content"`
+	FinishReason *string `json:"finishReason"`
+}
+
+type geminiUsageMetadata struct {
+	CandidatesTokenCount *int `json:"candidatesTokenCount"`
+	CandidatesTokensAlt  *int `json:"candidates_token_count"`
+}
+
+type geminiChunk struct {
+	Candidates       []geminiCandidate    `json:"candidates"`
+	UsageMetadata    *geminiUsageMetadata `json:"usageMetadata"`
+	UsageMetadataAlt *geminiUsageMetadata `json:"usage_metadata"`
+	Response         *struct {
+		Candidates       []geminiCandidate    `json:"candidates"`
+		UsageMetadata    *geminiUsageMetadata `json:"usageMetadata"`
+		UsageMetadataAlt *geminiUsageMetadata `json:"usage_metadata"`
+	} `json:"response"`
+}
+
 // emptyCompletionAccum accumulates the properties relevant to deciding whether
-// an OpenAI-style completion is empty.
+// an OpenAI-, Claude-, or Gemini-style completion is empty.
 type emptyCompletionAccum struct {
 	recognized       bool
 	terminal         bool
@@ -52,21 +118,27 @@ type emptyCompletionAccum struct {
 }
 
 func (a *emptyCompletionAccum) evalJSON(data []byte) {
-	var chunk openAIChunk
-	if err := json.Unmarshal(data, &chunk); err != nil {
+	if a.evalOpenAI(data) {
 		return
 	}
-	if len(chunk.Choices) > 0 {
-		a.recognized = true
+	if a.evalClaude(data) {
+		return
 	}
-	if chunk.Usage != nil {
+	a.evalGemini(data)
+}
+
+func (a *emptyCompletionAccum) evalOpenAI(data []byte) bool {
+	var chunk openAIChunk
+	if err := json.Unmarshal(data, &chunk); err != nil || len(chunk.Choices) == 0 {
+		return false
+	}
+	a.recognized = true
+	if chunk.Usage != nil && chunk.Usage.CompletionTokens != nil {
 		a.sawUsage = true
-		if chunk.Usage.CompletionTokens != nil {
-			a.completionTokens += *chunk.Usage.CompletionTokens
-		}
+		a.completionTokens += *chunk.Usage.CompletionTokens
 	}
 	for _, ch := range chunk.Choices {
-		if ch.FinishReason != nil && *ch.FinishReason == "stop" {
+		if ch.FinishReason != nil && *ch.FinishReason != "" {
 			a.terminal = true
 		}
 		content := ch.Delta.Content + ch.Message.Content + ch.Delta.ReasoningContent + ch.Message.ReasoningContent
@@ -77,6 +149,175 @@ func (a *emptyCompletionAccum) evalJSON(data []byte) {
 			a.hasToolCalls = true
 		}
 	}
+	return true
+}
+
+func (a *emptyCompletionAccum) evalClaude(data []byte) bool {
+	var chunk claudeChunk
+	if err := json.Unmarshal(data, &chunk); err != nil {
+		return false
+	}
+
+	isClaude := false
+	switch chunk.Type {
+	case "message", "message_start", "content_block_start", "content_block_delta", "message_delta", "message_stop":
+		isClaude = true
+	default:
+		if chunk.StopReason != nil || (chunk.Message != nil && (chunk.Message.Type == "message" || chunk.Message.StopReason != nil)) {
+			isClaude = true
+		}
+	}
+
+	if !isClaude {
+		return false
+	}
+
+	a.recognized = true
+
+	if chunk.Type == "message_stop" {
+		a.terminal = true
+	}
+	if chunk.StopReason != nil && strings.TrimSpace(*chunk.StopReason) != "" {
+		a.terminal = true
+	}
+	if chunk.Message != nil && chunk.Message.StopReason != nil && strings.TrimSpace(*chunk.Message.StopReason) != "" {
+		a.terminal = true
+	}
+	if chunk.Delta != nil && chunk.Delta.StopReason != nil && strings.TrimSpace(*chunk.Delta.StopReason) != "" {
+		a.terminal = true
+	}
+
+	if chunk.Usage != nil && chunk.Usage.OutputTokens != nil {
+		a.sawUsage = true
+		a.completionTokens += *chunk.Usage.OutputTokens
+	}
+	if chunk.Message != nil && chunk.Message.Usage != nil && chunk.Message.Usage.OutputTokens != nil {
+		a.sawUsage = true
+		a.completionTokens += *chunk.Message.Usage.OutputTokens
+	}
+
+	a.evalClaudeBlocks(chunk.Content)
+	if chunk.Message != nil {
+		a.evalClaudeBlocks(chunk.Message.Content)
+	}
+	if chunk.ContentBlock != nil {
+		a.evalClaudeBlocks([]claudeContentBlock{*chunk.ContentBlock})
+	}
+	if chunk.Delta != nil {
+		switch chunk.Delta.Type {
+		case "text_delta":
+			if strings.TrimSpace(chunk.Delta.Text) != "" {
+				a.hasContent = true
+			}
+		case "thinking_delta", "signature_delta":
+			if strings.TrimSpace(chunk.Delta.Thinking) != "" {
+				a.hasContent = true
+			}
+		case "input_json_delta":
+			a.hasToolCalls = true
+		default:
+			if strings.TrimSpace(chunk.Delta.Text) != "" || strings.TrimSpace(chunk.Delta.Thinking) != "" {
+				a.hasContent = true
+			}
+		}
+	}
+
+	return true
+}
+
+func (a *emptyCompletionAccum) evalClaudeBlocks(blocks []claudeContentBlock) {
+	for _, b := range blocks {
+		if b.Type == "tool_use" || len(b.Input) > 0 {
+			a.hasToolCalls = true
+			continue
+		}
+		if b.Type == "thinking" || b.Type == "redacted_thinking" || strings.TrimSpace(b.Thinking) != "" {
+			a.hasContent = true
+			continue
+		}
+		if strings.TrimSpace(b.Text) != "" {
+			a.hasContent = true
+			continue
+		}
+		if b.Type != "" && b.Type != "text" {
+			a.hasContent = true
+		}
+	}
+}
+
+func (a *emptyCompletionAccum) evalGemini(data []byte) bool {
+	var chunk geminiChunk
+	if err := json.Unmarshal(data, &chunk); err != nil {
+		return false
+	}
+
+	candidates := chunk.Candidates
+	usage := chunk.UsageMetadata
+	if usage == nil {
+		usage = chunk.UsageMetadataAlt
+	}
+
+	if chunk.Response != nil {
+		if len(candidates) == 0 {
+			candidates = chunk.Response.Candidates
+		}
+		if usage == nil {
+			usage = chunk.Response.UsageMetadata
+		}
+		if usage == nil {
+			usage = chunk.Response.UsageMetadataAlt
+		}
+	}
+
+	if len(candidates) == 0 {
+		return false
+	}
+
+	a.recognized = true
+
+	if usage != nil {
+		if usage.CandidatesTokenCount != nil {
+			a.sawUsage = true
+			a.completionTokens += *usage.CandidatesTokenCount
+		} else if usage.CandidatesTokensAlt != nil {
+			a.sawUsage = true
+			a.completionTokens += *usage.CandidatesTokensAlt
+		}
+	}
+
+	allTerminal := true
+	for _, cand := range candidates {
+		if cand.FinishReason == nil || strings.TrimSpace(*cand.FinishReason) == "" {
+			allTerminal = false
+		}
+		if cand.Content != nil {
+			for _, part := range cand.Content.Parts {
+				if len(part.FunctionCall) > 0 || len(part.FunctionCallAlt) > 0 {
+					a.hasToolCalls = true
+				}
+				if len(part.InlineData) > 0 || len(part.InlineDataAlt) > 0 ||
+					len(part.FileData) > 0 || len(part.FileDataAlt) > 0 ||
+					len(part.FunctionResponse) > 0 || len(part.FunctionRespAlt) > 0 {
+					a.hasContent = true
+				}
+				if len(part.Thought) > 0 {
+					thoughtStr := strings.TrimSpace(string(part.Thought))
+					if thoughtStr != "" && thoughtStr != "false" && thoughtStr != "null" {
+						a.hasContent = true
+					}
+				}
+				if strings.TrimSpace(part.Text) != "" {
+					a.hasContent = true
+				}
+			}
+		}
+	}
+
+	if allTerminal {
+		a.terminal = true
+	}
+
+	return true
 }
 
 // empty reports whether the accumulated stream is an empty completion.
@@ -94,7 +335,7 @@ func (a *emptyCompletionAccum) empty() bool {
 }
 
 // isEmptyCompletion reports whether the buffered SSE stream chunks aggregate to
-// an empty completion. It is conservative: non-OpenAI formats return false.
+// an empty completion.
 func isEmptyCompletion(chunks []cliproxyexecutor.StreamChunk) bool {
 	var buf bytes.Buffer
 	for _, c := range chunks {
@@ -106,9 +347,9 @@ func isEmptyCompletion(chunks []cliproxyexecutor.StreamChunk) bool {
 // streamBootstrapShouldForward reports whether the stream bootstrap should stop
 // buffering and forward the buffered chunks to the client. It returns true when
 // the aggregate already contains real output (content or tool calls), or when
-// the payload format is not recognized as OpenAI-style (conservative: no empty
-// completion detection for non-OpenAI streams). It returns false only while the
-// aggregate is a recognized OpenAI-style completion with no real output yet, so
+// the payload format is not recognized (conservative: no empty completion
+// detection for unrecognized streams). It returns false only while the
+// aggregate is a recognized completion with no real output yet, so
 // the bootstrap keeps reading to detect a complete empty completion.
 func streamBootstrapShouldForward(chunks []cliproxyexecutor.StreamChunk) bool {
 	var acc emptyCompletionAccum
@@ -116,23 +357,12 @@ func streamBootstrapShouldForward(chunks []cliproxyexecutor.StreamChunk) bool {
 	for _, c := range chunks {
 		buf.Write(c.Payload)
 	}
-	for _, line := range bytes.Split(buf.Bytes(), []byte("\n")) {
-		line = bytes.TrimSpace(line)
-		if !bytes.HasPrefix(line, []byte("data:")) {
-			continue
-		}
-		data := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
-		if bytes.Equal(data, []byte("[DONE]")) || len(data) == 0 {
-			continue
-		}
-		acc.evalJSON(data)
-	}
+	acc.evalSSE(buf.Bytes())
 	return acc.hasContent || acc.hasToolCalls || !acc.recognized
 }
 
 // isEmptyCompletionPayload reports whether a payload (aggregated SSE chunks or
-// a single non-stream JSON response) represents an empty completion. It is
-// conservative: non-OpenAI formats return false.
+// a single non-stream JSON response) represents an empty completion.
 func isEmptyCompletionPayload(payload []byte) bool {
 	trimmed := bytes.TrimSpace(payload)
 	if len(trimmed) == 0 {
@@ -141,29 +371,37 @@ func isEmptyCompletionPayload(payload []byte) bool {
 
 	var acc emptyCompletionAccum
 
-	// SSE events are prefixed with "data:". If the payload is not SSE, treat it
-	// as a single non-stream JSON object.
-	if !bytes.HasPrefix(trimmed, []byte("data:")) {
-		acc.evalJSON(trimmed)
+	if bytes.Contains(trimmed, []byte("data:")) || bytes.HasPrefix(trimmed, []byte("event:")) {
+		acc.evalSSE(trimmed)
 		return acc.empty()
 	}
 
+	acc.evalJSON(trimmed)
+	return acc.empty()
+}
+
+func (a *emptyCompletionAccum) evalSSE(payload []byte) {
 	for _, line := range bytes.Split(payload, []byte("\n")) {
 		line = bytes.TrimSpace(line)
+		if bytes.HasPrefix(line, []byte("event:")) {
+			event := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("event:")))
+			if bytes.Equal(event, []byte("message_stop")) {
+				a.recognized = true
+				a.terminal = true
+			}
+		}
 		if !bytes.HasPrefix(line, []byte("data:")) {
 			continue
 		}
 		data := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
 		if bytes.Equal(data, []byte("[DONE]")) {
-			acc.recognized = true
-			acc.terminal = true
+			a.recognized = true
+			a.terminal = true
 			continue
 		}
 		if len(data) == 0 {
 			continue
 		}
-		acc.evalJSON(data)
+		a.evalJSON(data)
 	}
-
-	return acc.empty()
 }

--- a/sdk/cliproxy/auth/empty_completion.go
+++ b/sdk/cliproxy/auth/empty_completion.go
@@ -1,0 +1,169 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// errEmptyCompletion indicates the upstream returned a terminal but empty
+// completion (no content, no tool calls, zero completion tokens). It is
+// retriable so the conductor marks the auth as failed, cools it down, and
+// rotates to the next auth/model.
+var errEmptyCompletion = &Error{
+	Code:      "empty_completion",
+	Message:   "upstream returned an empty completion",
+	Retryable: true,
+}
+
+// openAIChunk is the minimal OpenAI-style SSE/JSON shape used to detect empty
+// completions. Non-OpenAI payloads simply won't unmarshal into it and the
+// predicate conservatively returns false.
+type openAIChunk struct {
+	Choices []struct {
+		Delta struct {
+			Content          string            `json:"content"`
+			ReasoningContent string            `json:"reasoning_content"`
+			ToolCalls        []json.RawMessage `json:"tool_calls"`
+		} `json:"delta"`
+		Message struct {
+			Content          string            `json:"content"`
+			ReasoningContent string            `json:"reasoning_content"`
+			ToolCalls        []json.RawMessage `json:"tool_calls"`
+		} `json:"message"`
+		FinishReason *string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage *struct {
+		CompletionTokens *int `json:"completion_tokens"`
+	} `json:"usage"`
+}
+
+// emptyCompletionAccum accumulates the properties relevant to deciding whether
+// an OpenAI-style completion is empty.
+type emptyCompletionAccum struct {
+	recognized       bool
+	terminal         bool
+	hasContent       bool
+	hasToolCalls     bool
+	completionTokens int
+	sawUsage         bool
+}
+
+func (a *emptyCompletionAccum) evalJSON(data []byte) {
+	var chunk openAIChunk
+	if err := json.Unmarshal(data, &chunk); err != nil {
+		return
+	}
+	if len(chunk.Choices) > 0 {
+		a.recognized = true
+	}
+	if chunk.Usage != nil {
+		a.sawUsage = true
+		if chunk.Usage.CompletionTokens != nil {
+			a.completionTokens += *chunk.Usage.CompletionTokens
+		}
+	}
+	for _, ch := range chunk.Choices {
+		if ch.FinishReason != nil && *ch.FinishReason == "stop" {
+			a.terminal = true
+		}
+		content := ch.Delta.Content + ch.Message.Content + ch.Delta.ReasoningContent + ch.Message.ReasoningContent
+		if strings.TrimSpace(content) != "" {
+			a.hasContent = true
+		}
+		if len(ch.Delta.ToolCalls) > 0 || len(ch.Message.ToolCalls) > 0 {
+			a.hasToolCalls = true
+		}
+	}
+}
+
+// empty reports whether the accumulated stream is an empty completion.
+func (a *emptyCompletionAccum) empty() bool {
+	if !a.recognized || !a.terminal {
+		return false
+	}
+	if a.hasContent || a.hasToolCalls {
+		return false
+	}
+	if a.sawUsage && a.completionTokens > 0 {
+		return false
+	}
+	return true
+}
+
+// isEmptyCompletion reports whether the buffered SSE stream chunks aggregate to
+// an empty completion. It is conservative: non-OpenAI formats return false.
+func isEmptyCompletion(chunks []cliproxyexecutor.StreamChunk) bool {
+	var buf bytes.Buffer
+	for _, c := range chunks {
+		buf.Write(c.Payload)
+	}
+	return isEmptyCompletionPayload(buf.Bytes())
+}
+
+// streamBootstrapShouldForward reports whether the stream bootstrap should stop
+// buffering and forward the buffered chunks to the client. It returns true when
+// the aggregate already contains real output (content or tool calls), or when
+// the payload format is not recognized as OpenAI-style (conservative: no empty
+// completion detection for non-OpenAI streams). It returns false only while the
+// aggregate is a recognized OpenAI-style completion with no real output yet, so
+// the bootstrap keeps reading to detect a complete empty completion.
+func streamBootstrapShouldForward(chunks []cliproxyexecutor.StreamChunk) bool {
+	var acc emptyCompletionAccum
+	var buf bytes.Buffer
+	for _, c := range chunks {
+		buf.Write(c.Payload)
+	}
+	for _, line := range bytes.Split(buf.Bytes(), []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		data := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+		if bytes.Equal(data, []byte("[DONE]")) || len(data) == 0 {
+			continue
+		}
+		acc.evalJSON(data)
+	}
+	return acc.hasContent || acc.hasToolCalls || !acc.recognized
+}
+
+// isEmptyCompletionPayload reports whether a payload (aggregated SSE chunks or
+// a single non-stream JSON response) represents an empty completion. It is
+// conservative: non-OpenAI formats return false.
+func isEmptyCompletionPayload(payload []byte) bool {
+	trimmed := bytes.TrimSpace(payload)
+	if len(trimmed) == 0 {
+		return false
+	}
+
+	var acc emptyCompletionAccum
+
+	// SSE events are prefixed with "data:". If the payload is not SSE, treat it
+	// as a single non-stream JSON object.
+	if !bytes.HasPrefix(trimmed, []byte("data:")) {
+		acc.evalJSON(trimmed)
+		return acc.empty()
+	}
+
+	for _, line := range bytes.Split(payload, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		data := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+		if bytes.Equal(data, []byte("[DONE]")) {
+			acc.recognized = true
+			acc.terminal = true
+			continue
+		}
+		if len(data) == 0 {
+			continue
+		}
+		acc.evalJSON(data)
+	}
+
+	return acc.empty()
+}

--- a/sdk/cliproxy/auth/empty_completion.go
+++ b/sdk/cliproxy/auth/empty_completion.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -21,6 +22,11 @@ var errEmptyCompletion = &Error{
 	HTTPStatus: http.StatusServiceUnavailable,
 }
 
+// maxStreamBootstrapBytes bounds how much metadata a stream can accumulate
+// before the conductor conservatively forwards it. Empty-completion detection
+// must never create an unbounded pre-output buffer.
+const maxStreamBootstrapBytes = 1 << 20
+
 // openAIChunk is the minimal OpenAI-style SSE/JSON shape used to detect empty
 // completions.
 type openAIChunk struct {
@@ -28,11 +34,13 @@ type openAIChunk struct {
 		Delta struct {
 			Content          string            `json:"content"`
 			ReasoningContent string            `json:"reasoning_content"`
+			Refusal          *string           `json:"refusal"`
 			ToolCalls        []json.RawMessage `json:"tool_calls"`
 		} `json:"delta"`
 		Message struct {
 			Content          string            `json:"content"`
 			ReasoningContent string            `json:"reasoning_content"`
+			Refusal          *string           `json:"refusal"`
 			ToolCalls        []json.RawMessage `json:"tool_calls"`
 		} `json:"message"`
 		FinishReason *string `json:"finish_reason"`
@@ -93,12 +101,18 @@ type geminiUsageMetadata struct {
 	CandidatesTokenCount *int `json:"candidatesTokenCount"`
 }
 
+type geminiPromptFeedback struct {
+	BlockReason string `json:"blockReason"`
+}
+
 type geminiChunk struct {
-	Candidates    []geminiCandidate    `json:"candidates"`
-	UsageMetadata *geminiUsageMetadata `json:"usageMetadata"`
-	Response      *struct {
-		Candidates    []geminiCandidate    `json:"candidates"`
-		UsageMetadata *geminiUsageMetadata `json:"usageMetadata"`
+	Candidates     []geminiCandidate     `json:"candidates"`
+	UsageMetadata  *geminiUsageMetadata  `json:"usageMetadata"`
+	PromptFeedback *geminiPromptFeedback `json:"promptFeedback"`
+	Response       *struct {
+		Candidates     []geminiCandidate     `json:"candidates"`
+		UsageMetadata  *geminiUsageMetadata  `json:"usageMetadata"`
+		PromptFeedback *geminiPromptFeedback `json:"promptFeedback"`
 	} `json:"response"`
 }
 
@@ -109,21 +123,22 @@ type openAIResponseUsage struct {
 }
 
 type openAIResponseContentPart struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
+	Type    string `json:"type"`
+	Text    string `json:"text"`
+	Refusal string `json:"refusal"`
 }
 
 type openAIResponseOutputItem struct {
-	Type      string                       `json:"type"`
-	Text      string                       `json:"text"`
-	Arguments string                       `json:"arguments"`
-	Content   []openAIResponseContentPart  `json:"content"`
+	Type      string                      `json:"type"`
+	Text      string                      `json:"text"`
+	Arguments string                      `json:"arguments"`
+	Content   []openAIResponseContentPart `json:"content"`
 }
 
 type openAIResponseObject struct {
-	Status string                     `json:"status"`
-	Output json.RawMessage            `json:"output"`
-	Usage  *openAIResponseUsage       `json:"usage"`
+	Status string               `json:"status"`
+	Output json.RawMessage      `json:"output"`
+	Usage  *openAIResponseUsage `json:"usage"`
 }
 
 type openAIResponseChunk struct {
@@ -131,6 +146,7 @@ type openAIResponseChunk struct {
 	Object    string                `json:"object"`
 	Status    string                `json:"status"`
 	Output    json.RawMessage       `json:"output"`
+	Item      json.RawMessage       `json:"item"`
 	Usage     *openAIResponseUsage  `json:"usage"`
 	Response  *openAIResponseObject `json:"response"`
 	Delta     string                `json:"delta"`
@@ -142,23 +158,24 @@ type openAIResponseChunk struct {
 // event types we recognize. Unknown/partial sub-shapes are left unrecognized so
 // the stream is forwarded rather than judged empty.
 var openAIResponseEventTypes = map[string]bool{
-	"response.created":                         true,
-	"response.in_progress":                     true,
-	"response.completed":                       true,
-	"response.incomplete":                      true,
-	"response.failed":                          true,
-	"response.output_item.added":               true,
-	"response.output_item.done":                true,
-	"response.output_text.delta":               true,
-	"response.output_text.done":                true,
-	"response.function_call_arguments.delta":   true,
-	"response.function_call_arguments.done":    true,
+	"response.created":                       true,
+	"response.in_progress":                   true,
+	"response.completed":                     true,
+	"response.incomplete":                    true,
+	"response.failed":                        true,
+	"response.output_item.added":             true,
+	"response.output_item.done":              true,
+	"response.output_text.delta":             true,
+	"response.output_text.done":              true,
+	"response.function_call_arguments.delta": true,
+	"response.function_call_arguments.done":  true,
 }
 
 // emptyCompletionAccum accumulates the properties relevant to deciding whether
 // an OpenAI-, Claude-, or Gemini-style completion is empty.
 type emptyCompletionAccum struct {
 	recognized       bool
+	sawUnknownData   bool
 	terminal         bool
 	hasContent       bool
 	hasToolCalls     bool
@@ -167,17 +184,17 @@ type emptyCompletionAccum struct {
 	blocked          bool
 }
 
-func (a *emptyCompletionAccum) evalJSON(data []byte) {
+func (a *emptyCompletionAccum) evalJSON(data []byte) bool {
 	if a.evalOpenAI(data) {
-		return
+		return true
 	}
 	if a.evalClaude(data) {
-		return
+		return true
 	}
 	if a.evalOpenAIResponse(data) {
-		return
+		return true
 	}
-	a.evalGemini(data)
+	return a.evalGemini(data)
 }
 
 func (a *emptyCompletionAccum) evalOpenAI(data []byte) bool {
@@ -216,6 +233,9 @@ func (a *emptyCompletionAccum) evalOpenAI(data []byte) bool {
 		if strings.TrimSpace(content) != "" {
 			a.hasContent = true
 		}
+		if ch.Delta.Refusal != nil || ch.Message.Refusal != nil {
+			a.hasContent = true
+		}
 		if len(ch.Delta.ToolCalls) > 0 || len(ch.Message.ToolCalls) > 0 {
 			a.hasToolCalls = true
 		}
@@ -245,17 +265,12 @@ func (a *emptyCompletionAccum) evalClaude(data []byte) bool {
 
 	a.recognized = true
 
-	if chunk.Type == "message_stop" {
-		a.terminal = true
+	a.evalClaudeStopReason(chunk.StopReason)
+	if chunk.Message != nil {
+		a.evalClaudeStopReason(chunk.Message.StopReason)
 	}
-	if chunk.StopReason != nil && strings.TrimSpace(*chunk.StopReason) != "" {
-		a.terminal = true
-	}
-	if chunk.Message != nil && chunk.Message.StopReason != nil && strings.TrimSpace(*chunk.Message.StopReason) != "" {
-		a.terminal = true
-	}
-	if chunk.Delta != nil && chunk.Delta.StopReason != nil && strings.TrimSpace(*chunk.Delta.StopReason) != "" {
-		a.terminal = true
+	if chunk.Delta != nil {
+		a.evalClaudeStopReason(chunk.Delta.StopReason)
 	}
 
 	if chunk.Usage != nil && chunk.Usage.OutputTokens != nil {
@@ -296,6 +311,20 @@ func (a *emptyCompletionAccum) evalClaude(data []byte) bool {
 	return true
 }
 
+func (a *emptyCompletionAccum) evalClaudeStopReason(stopReason *string) {
+	if stopReason == nil {
+		return
+	}
+	reason := strings.TrimSpace(*stopReason)
+	if strings.EqualFold(reason, "end_turn") {
+		a.terminal = true
+	} else if reason != "" {
+		// Request/output limits, refusals, and control stop reasons must reach the
+		// client instead of being converted into a credential failure.
+		a.blocked = true
+	}
+}
+
 func (a *emptyCompletionAccum) evalOpenAIResponse(data []byte) bool {
 	var probe map[string]json.RawMessage
 	if err := json.Unmarshal(data, &probe); err != nil {
@@ -322,12 +351,15 @@ func (a *emptyCompletionAccum) evalOpenAIResponse(data []byte) bool {
 	}
 
 	switch evType {
-	case "response.completed", "response.incomplete":
+	case "response.completed":
 		a.terminal = true
+	case "response.incomplete", "response.failed":
+		a.terminal = true
+		a.blocked = true
 	}
-	if (chunk.Object == "response" && (chunk.Status == "completed" || chunk.Status == "incomplete")) ||
-		(chunk.Response != nil && (chunk.Response.Status == "completed" || chunk.Response.Status == "incomplete")) {
-		a.terminal = true
+	a.evalOpenAIResponseStatus(chunk.Status)
+	if chunk.Response != nil {
+		a.evalOpenAIResponseStatus(chunk.Response.Status)
 	}
 
 	if chunk.Usage != nil && chunk.Usage.OutputTokens != nil {
@@ -353,11 +385,22 @@ func (a *emptyCompletionAccum) evalOpenAIResponse(data []byte) bool {
 	}
 
 	a.evalOpenAIResponseRawOutput(chunk.Output)
+	a.evalOpenAIResponseRawOutput(chunk.Item)
 	if chunk.Response != nil {
 		a.evalOpenAIResponseRawOutput(chunk.Response.Output)
 	}
 
 	return true
+}
+
+func (a *emptyCompletionAccum) evalOpenAIResponseStatus(status string) {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "completed":
+		a.terminal = true
+	case "incomplete", "failed":
+		a.terminal = true
+		a.blocked = true
+	}
 }
 
 func (a *emptyCompletionAccum) evalOpenAIResponseRawOutput(raw json.RawMessage) {
@@ -377,15 +420,24 @@ func (a *emptyCompletionAccum) evalOpenAIResponseRawOutput(raw json.RawMessage) 
 
 func (a *emptyCompletionAccum) evalOpenAIResponseOutput(items []openAIResponseOutputItem) {
 	for _, item := range items {
-		switch item.Type {
-		case "function_call", "web_search_call", "file_search_call", "computer_call":
+		itemType := strings.ToLower(strings.TrimSpace(item.Type))
+		switch {
+		case itemType == "image_generation_call":
+			a.hasContent = true
+		case strings.HasSuffix(itemType, "_call"):
 			a.hasToolCalls = true
+		case itemType != "" && itemType != "message":
+			// Responses may add output item types over time. A complete, typed
+			// non-message item is output unless the protocol proves otherwise.
+			a.hasContent = true
 		}
 		if strings.TrimSpace(item.Text) != "" {
 			a.hasContent = true
 		}
 		for _, part := range item.Content {
-			if strings.TrimSpace(part.Text) != "" {
+			partType := strings.ToLower(strings.TrimSpace(part.Type))
+			if strings.TrimSpace(part.Text) != "" || strings.TrimSpace(part.Refusal) != "" ||
+				partType == "refusal" || (partType != "" && partType != "output_text" && partType != "text") {
 				a.hasContent = true
 			}
 		}
@@ -444,6 +496,7 @@ func (a *emptyCompletionAccum) evalGemini(data []byte) bool {
 
 	candidates := chunk.Candidates
 	usage := chunk.UsageMetadata
+	promptFeedback := chunk.PromptFeedback
 
 	if chunk.Response != nil {
 		if len(candidates) == 0 {
@@ -452,7 +505,11 @@ func (a *emptyCompletionAccum) evalGemini(data []byte) bool {
 		if usage == nil {
 			usage = chunk.Response.UsageMetadata
 		}
+		if promptFeedback == nil {
+			promptFeedback = chunk.Response.PromptFeedback
+		}
 	}
+	promptBlocked := promptFeedback != nil && strings.TrimSpace(promptFeedback.BlockReason) != ""
 
 	if len(candidates) == 0 {
 		// Only treat an empty candidates array as a recognized empty completion
@@ -463,6 +520,7 @@ func (a *emptyCompletionAccum) evalGemini(data []byte) bool {
 		if hasJSONKey(data, "candidates") || hasNestedResponseCandidates(data) {
 			a.recognized = true
 			a.terminal = true
+			a.blocked = promptBlocked
 			if usage != nil && usage.CandidatesTokenCount != nil {
 				a.sawUsage = true
 				a.completionTokens += *usage.CandidatesTokenCount
@@ -473,6 +531,9 @@ func (a *emptyCompletionAccum) evalGemini(data []byte) bool {
 	}
 
 	a.recognized = true
+	if promptBlocked {
+		a.blocked = true
+	}
 
 	if usage != nil {
 		if usage.CandidatesTokenCount != nil {
@@ -534,7 +595,7 @@ func (a *emptyCompletionAccum) evalGemini(data []byte) bool {
 
 // empty reports whether the accumulated stream is an empty completion.
 func (a *emptyCompletionAccum) empty() bool {
-	if !a.recognized || !a.terminal {
+	if !a.recognized || a.sawUnknownData || !a.terminal {
 		return false
 	}
 	if a.blocked {
@@ -559,21 +620,82 @@ func isEmptyCompletion(chunks []cliproxyexecutor.StreamChunk) bool {
 	return isEmptyCompletionPayload(buf.Bytes())
 }
 
-// streamBootstrapShouldForward reports whether the stream bootstrap should stop
-// buffering and forward the buffered chunks to the client. It returns true when
-// the aggregate already contains real output (content or tool calls), or when
-// the payload format is not recognized (conservative: no empty completion
-// detection for unrecognized streams). It returns false only while the
-// aggregate is a recognized completion with no real output yet, so
-// the bootstrap keeps reading to detect a complete empty completion.
-func streamBootstrapShouldForward(chunks []cliproxyexecutor.StreamChunk) bool {
-	var acc emptyCompletionAccum
-	var buf bytes.Buffer
-	for _, c := range chunks {
-		buf.Write(c.Payload)
+func isEmptyCompletionError(err error) bool {
+	var authErr *Error
+	return errors.As(err, &authErr) && authErr != nil && authErr.Code == errEmptyCompletion.Code
+}
+
+// streamBootstrapState incrementally evaluates chunks so a metadata-heavy
+// prefix is processed once instead of reparsing the entire prefix per chunk.
+type streamBootstrapState struct {
+	acc     emptyCompletionAccum
+	bytes   int
+	pending []byte
+	forward bool
+	sawSSE  bool
+}
+
+func (s *streamBootstrapState) observe(fragment []byte) bool {
+	if s.forward {
+		return true
 	}
-	acc.evalSSE(buf.Bytes())
-	return acc.hasContent || acc.hasToolCalls || !acc.recognized
+	s.bytes += len(fragment)
+	if s.bytes > maxStreamBootstrapBytes {
+		s.forward = true
+		return true
+	}
+	s.pending = append(s.pending, fragment...)
+	for {
+		if newline := bytes.IndexByte(s.pending, '\n'); newline >= 0 {
+			line := bytes.TrimSpace(s.pending[:newline])
+			s.pending = s.pending[newline+1:]
+			if len(line) > 0 {
+				switch {
+				case bytes.HasPrefix(line, []byte("event:")), bytes.HasPrefix(line, []byte("data:")), bytes.HasPrefix(line, []byte(":")):
+					s.sawSSE = true
+					s.acc.evalSSE(line)
+				default:
+					s.acc.sawUnknownData = true
+				}
+			}
+			if s.shouldForward() {
+				s.forward = true
+				return true
+			}
+			continue
+		}
+		break
+	}
+
+	trimmed := bytes.TrimSpace(s.pending)
+	if len(trimmed) == 0 || couldBeSSEPrefix(trimmed) {
+		return false
+	}
+	if json.Valid(trimmed) {
+		if !s.acc.evalJSON(trimmed) {
+			s.acc.sawUnknownData = true
+		}
+		s.pending = s.pending[:0]
+	} else if (trimmed[0] == '{' && trimmed[len(trimmed)-1] != '}') ||
+		(trimmed[0] == '[' && trimmed[len(trimmed)-1] != ']') {
+		return false
+	} else {
+		s.acc.sawUnknownData = true
+	}
+	s.forward = s.shouldForward()
+	return s.forward
+}
+
+func (s *streamBootstrapState) shouldForward() bool {
+	return s.acc.hasContent || s.acc.hasToolCalls || s.acc.sawUnknownData || (!s.acc.recognized && !s.sawSSE)
+}
+
+func couldBeSSEPrefix(payload []byte) bool {
+	const dataPrefix = "data:"
+	const eventPrefix = "event:"
+	value := string(payload)
+	return strings.HasPrefix(value, ":") || strings.HasPrefix(dataPrefix, value) || strings.HasPrefix(eventPrefix, value) ||
+		strings.HasPrefix(value, dataPrefix) || strings.HasPrefix(value, eventPrefix)
 }
 
 // isEmptyCompletionPayload reports whether a payload (aggregated SSE chunks or
@@ -602,7 +724,6 @@ func (a *emptyCompletionAccum) evalSSE(payload []byte) {
 			event := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("event:")))
 			if bytes.Equal(event, []byte("message_stop")) {
 				a.recognized = true
-				a.terminal = true
 			}
 		}
 		if !bytes.HasPrefix(line, []byte("data:")) {
@@ -617,7 +738,9 @@ func (a *emptyCompletionAccum) evalSSE(payload []byte) {
 		if len(data) == 0 {
 			continue
 		}
-		a.evalJSON(data)
+		if !a.evalJSON(data) {
+			a.sawUnknownData = true
+		}
 	}
 }
 

--- a/sdk/cliproxy/auth/empty_completion_export.go
+++ b/sdk/cliproxy/auth/empty_completion_export.go
@@ -1,0 +1,18 @@
+package auth
+
+// IsEmptyCompletionPayload reports whether a payload (aggregated SSE chunks or
+// a single non-stream JSON response) represents a terminal but empty
+// completion. It is the exported form of the internal predicate used by the
+// conductor, exposed so the plugin-executor path can reject empty completions
+// before they reach the client.
+func IsEmptyCompletionPayload(payload []byte) bool {
+	return isEmptyCompletionPayload(payload)
+}
+
+// EmptyCompletionError returns the retriable error used when upstream returns
+// a terminal but empty completion. The plugin-executor path returns it so the
+// client receives an error instead of a silent empty response, matching how
+// the conductor surfaces empty completions.
+func EmptyCompletionError() error {
+	return errEmptyCompletion
+}

--- a/sdk/cliproxy/auth/empty_completion_export.go
+++ b/sdk/cliproxy/auth/empty_completion_export.go
@@ -1,5 +1,7 @@
 package auth
 
+import "bytes"
+
 // IsEmptyCompletionPayload reports whether a payload (aggregated SSE chunks or
 // a single non-stream JSON response) represents a terminal but empty
 // completion. It is the exported form of the internal predicate used by the
@@ -15,4 +17,25 @@ func IsEmptyCompletionPayload(payload []byte) bool {
 // the conductor surfaces empty completions.
 func EmptyCompletionError() error {
 	return errEmptyCompletion
+}
+
+// IsCompletionFormatRecognized reports whether payload uses a wire format the
+// empty-completion detection understands (OpenAI chat, OpenAI Responses,
+// Anthropic Claude, or Gemini). It is the exported form of the conductor's
+// recognition predicate, exposed so the executor-format contract test can assert
+// that every executor's emitted stream format is recognized — a new executor
+// emitting an unrecognized format fails that test loudly instead of silently
+// bypassing empty-completion detection.
+func IsCompletionFormatRecognized(payload []byte) bool {
+	trimmed := bytes.TrimSpace(payload)
+	if len(trimmed) == 0 {
+		return false
+	}
+	var acc emptyCompletionAccum
+	if bytes.Contains(trimmed, []byte("data:")) || bytes.HasPrefix(trimmed, []byte("event:")) {
+		acc.evalSSE(trimmed)
+	} else {
+		acc.evalJSON(trimmed)
+	}
+	return acc.recognized
 }

--- a/sdk/cliproxy/auth/empty_completion_export.go
+++ b/sdk/cliproxy/auth/empty_completion_export.go
@@ -1,6 +1,8 @@
 package auth
 
-import "bytes"
+import (
+	"bytes"
+)
 
 // IsEmptyCompletionPayload reports whether a payload (aggregated SSE chunks or
 // a single non-stream JSON response) represents a terminal but empty
@@ -21,11 +23,8 @@ func EmptyCompletionError() error {
 
 // IsCompletionFormatRecognized reports whether payload uses a wire format the
 // empty-completion detection understands (OpenAI chat, OpenAI Responses,
-// Anthropic Claude, or Gemini). It is the exported form of the conductor's
-// recognition predicate, exposed so the executor-format contract test can assert
-// that every executor's emitted stream format is recognized — a new executor
-// emitting an unrecognized format fails that test loudly instead of silently
-// bypassing empty-completion detection.
+// Anthropic Claude, or Gemini). It supports representative format-contract
+// tests without claiming registry-wide executor coverage.
 func IsCompletionFormatRecognized(payload []byte) bool {
 	trimmed := bytes.TrimSpace(payload)
 	if len(trimmed) == 0 {
@@ -38,4 +37,20 @@ func IsCompletionFormatRecognized(payload []byte) bool {
 		acc.evalJSON(trimmed)
 	}
 	return acc.recognized
+}
+
+// StreamBootstrapDetector incrementally classifies a stream prefix without
+// reparsing previously observed chunks. Its zero value is ready for use.
+type StreamBootstrapDetector struct {
+	state streamBootstrapState
+}
+
+// Observe records an arbitrary stream byte fragment and reports whether
+// buffered data should now be forwarded. It retains incomplete SSE lines across
+// calls and forwards conservatively at the bootstrap byte limit.
+func (d *StreamBootstrapDetector) Observe(payload []byte) bool {
+	if d == nil {
+		return true
+	}
+	return d.state.observe(payload)
 }

--- a/sdk/cliproxy/auth/empty_completion_formats_test.go
+++ b/sdk/cliproxy/auth/empty_completion_formats_test.go
@@ -4,26 +4,21 @@ import (
 	"testing"
 )
 
-// TestExecutorFormatsRecognized enforces the ROOT guarantee: every registered
-// text executor's emitted stream format must be recognizable by the
-// empty-completion detection. The conductor judges the SSE/JSON payloads each
-// executor hands it at the boundary (bootstrap-close for streams, return for
-// non-streams), so an executor emitting a wire format the detection cannot
-// recognize would silently bypass empty-completion handling.
+// TestSupportedCompletionFormatsRecognized covers representative wire formats
+// handled by empty-completion detection. Executor names document current users
+// of each format; this manually maintained table is not an executor-registry
+// completeness check.
 //
-// Each case lists the registered executors that emit a given wire format plus a
+// Each case lists executors that emit a given wire format plus a
 // representative NON-empty chunk in that format (asserted recognized=true) and
-// the corresponding empty-terminal variant (asserted empty). If a future
-// executor emits a format not covered here, this table fails loudly and forces
-// the author to either map it onto an existing format or get empty-completion
-// detection extended for it.
+// the corresponding empty-terminal variant (asserted empty).
 //
 // Documented exclusions (NOT in this table, by design):
 //   - codex-live: realtime bidirectional voice/media relay, not a text
 //     completion stream — empty-completion handling does not apply.
 //   - gemini-interactions: Gemini Live realtime relay (parts/role frames, not
 //     candidates-shaped) — voice/media channel, not a text completion stream.
-func TestExecutorFormatsRecognized(t *testing.T) {
+func TestSupportedCompletionFormatsRecognized(t *testing.T) {
 	cases := []struct {
 		name      string
 		executors []string
@@ -51,8 +46,8 @@ func TestExecutorFormatsRecognized(t *testing.T) {
 			// (requestToFormat is FormatClaude).
 			name:      "claude",
 			executors: []string{"claude"},
-			nonEmpty:  []byte("data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"),
-			empty:     []byte("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"),
+			nonEmpty:  []byte("data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"),
+			empty:     []byte("data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"),
 		},
 		{
 			// Gemini wire (top-level candidates). Emitted by the Gemini-family

--- a/sdk/cliproxy/auth/empty_completion_formats_test.go
+++ b/sdk/cliproxy/auth/empty_completion_formats_test.go
@@ -1,0 +1,90 @@
+package auth
+
+import (
+	"testing"
+)
+
+// TestExecutorFormatsRecognized enforces the ROOT guarantee: every registered
+// text executor's emitted stream format must be recognizable by the
+// empty-completion detection. The conductor judges the SSE/JSON payloads each
+// executor hands it at the boundary (bootstrap-close for streams, return for
+// non-streams), so an executor emitting a wire format the detection cannot
+// recognize would silently bypass empty-completion handling.
+//
+// Each case lists the registered executors that emit a given wire format plus a
+// representative NON-empty chunk in that format (asserted recognized=true) and
+// the corresponding empty-terminal variant (asserted empty). If a future
+// executor emits a format not covered here, this table fails loudly and forces
+// the author to either map it onto an existing format or get empty-completion
+// detection extended for it.
+//
+// Documented exclusions (NOT in this table, by design):
+//   - codex-live: realtime bidirectional voice/media relay, not a text
+//     completion stream — empty-completion handling does not apply.
+//   - gemini-interactions: Gemini Live realtime relay (parts/role frames, not
+//     candidates-shaped) — voice/media channel, not a text completion stream.
+func TestExecutorFormatsRecognized(t *testing.T) {
+	cases := []struct {
+		name      string
+		executors []string
+		nonEmpty  []byte
+		empty     []byte
+	}{
+		{
+			// OpenAI chat-completions wire. Emitted by the OpenAI-compatible
+			// proxy executors (their requestToFormat is FormatOpenAI).
+			name:      "openai-chat",
+			executors: []string{"kimi", "kiro", "kilo", "cursor", "github-copilot", "codebuddy", "gitlab", "qoder", "openai-compatibility"},
+			nonEmpty:  []byte("data: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\ndata: [DONE]\n\n"),
+			empty:     []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"completion_tokens\":0}}\n\ndata: [DONE]\n\n"),
+		},
+		{
+			// OpenAI Responses-API wire (codex agent format). Emitted by the
+			// codex-family executors (requestToFormat is FormatCodex).
+			name:      "codex-responses",
+			executors: []string{"codex", "home_codex", "xai"},
+			nonEmpty:  []byte("data: {\"type\":\"response.output_text.delta\",\"item_id\":\"1\",\"output_index\":0,\"content_index\":0,\"delta\":\"hello\"}\n\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"hello\"}]}],\"usage\":{\"output_tokens\":5}}}\n\ndata: [DONE]\n\n"),
+			empty:     []byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"status\":\"completed\",\"output\":[],\"usage\":{\"output_tokens\":0}}}\n\ndata: [DONE]\n\n"),
+		},
+		{
+			// Anthropic Claude wire. Emitted by the Claude executor
+			// (requestToFormat is FormatClaude).
+			name:      "claude",
+			executors: []string{"claude"},
+			nonEmpty:  []byte("data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"),
+			empty:     []byte("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"),
+		},
+		{
+			// Gemini wire (top-level candidates). Emitted by the Gemini-family
+			// executors (requestToFormat is FormatGemini). aistudio is listed
+			// here as its representative case: it emits the client-requested
+			// SDK format (body.toFormat), and Gemini is one of its valid
+			// outputs — all of which are recognized formats.
+			name:      "gemini",
+			executors: []string{"gemini", "gemini-cli", "vertex", "aistudio"},
+			nonEmpty:  []byte("data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"hello\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"candidatesTokenCount\":5}}\n\n"),
+			empty:     []byte("data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"candidatesTokenCount\":0}}\n\n"),
+		},
+		{
+			// Antigravity emits Gemini-shaped wire (nested response.candidates
+			// wrapper), recognized through the same Gemini predicate.
+			name:      "antigravity",
+			executors: []string{"antigravity"},
+			nonEmpty:  []byte("data: {\"response\":{\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"hello\"}]},\"finishReason\":\"STOP\"}]}}\n\n"),
+			empty:     []byte("data: {\"response\":{\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[]},\"finishReason\":\"STOP\"}]}}\n\n"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !IsCompletionFormatRecognized(tc.nonEmpty) {
+				t.Fatalf("non-empty chunk for executors %v was NOT recognized; a new executor emitting this format would silently bypass empty-completion detection", tc.executors)
+			}
+			if !IsEmptyCompletionPayload(tc.empty) {
+				t.Fatalf("empty-terminal variant for executors %v was not judged empty", tc.executors)
+			}
+			if IsEmptyCompletionPayload(tc.nonEmpty) {
+				t.Fatalf("non-empty chunk for executors %v was wrongly judged empty", tc.executors)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/auth/empty_completion_test.go
+++ b/sdk/cliproxy/auth/empty_completion_test.go
@@ -316,6 +316,66 @@ func TestEmptyCompletionPredicate(t *testing.T) {
 			payload:  []byte("data: {\"choices\":[]}\n\ndata: [DONE]\n\n"),
 			expected: true,
 		},
+		{
+			name:     "openai sse content_filter with empty content is not empty",
+			payload:  []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"content_filter\"}]}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name:     "openai sse length with empty content is not empty",
+			payload:  []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}]}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name:     "openai non-stream content_filter with empty content is not empty",
+			payload:  []byte(`{"choices":[{"message":{"content":""},"finish_reason":"content_filter"}],"usage":{"completion_tokens":0}}`),
+			expected: false,
+		},
+		{
+			name:     "openai non-stream length with empty content is not empty",
+			payload:  []byte(`{"choices":[{"message":{"content":""},"finish_reason":"length"}],"usage":{"completion_tokens":0}}`),
+			expected: false,
+		},
+		{
+			name:     "openai non-stream stop empty is empty",
+			payload:  []byte(`{"choices":[{"message":{"content":""},"finish_reason":"stop"}],"usage":{"completion_tokens":0}}`),
+			expected: true,
+		},
+		{
+			name:     "codex responses-api sse completed with empty output is empty",
+			payload:  []byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"status\":\"completed\",\"output\":[],\"usage\":{\"output_tokens\":0}}}\n\ndata: [DONE]\n\n"),
+			expected: true,
+		},
+		{
+			name:     "codex responses-api non-stream completed with empty output is empty",
+			payload:  []byte(`{"object":"response","id":"r","status":"completed","output":[],"usage":{"output_tokens":0}}`),
+			expected: true,
+		},
+		{
+			name:     "codex responses-api sse output_item message empty then completed is empty",
+			payload:  []byte("data: {\"type\":\"response.output_item.done\",\"output\":{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"\",\"annotations\":[]}],\"status\":\"completed\"}}\n\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"\",\"annotations\":[]}]}],\"usage\":{\"output_tokens\":0}}}\n\ndata: [DONE]\n\n"),
+			expected: true,
+		},
+		{
+			name:     "codex responses-api non-stream with function_call is not empty",
+			payload:  []byte(`{"object":"response","id":"r","status":"completed","output":[{"type":"function_call","name":"get_weather","arguments":"{}","call_id":"call_1"}],"usage":{"output_tokens":5}}`),
+			expected: false,
+		},
+		{
+			name:     "codex responses-api sse with function_call is not empty",
+			payload:  []byte("data: {\"type\":\"response.output_item.done\",\"output\":{\"type\":\"function_call\",\"name\":\"get_weather\",\"arguments\":\"{}\",\"call_id\":\"call_1\"}}\n\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"status\":\"completed\",\"output\":[{\"type\":\"function_call\",\"name\":\"get_weather\",\"arguments\":\"{}\",\"call_id\":\"call_1\"}],\"usage\":{\"output_tokens\":5}}}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name:     "gemini non-stream empty candidates array is empty",
+			payload:  []byte(`{"candidates":[],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":0}}`),
+			expected: true,
+		},
+		{
+			name:     "gemini sse empty candidates array is empty",
+			payload:  []byte("data: {\"candidates\":[],\"usageMetadata\":{\"candidatesTokenCount\":0}}\n\n"),
+			expected: true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/sdk/cliproxy/auth/empty_completion_test.go
+++ b/sdk/cliproxy/auth/empty_completion_test.go
@@ -1,0 +1,349 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// emptyCompletionTestExecutor returns a configurable payload per auth, allowing
+// tests to make one auth produce an empty completion and another a real one.
+type emptyCompletionTestExecutor struct {
+	executePayloads map[string][]byte   // auth ID -> non-stream payload
+	streamPayloads  map[string][][]byte // auth ID -> SSE chunk payloads
+	executeErr      map[string]error    // auth ID -> forced execute error
+	streamErr       map[string]error    // auth ID -> forced stream error
+	executeCalls    map[string]int      // auth ID -> call count (non-stream)
+	streamCalls     map[string]int      // auth ID -> call count (stream)
+	hook            func(authID, kind string)
+
+	// firstExecute records the first auth that was picked for a non-stream
+	// execution, so tests can deterministically wire the empty payload to it
+	// regardless of global selector state.
+	firstExecute string
+	// firstStream records the first auth picked for a stream execution.
+	firstStream string
+}
+
+func (e *emptyCompletionTestExecutor) Identifier() string { return "claude" }
+
+func (*emptyCompletionTestExecutor) ShouldPrepareRequestAuth(*Auth) bool { return false }
+
+func (e *emptyCompletionTestExecutor) PrepareRequestAuth(ctx context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *emptyCompletionTestExecutor) Execute(ctx context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.executeCalls[auth.ID]++
+	if e.firstExecute == "" {
+		e.firstExecute = auth.ID
+	}
+	if err := e.executeErr[auth.ID]; err != nil {
+		return cliproxyexecutor.Response{}, err
+	}
+	// The first auth picked returns an empty completion; every subsequent auth
+	// returns real content. This guarantees the rotation test exercises the
+	// empty-completion failure path regardless of global selector state.
+	if e.firstExecute == auth.ID {
+		return cliproxyexecutor.Response{Payload: []byte(`{"choices":[{"message":{"content":""},"finish_reason":"stop"}],"usage":{"completion_tokens":0}}`)}, nil
+	}
+	if p, ok := e.executePayloads[auth.ID]; ok {
+		return cliproxyexecutor.Response{Payload: p}, nil
+	}
+	return cliproxyexecutor.Response{Payload: []byte(`{"choices":[{"message":{"content":"real"},"finish_reason":"stop"}]}`)}, nil
+}
+
+func (e *emptyCompletionTestExecutor) CountTokens(ctx context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+}
+
+func (e *emptyCompletionTestExecutor) ExecuteStream(ctx context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.streamCalls[auth.ID]++
+	if e.firstStream == "" {
+		e.firstStream = auth.ID
+	}
+	if err := e.streamErr[auth.ID]; err != nil {
+		return nil, err
+	}
+	// When the test pre-wires explicit payloads (e.g. the thinking-then-content
+	// positive control), honor them. Otherwise force the first auth to stream an
+	// empty completion and subsequent auths to stream real content, so rotation
+	// tests are deterministic regardless of global selector state.
+	if len(e.streamPayloads) == 0 && e.firstStream == auth.ID {
+		empty := [][]byte{
+			[]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"),
+			[]byte("data: [DONE]\n\n"),
+		}
+		chunks := make(chan cliproxyexecutor.StreamChunk, len(empty))
+		for _, p := range empty {
+			chunks <- cliproxyexecutor.StreamChunk{Payload: p}
+		}
+		close(chunks)
+		return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+	}
+	if payloads, ok := e.streamPayloads[auth.ID]; ok && len(payloads) > 0 {
+		chunks := make(chan cliproxyexecutor.StreamChunk, len(payloads))
+		for _, p := range payloads {
+			chunks <- cliproxyexecutor.StreamChunk{Payload: p}
+		}
+		close(chunks)
+		return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+	}
+	content := [][]byte{
+		[]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n"),
+		[]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"),
+		[]byte("data: [DONE]\n\n"),
+	}
+	chunks := make(chan cliproxyexecutor.StreamChunk, len(content))
+	for _, p := range content {
+		chunks <- cliproxyexecutor.StreamChunk{Payload: p}
+	}
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *emptyCompletionTestExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (*emptyCompletionTestExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+// newEmptyCompletionTestManager registers two auths for the same model and
+// returns the manager, the auth IDs, the model name, and a result-capture hook.
+func newEmptyCompletionTestManager(t *testing.T, executor *emptyCompletionTestExecutor) (*Manager, []string, string, *resultCaptureHook) {
+	t.Helper()
+	model := "empty-completion-model-" + uuid.NewString()
+	capture := &resultCaptureHook{}
+	manager := NewManager(nil, nil, capture)
+	manager.SetRetryConfig(0, 0, 0)
+	manager.RegisterExecutor(executor)
+
+	var ids []string
+	for i := 0; i < 2; i++ {
+		auth := &Auth{
+			ID:         "empty-completion-auth-" + uuid.NewString(),
+			Provider:   "claude",
+			Attributes: map[string]string{"auth_kind": "oauth"},
+			Metadata: map[string]any{
+				"access_token":  "access-token",
+				"refresh_token": "refresh-token",
+				"request_retry": float64(0),
+			},
+		}
+		registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+		t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+		if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+			t.Fatalf("Register(%s) error = %v", auth.ID, errRegister)
+		}
+		ids = append(ids, auth.ID)
+	}
+	return manager, ids, model, capture
+}
+
+func TestEmptyCompletionPredicate(t *testing.T) {
+	cases := []struct {
+		name     string
+		payload  []byte
+		expected bool
+	}{
+		{
+			name: "openai sse empty",
+			payload: []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
+			expected: true,
+		},
+		{
+			name: "openai sse thinking then content is not empty",
+			payload: []byte("data: {\"choices\":[{\"delta\":{\"content\":\"\"},\"finish_reason\":null}]}\n\ndata: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name: "whitespace only zero tokens is empty",
+			payload: []byte("data: {\"choices\":[{\"delta\":{\"content\":\"   \"},\"finish_reason\":\"stop\"}],\"usage\":{\"completion_tokens\":0}}\n\ndata: [DONE]\n\n"),
+			expected: true,
+		},
+		{
+			name: "non zero tokens is not empty",
+			payload: []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"completion_tokens\":5}}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name: "tool calls are not empty",
+			payload: []byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"x\"}]},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name: "openai sse reasoning only is not empty",
+			payload: []byte("data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"thinking step by step\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name: "unterminated is not empty",
+			payload: []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":null}]}\n\n"),
+			expected: false,
+		},
+		{
+			name: "non openai format is not empty",
+			payload: []byte("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"),
+			expected: false,
+		},
+		{
+			name: "non stream empty json",
+			payload: []byte(`{"choices":[{"message":{"content":""},"finish_reason":"stop"}],"usage":{"completion_tokens":0}}`),
+			expected: true,
+		},
+		{
+			name: "non stream content is not empty",
+			payload: []byte(`{"choices":[{"message":{"content":"hi"},"finish_reason":"stop"}]}`),
+			expected: false,
+		},
+		{
+			name: "non stream reasoning only is not empty",
+			payload: []byte(`{"choices":[{"message":{"reasoning_content":"thinking"},"finish_reason":"stop"}]}`),
+			expected: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isEmptyCompletionPayload(tc.payload); got != tc.expected {
+				t.Fatalf("isEmptyCompletionPayload() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestExecuteEmptyCompletionRotatesAuth(t *testing.T) {
+	executor := &emptyCompletionTestExecutor{
+		executePayloads: map[string][]byte{},
+		executeCalls:    map[string]int{},
+	}
+	manager, ids, model, capture := newEmptyCompletionTestManager(t, executor)
+
+	resp, err := manager.Execute(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(string(resp.Payload), "real") {
+		t.Fatalf("Execute() payload = %q, want success content from the non-empty auth", resp.Payload)
+	}
+	// The first-picked auth (which returned empty) must have been recorded as a
+	// failure; the other must have succeeded.
+	emptyFirst := executor.firstExecute
+	if emptyFirst == "" {
+		t.Fatal("executor never executed any auth")
+	}
+	other := ids[0]
+	if emptyFirst == ids[0] {
+		other = ids[1]
+	}
+	var emptyRecorded bool
+	var otherSucceeded bool
+	for _, r := range capture.Results() {
+		if r.AuthID == emptyFirst && !r.Success {
+			emptyRecorded = true
+		}
+		if r.AuthID == other && r.Success {
+			otherSucceeded = true
+		}
+	}
+	if !emptyRecorded {
+		t.Fatalf("empty auth %q was not recorded as a failure result; results=%v", emptyFirst, capture.Results())
+	}
+	if !otherSucceeded {
+		t.Fatalf("content auth %q was not recorded as a success result; results=%v", other, capture.Results())
+	}
+}
+
+func TestExecuteStreamEmptyCompletionRotatesAuth(t *testing.T) {
+	executor := &emptyCompletionTestExecutor{
+		streamPayloads: map[string][][]byte{},
+		streamCalls:    map[string]int{},
+	}
+	manager, ids, model, capture := newEmptyCompletionTestManager(t, executor)
+
+	stream, err := manager.ExecuteStream(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	if stream == nil {
+		t.Fatal("ExecuteStream() returned nil stream")
+	}
+	var got strings.Builder
+	for chunk := range stream.Chunks {
+		got.Write(chunk.Payload)
+	}
+	if !strings.Contains(got.String(), "hello") {
+		t.Fatalf("stream payload = %q, want content from the non-empty auth", got.String())
+	}
+	// The first-streamed auth (which returned empty) must have been recorded as
+	// a failure; the other must have succeeded.
+	emptyFirst := executor.firstStream
+	if emptyFirst == "" {
+		t.Fatal("executor never streamed any auth")
+	}
+	other := ids[0]
+	if emptyFirst == ids[0] {
+		other = ids[1]
+	}
+	var emptyRecorded bool
+	var otherSucceeded bool
+	for _, r := range capture.Results() {
+		if r.AuthID == emptyFirst && !r.Success {
+			emptyRecorded = true
+		}
+		if r.AuthID == other && r.Success {
+			otherSucceeded = true
+		}
+	}
+	if !emptyRecorded {
+		t.Fatalf("empty auth %q was not recorded as a failure result; results=%v", emptyFirst, capture.Results())
+	}
+	if !otherSucceeded {
+		t.Fatalf("content auth %q was not recorded as a success result; results=%v", other, capture.Results())
+	}
+}
+
+func TestExecuteStreamThinkingThenContentNotRotated(t *testing.T) {
+	executor := &emptyCompletionTestExecutor{
+		streamPayloads: map[string][][]byte{},
+		streamCalls:    map[string]int{},
+	}
+	manager, ids, model, _ := newEmptyCompletionTestManager(t, executor)
+
+	// Positive control: a thinking-first-then-content stream must NOT be
+	// treated as empty, so it should not rotate to the second auth.
+	content := [][]byte{
+		[]byte("data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"thinking\"},\"finish_reason\":null}]}\n\n"),
+		[]byte("data: {\"choices\":[{\"delta\":{\"content\":\"answer\"},\"finish_reason\":\"stop\"}]}\n\n"),
+		[]byte("data: [DONE]\n\n"),
+	}
+	executor.streamPayloads[ids[0]] = content
+	executor.streamPayloads[ids[1]] = content
+
+	var streamCalls int
+	stream, err := manager.ExecuteStream(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	var got strings.Builder
+	for chunk := range stream.Chunks {
+		got.Write(chunk.Payload)
+	}
+	_ = streamCalls
+	if !strings.Contains(got.String(), "answer") {
+		t.Fatalf("stream payload = %q, want thinking-then-content stream to pass through", got.String())
+	}
+	// The first auth must NOT have been cooled (it produced a real completion).
+	if auth, ok := manager.GetByID(ids[0]); ok && auth != nil {
+		if auth.Unavailable || !auth.NextRetryAfter.IsZero() {
+			t.Fatalf("auth %q was cooled despite producing a real completion", ids[0])
+		}
+	}
+}

--- a/sdk/cliproxy/auth/empty_completion_test.go
+++ b/sdk/cliproxy/auth/empty_completion_test.go
@@ -197,19 +197,34 @@ func TestEmptyCompletionPredicate(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "openai sse refusal is not credential empty",
+			payload:  []byte("data: {\"choices\":[{\"delta\":{\"refusal\":\"I cannot help with that\"},\"finish_reason\":null}]}\n\ndata: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
 			name:     "unterminated is not empty",
 			payload:  []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":null}]}\n\n"),
 			expected: false,
 		},
 		{
-			name:     "claude sse message_stop only is empty",
+			name:     "claude sse message_stop without end_turn is not empty",
 			payload:  []byte("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"),
-			expected: true,
+			expected: false,
 		},
 		{
 			name:     "unrecognized format is not empty",
 			payload:  []byte("data: {\"unknown_payload\":true}\n\n"),
 			expected: false,
+		},
+		{
+			name:     "unknown sse data followed by done is not empty",
+			payload:  []byte("data: {\"vendor_event\":\"usable-or-unknown\"}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name:     "done-only stream remains intentionally empty",
+			payload:  []byte("data: [DONE]\n\n"),
+			expected: true,
 		},
 		{
 			name:     "non stream empty json",
@@ -224,6 +239,11 @@ func TestEmptyCompletionPredicate(t *testing.T) {
 		{
 			name:     "non stream reasoning only is not empty",
 			payload:  []byte(`{"choices":[{"message":{"reasoning_content":"thinking"},"finish_reason":"stop"}]}`),
+			expected: false,
+		},
+		{
+			name:     "openai non-stream refusal is not credential empty",
+			payload:  []byte(`{"choices":[{"message":{"content":"","refusal":"I cannot help with that"},"finish_reason":"stop"}],"usage":{"completion_tokens":0}}`),
 			expected: false,
 		},
 		{
@@ -249,6 +269,16 @@ func TestEmptyCompletionPredicate(t *testing.T) {
 		{
 			name:     "claude non-stream with text content is not empty",
 			payload:  []byte(`{"type":"message","id":"msg_1","role":"assistant","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":1}}`),
+			expected: false,
+		},
+		{
+			name:     "claude non-stream max_tokens is not credential empty",
+			payload:  []byte(`{"type":"message","content":[],"stop_reason":"max_tokens","usage":{"output_tokens":0}}`),
+			expected: false,
+		},
+		{
+			name:     "claude sse refusal is not credential empty",
+			payload:  []byte("event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"refusal\"},\"usage\":{\"output_tokens\":0}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"),
 			expected: false,
 		},
 		{
@@ -312,6 +342,16 @@ func TestEmptyCompletionPredicate(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "gemini prompt feedback safety is not credential empty",
+			payload:  []byte(`{"promptFeedback":{"blockReason":"SAFETY"},"candidates":[]}`),
+			expected: false,
+		},
+		{
+			name:     "gemini sse prompt feedback safety is not credential empty",
+			payload:  []byte("data: {\"promptFeedback\":{\"blockReason\":\"SAFETY\"},\"candidates\":[]}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
 			name:     "openai sse empty choices array then done is empty",
 			payload:  []byte("data: {\"choices\":[]}\n\ndata: [DONE]\n\n"),
 			expected: true,
@@ -367,6 +407,56 @@ func TestEmptyCompletionPredicate(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "codex responses-api non-stream with custom_tool_call is not empty",
+			payload:  []byte(`{"object":"response","status":"completed","output":[{"type":"custom_tool_call","name":"shell","input":"pwd"}],"usage":{"output_tokens":0}}`),
+			expected: false,
+		},
+		{
+			name:     "codex responses-api sse with custom_tool_call is not empty",
+			payload:  []byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"custom_tool_call\",\"name\":\"shell\",\"input\":\"pwd\"}}\n\ndata: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"output_tokens\":0}}}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name:     "codex responses-api non-stream with image_generation_call is not empty",
+			payload:  []byte(`{"object":"response","status":"completed","output":[{"type":"image_generation_call","status":"completed","result":"image-data"}],"usage":{"output_tokens":0}}`),
+			expected: false,
+		},
+		{
+			name:     "codex responses-api sse with image_generation_call is not empty",
+			payload:  []byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"image_generation_call\",\"status\":\"completed\",\"result\":\"image-data\"}}\n\ndata: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"output_tokens\":0}}}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name:     "codex responses-api sse with reasoning item is not empty",
+			payload:  []byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"reasoning\",\"status\":\"completed\",\"summary\":[]}}\n\ndata: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"output_tokens\":0}}}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name:     "codex responses-api non-stream refusal is not credential empty",
+			payload:  []byte(`{"object":"response","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"refusal","refusal":"I cannot help with that"}]}],"usage":{"output_tokens":0}}`),
+			expected: false,
+		},
+		{
+			name:     "codex responses-api sse refusal item is not credential empty",
+			payload:  []byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"refusal\",\"refusal\":\"I cannot help with that\"}]}}\n\ndata: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"output_tokens\":0}}}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name:     "codex responses-api non-stream incomplete is not credential empty",
+			payload:  []byte(`{"object":"response","status":"incomplete","output":[],"usage":{"output_tokens":0}}`),
+			expected: false,
+		},
+		{
+			name:     "codex responses-api sse incomplete is not credential empty",
+			payload:  []byte("data: {\"type\":\"response.incomplete\",\"response\":{\"status\":\"incomplete\",\"output\":[],\"usage\":{\"output_tokens\":0}}}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name:     "codex responses-api sse failed is not credential empty",
+			payload:  []byte("data: {\"type\":\"response.failed\",\"response\":{\"status\":\"failed\",\"output\":[],\"usage\":{\"output_tokens\":0}}}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
 			name:     "gemini non-stream empty candidates array is empty",
 			payload:  []byte(`{"candidates":[],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":0}}`),
 			expected: true,
@@ -383,6 +473,136 @@ func TestEmptyCompletionPredicate(t *testing.T) {
 				t.Fatalf("isEmptyCompletionPayload() = %v, want %v", got, tc.expected)
 			}
 		})
+	}
+}
+
+func TestStreamBootstrapStateForwardsAtMetadataLimit(t *testing.T) {
+	var state streamBootstrapState
+	metadata := []byte("data: {\"type\":\"response.in_progress\",\"response\":{\"status\":\"in_progress\"}}\n\n")
+	for state.bytes+len(metadata) <= maxStreamBootstrapBytes {
+		if state.observe(metadata) {
+			t.Fatal("bootstrap forwarded recognized metadata before reaching its byte limit")
+		}
+	}
+	if !state.observe(metadata) {
+		t.Fatal("bootstrap did not conservatively forward after reaching its byte limit")
+	}
+}
+
+func TestStreamBootstrapDetector(t *testing.T) {
+	var detector StreamBootstrapDetector
+	if detector.Observe([]byte("data: {\"type\":\"response.created\",\"response\":{\"status\":\"in_progress\"}}\n\n")) {
+		t.Fatal("StreamBootstrapDetector.Observe() = true for metadata-only prefix")
+	}
+	if !detector.Observe([]byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"custom_tool_call\"}}\n\n")) {
+		t.Fatal("StreamBootstrapDetector.Observe() = false after complete custom tool output")
+	}
+}
+
+func TestStreamBootstrapDetectorHandlesSplitSSEFrames(t *testing.T) {
+	t.Run("terminal empty remains buffered", func(t *testing.T) {
+		var detector StreamBootstrapDetector
+		fragments := [][]byte{
+			[]byte("da"),
+			[]byte("ta: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n"),
+			[]byte("\nda"),
+			[]byte("ta: [DO"),
+			[]byte("NE]\n\n"),
+		}
+		for i, fragment := range fragments {
+			if detector.Observe(fragment) {
+				t.Fatalf("Observe(fragment %d) forwarded terminal empty stream", i)
+			}
+		}
+	})
+
+	t.Run("meaningful output forwards after complete line", func(t *testing.T) {
+		var detector StreamBootstrapDetector
+		if detector.Observe([]byte("da")) {
+			t.Fatal("Observe() forwarded incomplete SSE prefix")
+		}
+		if detector.Observe([]byte("ta: {\"type\":\"response.output_text.delta\",\"delta\":\"hel")) {
+			t.Fatal("Observe() forwarded incomplete meaningful SSE line")
+		}
+		if !detector.Observe([]byte("lo\"}\n\n")) {
+			t.Fatal("Observe() did not forward completed meaningful SSE line")
+		}
+	})
+
+	t.Run("opaque payload forwards promptly", func(t *testing.T) {
+		var detector StreamBootstrapDetector
+		if !detector.Observe([]byte("opaque-provider-payload")) {
+			t.Fatal("Observe() buffered definitely unrecognized payload")
+		}
+	})
+
+	t.Run("event line waits for empty claude data", func(t *testing.T) {
+		var detector StreamBootstrapDetector
+		fragments := [][]byte{
+			[]byte("event: message_start\n"),
+			[]byte("data: {\"type\":\"message_start\",\"message\":{\"type\":\"message\",\"content\":[],\"stop_reason\":null,\"usage\":{\"output_tokens\":0}}}\n\n"),
+			[]byte("event: message_delta\n"),
+			[]byte("data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":0}}\n\n"),
+			[]byte("event: message_stop\n"),
+			[]byte("data: {\"type\":\"message_stop\"}\n\n"),
+		}
+		for i, fragment := range fragments {
+			if detector.Observe(fragment) {
+				t.Fatalf("Observe(fragment %d) forwarded empty Claude stream", i)
+			}
+		}
+	})
+
+	t.Run("split comment waits for terminal empty data", func(t *testing.T) {
+		var detector StreamBootstrapDetector
+		fragments := [][]byte{
+			[]byte(":"),
+			[]byte(" ping\n"),
+			[]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"),
+			[]byte("data: [DONE]\n\n"),
+		}
+		for i, fragment := range fragments {
+			if detector.Observe(fragment) {
+				t.Fatalf("Observe(fragment %d) forwarded comment-prefixed empty stream", i)
+			}
+		}
+	})
+
+	t.Run("comment then opaque line forwards", func(t *testing.T) {
+		var detector StreamBootstrapDetector
+		if detector.Observe([]byte(":")) || detector.Observe([]byte(" heartbeat\n")) {
+			t.Fatal("Observe() forwarded a valid split SSE comment")
+		}
+		if !detector.Observe([]byte("opaque-provider-payload\n")) {
+			t.Fatal("Observe() buffered a definitely non-SSE line after a comment")
+		}
+	})
+}
+
+func TestReadStreamBootstrapWithholdsSplitClaudeEmptyCompletion(t *testing.T) {
+	fragments := [][]byte{
+		[]byte("event: message_start\n"),
+		[]byte("data: {\"type\":\"message_start\",\"message\":{\"type\":\"message\",\"content\":[],\"stop_reason\":null,\"usage\":{\"output_tokens\":0}}}\n\n"),
+		[]byte("event: message_delta\n"),
+		[]byte("data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":0}}\n\n"),
+		[]byte("event: message_stop\n"),
+		[]byte("data: {\"type\":\"message_stop\"}\n\n"),
+	}
+	chunks := make(chan cliproxyexecutor.StreamChunk, len(fragments))
+	for _, fragment := range fragments {
+		chunks <- cliproxyexecutor.StreamChunk{Payload: fragment}
+	}
+	close(chunks)
+
+	buffered, closed, err := readStreamBootstrap(context.Background(), chunks)
+	if err != nil {
+		t.Fatalf("readStreamBootstrap() error = %v", err)
+	}
+	if !closed {
+		t.Fatal("readStreamBootstrap() forwarded empty Claude stream")
+	}
+	if !isEmptyCompletion(buffered) {
+		t.Fatal("split Claude stream was not classified as empty at close")
 	}
 }
 

--- a/sdk/cliproxy/auth/empty_completion_test.go
+++ b/sdk/cliproxy/auth/empty_completion_test.go
@@ -29,6 +29,12 @@ type emptyCompletionTestExecutor struct {
 	firstExecute string
 	// firstStream records the first auth picked for a stream execution.
 	firstStream string
+
+	// emptyStreamPayload/contentStreamPayload override the default first-auth
+	// empty stream and subsequent-auth content stream (used to exercise
+	// non-OpenAI stream formats).
+	emptyStreamPayload   [][]byte
+	contentStreamPayload [][]byte
 }
 
 func (e *emptyCompletionTestExecutor) Identifier() string { return "claude" }
@@ -76,9 +82,12 @@ func (e *emptyCompletionTestExecutor) ExecuteStream(ctx context.Context, auth *A
 	// empty completion and subsequent auths to stream real content, so rotation
 	// tests are deterministic regardless of global selector state.
 	if len(e.streamPayloads) == 0 && e.firstStream == auth.ID {
-		empty := [][]byte{
-			[]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"),
-			[]byte("data: [DONE]\n\n"),
+		empty := e.emptyStreamPayload
+		if len(empty) == 0 {
+			empty = [][]byte{
+				[]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"),
+				[]byte("data: [DONE]\n\n"),
+			}
 		}
 		chunks := make(chan cliproxyexecutor.StreamChunk, len(empty))
 		for _, p := range empty {
@@ -95,10 +104,13 @@ func (e *emptyCompletionTestExecutor) ExecuteStream(ctx context.Context, auth *A
 		close(chunks)
 		return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
 	}
-	content := [][]byte{
-		[]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n"),
-		[]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"),
-		[]byte("data: [DONE]\n\n"),
+	content := e.contentStreamPayload
+	if len(content) == 0 {
+		content = [][]byte{
+			[]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n"),
+			[]byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"),
+			[]byte("data: [DONE]\n\n"),
+		}
 	}
 	chunks := make(chan cliproxyexecutor.StreamChunk, len(content))
 	for _, p := range content {
@@ -190,8 +202,13 @@ func TestEmptyCompletionPredicate(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "non openai format is not empty",
-			payload: []byte("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"),
+			name:     "claude sse message_stop only is empty",
+			payload:  []byte("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"),
+			expected: true,
+		},
+		{
+			name:     "unrecognized format is not empty",
+			payload:  []byte("data: {\"unknown_payload\":true}\n\n"),
 			expected: false,
 		},
 		{
@@ -205,9 +222,74 @@ func TestEmptyCompletionPredicate(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "non stream reasoning only is not empty",
-			payload: []byte(`{"choices":[{"message":{"reasoning_content":"thinking"},"finish_reason":"stop"}]}`),
+			name:     "non stream reasoning only is not empty",
+			payload:  []byte(`{"choices":[{"message":{"reasoning_content":"thinking"},"finish_reason":"stop"}]}`),
 			expected: false,
+		},
+		{
+			name:     "claude non-stream empty message is empty",
+			payload:  []byte(`{"type":"message","id":"msg_1","role":"assistant","content":[],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":0}}`),
+			expected: true,
+		},
+		{
+			name:     "claude non-stream empty message without usage is empty",
+			payload:  []byte(`{"type":"message","id":"msg_1","role":"assistant","content":[],"stop_reason":"end_turn"}`),
+			expected: true,
+		},
+		{
+			name:     "claude non-stream with tool_use is not empty",
+			payload:  []byte(`{"type":"message","id":"msg_1","role":"assistant","content":[{"type":"tool_use","id":"call_1","name":"get_weather","input":{}}],"stop_reason":"tool_use","usage":{"input_tokens":10,"output_tokens":5}}`),
+			expected: false,
+		},
+		{
+			name:     "claude non-stream thinking-block-only is not empty",
+			payload:  []byte(`{"type":"message","id":"msg_1","role":"assistant","content":[{"type":"thinking","thinking":"let me think","signature":"sig"}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5}}`),
+			expected: false,
+		},
+		{
+			name:     "claude non-stream with text content is not empty",
+			payload:  []byte(`{"type":"message","id":"msg_1","role":"assistant","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":1}}`),
+			expected: false,
+		},
+		{
+			name:     "claude sse empty stream is empty",
+			payload:  []byte("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"stop_reason\":null,\"usage\":{\"output_tokens\":0}}}\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":0}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"),
+			expected: true,
+		},
+		{
+			name:     "gemini non-stream empty candidates is empty",
+			payload:  []byte(`{"candidates":[{"content":{"role":"model","parts":[]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":0}}`),
+			expected: true,
+		},
+		{
+			name:     "gemini non-stream whitespace parts is empty",
+			payload:  []byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"   "}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":0}}`),
+			expected: true,
+		},
+		{
+			name:     "gemini non-stream without usage is empty",
+			payload:  []byte(`{"candidates":[{"content":{"role":"model","parts":[]},"finishReason":"STOP"}]}`),
+			expected: true,
+		},
+		{
+			name:     "gemini non-stream with functionCall part is not empty",
+			payload:  []byte(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"search","args":{}}}]},"finishReason":"STOP"}]}`),
+			expected: false,
+		},
+		{
+			name:     "gemini non-stream with text content is not empty",
+			payload:  []byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"hello"}]},"finishReason":"STOP"}]}`),
+			expected: false,
+		},
+		{
+			name:     "gemini non-stream with thought part is not empty",
+			payload:  []byte(`{"candidates":[{"content":{"role":"model","parts":[{"thought":true,"text":"thinking"}]},"finishReason":"STOP"}]}`),
+			expected: false,
+		},
+		{
+			name:     "gemini sse empty stream is empty",
+			payload:  []byte("data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"candidatesTokenCount\":0}}\n\n"),
+			expected: true,
 		},
 	}
 	for _, tc := range cases {
@@ -307,6 +389,59 @@ func TestExecuteStreamEmptyCompletionRotatesAuth(t *testing.T) {
 	}
 	if !otherSucceeded {
 		t.Fatalf("content auth %q was not recorded as a success result; results=%v", other, capture.Results())
+	}
+}
+
+func TestExecuteStreamEmptyGeminiStreamRotatesAuth(t *testing.T) {
+	executor := &emptyCompletionTestExecutor{
+		streamPayloads: map[string][][]byte{},
+		streamCalls:    map[string]int{},
+		emptyStreamPayload: [][]byte{
+			[]byte("data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"candidatesTokenCount\":0}}\n\n"),
+		},
+		contentStreamPayload: [][]byte{
+			[]byte("data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"functionCall\":{\"name\":\"search\",\"args\":{}}}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"candidatesTokenCount\":5}}\n\n"),
+		},
+	}
+	manager, ids, model, capture := newEmptyCompletionTestManager(t, executor)
+
+	stream, err := manager.ExecuteStream(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	if stream == nil {
+		t.Fatal("ExecuteStream() returned nil stream")
+	}
+	var got strings.Builder
+	for chunk := range stream.Chunks {
+		got.Write(chunk.Payload)
+	}
+	if !strings.Contains(got.String(), "functionCall") {
+		t.Fatalf("stream payload = %q, want content from the non-empty auth", got.String())
+	}
+	emptyFirst := executor.firstStream
+	if emptyFirst == "" {
+		t.Fatal("executor never streamed any auth")
+	}
+	other := ids[0]
+	if emptyFirst == ids[0] {
+		other = ids[1]
+	}
+	var emptyRecorded bool
+	var otherSucceeded bool
+	for _, r := range capture.Results() {
+		if r.AuthID == emptyFirst && !r.Success {
+			emptyRecorded = true
+		}
+		if r.AuthID == other && r.Success {
+			otherSucceeded = true
+		}
+	}
+	if !emptyRecorded {
+		t.Fatalf("expected failure recorded for empty auth %s, results: %+v", emptyFirst, capture.Results())
+	}
+	if !otherSucceeded {
+		t.Fatalf("expected success recorded for non-empty auth %s, results: %+v", other, capture.Results())
 	}
 }
 

--- a/sdk/cliproxy/auth/empty_completion_test.go
+++ b/sdk/cliproxy/auth/empty_completion_test.go
@@ -167,38 +167,38 @@ func TestEmptyCompletionPredicate(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "openai sse empty",
-			payload: []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
+			name:     "openai sse empty",
+			payload:  []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
 			expected: true,
 		},
 		{
-			name: "openai sse thinking then content is not empty",
-			payload: []byte("data: {\"choices\":[{\"delta\":{\"content\":\"\"},\"finish_reason\":null}]}\n\ndata: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
+			name:     "openai sse thinking then content is not empty",
+			payload:  []byte("data: {\"choices\":[{\"delta\":{\"content\":\"\"},\"finish_reason\":null}]}\n\ndata: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
 			expected: false,
 		},
 		{
-			name: "whitespace only zero tokens is empty",
-			payload: []byte("data: {\"choices\":[{\"delta\":{\"content\":\"   \"},\"finish_reason\":\"stop\"}],\"usage\":{\"completion_tokens\":0}}\n\ndata: [DONE]\n\n"),
+			name:     "whitespace only zero tokens is empty",
+			payload:  []byte("data: {\"choices\":[{\"delta\":{\"content\":\"   \"},\"finish_reason\":\"stop\"}],\"usage\":{\"completion_tokens\":0}}\n\ndata: [DONE]\n\n"),
 			expected: true,
 		},
 		{
-			name: "non zero tokens is not empty",
-			payload: []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"completion_tokens\":5}}\n\ndata: [DONE]\n\n"),
+			name:     "non zero tokens is not empty",
+			payload:  []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"completion_tokens\":5}}\n\ndata: [DONE]\n\n"),
 			expected: false,
 		},
 		{
-			name: "tool calls are not empty",
-			payload: []byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"x\"}]},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
+			name:     "tool calls are not empty",
+			payload:  []byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"x\"}]},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
 			expected: false,
 		},
 		{
-			name: "openai sse reasoning only is not empty",
-			payload: []byte("data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"thinking step by step\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
+			name:     "openai sse reasoning only is not empty",
+			payload:  []byte("data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"thinking step by step\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
 			expected: false,
 		},
 		{
-			name: "unterminated is not empty",
-			payload: []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":null}]}\n\n"),
+			name:     "unterminated is not empty",
+			payload:  []byte("data: {\"choices\":[{\"delta\":{},\"finish_reason\":null}]}\n\n"),
 			expected: false,
 		},
 		{
@@ -212,13 +212,13 @@ func TestEmptyCompletionPredicate(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "non stream empty json",
-			payload: []byte(`{"choices":[{"message":{"content":""},"finish_reason":"stop"}],"usage":{"completion_tokens":0}}`),
+			name:     "non stream empty json",
+			payload:  []byte(`{"choices":[{"message":{"content":""},"finish_reason":"stop"}],"usage":{"completion_tokens":0}}`),
 			expected: true,
 		},
 		{
-			name: "non stream content is not empty",
-			payload: []byte(`{"choices":[{"message":{"content":"hi"},"finish_reason":"stop"}]}`),
+			name:     "non stream content is not empty",
+			payload:  []byte(`{"choices":[{"message":{"content":"hi"},"finish_reason":"stop"}]}`),
 			expected: false,
 		},
 		{
@@ -291,6 +291,31 @@ func TestEmptyCompletionPredicate(t *testing.T) {
 			payload:  []byte("data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"candidatesTokenCount\":0}}\n\n"),
 			expected: true,
 		},
+		{
+			name:     "gemini blocked safety is not empty",
+			payload:  []byte(`{"candidates":[{"content":{"role":"model","parts":[]},"finishReason":"SAFETY"}]}`),
+			expected: false,
+		},
+		{
+			name:     "gemini blocked recitation is not empty",
+			payload:  []byte(`{"candidates":[{"content":{"role":"model","parts":[]},"finishReason":"RECITATION"}]}`),
+			expected: false,
+		},
+		{
+			name:     "gemini max tokens with empty content is not empty",
+			payload:  []byte(`{"candidates":[{"content":{"role":"model","parts":[]},"finishReason":"MAX_TOKENS"}]}`),
+			expected: false,
+		},
+		{
+			name:     "gemini sse blocked safety closed by done is not empty",
+			payload:  []byte("data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[]},\"finishReason\":\"SAFETY\"}]}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name:     "openai sse empty choices array then done is empty",
+			payload:  []byte("data: {\"choices\":[]}\n\ndata: [DONE]\n\n"),
+			expected: true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -312,35 +337,7 @@ func TestExecuteEmptyCompletionRotatesAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
-	if !strings.Contains(string(resp.Payload), "real") {
-		t.Fatalf("Execute() payload = %q, want success content from the non-empty auth", resp.Payload)
-	}
-	// The first-picked auth (which returned empty) must have been recorded as a
-	// failure; the other must have succeeded.
-	emptyFirst := executor.firstExecute
-	if emptyFirst == "" {
-		t.Fatal("executor never executed any auth")
-	}
-	other := ids[0]
-	if emptyFirst == ids[0] {
-		other = ids[1]
-	}
-	var emptyRecorded bool
-	var otherSucceeded bool
-	for _, r := range capture.Results() {
-		if r.AuthID == emptyFirst && !r.Success {
-			emptyRecorded = true
-		}
-		if r.AuthID == other && r.Success {
-			otherSucceeded = true
-		}
-	}
-	if !emptyRecorded {
-		t.Fatalf("empty auth %q was not recorded as a failure result; results=%v", emptyFirst, capture.Results())
-	}
-	if !otherSucceeded {
-		t.Fatalf("content auth %q was not recorded as a success result; results=%v", other, capture.Results())
-	}
+	assertRotatesToContent(t, ids, executor.firstExecute, string(resp.Payload), "real", capture)
 }
 
 func TestExecuteStreamEmptyCompletionRotatesAuth(t *testing.T) {
@@ -361,35 +358,7 @@ func TestExecuteStreamEmptyCompletionRotatesAuth(t *testing.T) {
 	for chunk := range stream.Chunks {
 		got.Write(chunk.Payload)
 	}
-	if !strings.Contains(got.String(), "hello") {
-		t.Fatalf("stream payload = %q, want content from the non-empty auth", got.String())
-	}
-	// The first-streamed auth (which returned empty) must have been recorded as
-	// a failure; the other must have succeeded.
-	emptyFirst := executor.firstStream
-	if emptyFirst == "" {
-		t.Fatal("executor never streamed any auth")
-	}
-	other := ids[0]
-	if emptyFirst == ids[0] {
-		other = ids[1]
-	}
-	var emptyRecorded bool
-	var otherSucceeded bool
-	for _, r := range capture.Results() {
-		if r.AuthID == emptyFirst && !r.Success {
-			emptyRecorded = true
-		}
-		if r.AuthID == other && r.Success {
-			otherSucceeded = true
-		}
-	}
-	if !emptyRecorded {
-		t.Fatalf("empty auth %q was not recorded as a failure result; results=%v", emptyFirst, capture.Results())
-	}
-	if !otherSucceeded {
-		t.Fatalf("content auth %q was not recorded as a success result; results=%v", other, capture.Results())
-	}
+	assertRotatesToContent(t, ids, executor.firstStream, got.String(), "hello", capture)
 }
 
 func TestExecuteStreamEmptyGeminiStreamRotatesAuth(t *testing.T) {
@@ -416,33 +385,7 @@ func TestExecuteStreamEmptyGeminiStreamRotatesAuth(t *testing.T) {
 	for chunk := range stream.Chunks {
 		got.Write(chunk.Payload)
 	}
-	if !strings.Contains(got.String(), "functionCall") {
-		t.Fatalf("stream payload = %q, want content from the non-empty auth", got.String())
-	}
-	emptyFirst := executor.firstStream
-	if emptyFirst == "" {
-		t.Fatal("executor never streamed any auth")
-	}
-	other := ids[0]
-	if emptyFirst == ids[0] {
-		other = ids[1]
-	}
-	var emptyRecorded bool
-	var otherSucceeded bool
-	for _, r := range capture.Results() {
-		if r.AuthID == emptyFirst && !r.Success {
-			emptyRecorded = true
-		}
-		if r.AuthID == other && r.Success {
-			otherSucceeded = true
-		}
-	}
-	if !emptyRecorded {
-		t.Fatalf("expected failure recorded for empty auth %s, results: %+v", emptyFirst, capture.Results())
-	}
-	if !otherSucceeded {
-		t.Fatalf("expected success recorded for non-empty auth %s, results: %+v", other, capture.Results())
-	}
+	assertRotatesToContent(t, ids, executor.firstStream, got.String(), "functionCall", capture)
 }
 
 func TestExecuteStreamThinkingThenContentNotRotated(t *testing.T) {
@@ -480,5 +423,37 @@ func TestExecuteStreamThinkingThenContentNotRotated(t *testing.T) {
 		if auth.Unavailable || !auth.NextRetryAfter.IsZero() {
 			t.Fatalf("auth %q was cooled despite producing a real completion", ids[0])
 		}
+	}
+}
+
+// assertRotatesToContent verifies that an empty-completion from the first-picked
+// auth rotates to the other auth, which then succeeds with the given content.
+func assertRotatesToContent(t *testing.T, ids []string, emptyFirst, gotPayload, wantSubstr string, capture *resultCaptureHook) {
+	t.Helper()
+	if emptyFirst == "" {
+		t.Fatal("executor never executed/streamed any auth")
+	}
+	if !strings.Contains(gotPayload, wantSubstr) {
+		t.Fatalf("payload = %q, want %q from the non-empty auth", gotPayload, wantSubstr)
+	}
+	other := ids[0]
+	if emptyFirst == ids[0] {
+		other = ids[1]
+	}
+	var emptyRecorded bool
+	var otherSucceeded bool
+	for _, r := range capture.Results() {
+		if r.AuthID == emptyFirst && !r.Success {
+			emptyRecorded = true
+		}
+		if r.AuthID == other && r.Success {
+			otherSucceeded = true
+		}
+	}
+	if !emptyRecorded {
+		t.Fatalf("empty auth %q was not recorded as a failure result; results=%v", emptyFirst, capture.Results())
+	}
+	if !otherSucceeded {
+		t.Fatalf("content auth %q was not recorded as a success result; results=%v", other, capture.Results())
 	}
 }

--- a/sdk/cliproxy/auth/home_execution_paths_test.go
+++ b/sdk/cliproxy/auth/home_execution_paths_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -516,8 +517,9 @@ func (e *lifecycleRetryExecutor) ExecuteStream(ctx context.Context, _ *Auth, _ c
 		e.firstCtx = ctx
 		return nil, &Error{HTTPStatus: http.StatusUpgradeRequired, Message: "websocket upgrade required"}
 	}
-	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
-	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(`{"type":"response.completed"}`)}
+	chunks := make(chan cliproxyexecutor.StreamChunk, 2)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(`{"type":"response.output_text.delta","delta":"ok"}`)}
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(`{"type":"response.completed","response":{"status":"completed"}}`)}
 	close(chunks)
 	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
 }
@@ -592,8 +594,9 @@ func (e *retryingHomeStreamExecutor) ExecuteStream(context.Context, *Auth, clipr
 	if e.calls.Add(1) == 1 {
 		return nil, &Error{HTTPStatus: http.StatusUnauthorized, Message: "expired"}
 	}
-	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
-	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("data: {\"type\":\"response.completed\"}\n\n")}
+	chunks := make(chan cliproxyexecutor.StreamChunk, 2)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n")}
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n")}
 	close(chunks)
 	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
 }
@@ -623,6 +626,123 @@ func TestHomeStreamRetryUsesFreshSelection(t *testing.T) {
 	}
 	if got := dispatcher.calls.Load(); got != 2 {
 		t.Fatalf("Home RPOP calls = %d, want 2 for retrying stream invocations", got)
+	}
+}
+
+type alwaysEmptyHomeStreamExecutor struct {
+	calls atomic.Int32
+}
+
+func (*alwaysEmptyHomeStreamExecutor) Identifier() string { return "home-execution" }
+func (*alwaysEmptyHomeStreamExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (e *alwaysEmptyHomeStreamExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.calls.Add(1)
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"output_tokens\":0}}}\n\n")}
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+func (*alwaysEmptyHomeStreamExecutor) Refresh(context.Context, *Auth) (*Auth, error) {
+	return nil, nil
+}
+func (*alwaysEmptyHomeStreamExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (*alwaysEmptyHomeStreamExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestHomeStreamRepeatedEmptyCompletionStopsAtRepeatedAuth(t *testing.T) {
+	dispatcher := &retainingHomeExecutionDispatcher{}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	executor := &alwaysEmptyHomeStreamExecutor{}
+	manager.RegisterExecutor(executor)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	result, errExecute := manager.ExecuteStream(ctx, []string{"home-execution"}, cliproxyexecutor.Request{Model: "model-a"}, cliproxyexecutor.Options{Stream: true})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+	var terminalErr error
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			terminalErr = chunk.Err
+		}
+	}
+	if !isEmptyCompletionError(terminalErr) {
+		t.Fatalf("terminal error = %v, want empty_completion", terminalErr)
+	}
+	if got := executor.calls.Load(); got != 1 {
+		t.Fatalf("executor calls = %d, want 1 before repeated auth is rejected", got)
+	}
+	if got := dispatcher.calls.Load(); got != 2 {
+		t.Fatalf("Home RPOP calls = %d, want 2 to detect the repeated auth", got)
+	}
+}
+
+type alternatingEmptyHomeDispatcher struct {
+	calls atomic.Int32
+}
+
+func (*alternatingEmptyHomeDispatcher) HeartbeatOK() bool { return true }
+func (d *alternatingEmptyHomeDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+	call := d.calls.Add(1)
+	authID := "home-auth-a"
+	if call == 2 {
+		authID = "home-auth-b"
+	}
+	return json.Marshal(homeAuthDispatchResponse{Auth: Auth{ID: authID, Provider: "home-execution", Status: StatusActive}})
+}
+func (*alternatingEmptyHomeDispatcher) AbortAmbiguousDispatch() {}
+
+type alternatingEmptyHomeExecutor struct {
+	calls atomic.Int32
+}
+
+func (*alternatingEmptyHomeExecutor) Identifier() string { return "home-execution" }
+func (*alternatingEmptyHomeExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (e *alternatingEmptyHomeExecutor) ExecuteStream(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.calls.Add(1)
+	if auth.ID == "home-auth-b" {
+		return nil, &Error{Code: "transient", Message: "transient stream failure", Retryable: true}
+	}
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte("data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[]}}\n\n")}
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+func (*alternatingEmptyHomeExecutor) Refresh(context.Context, *Auth) (*Auth, error) { return nil, nil }
+func (*alternatingEmptyHomeExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (*alternatingEmptyHomeExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestHomeStreamDoesNotRevisitEmptyAuthAfterAnotherFailure(t *testing.T) {
+	dispatcher := &alternatingEmptyHomeDispatcher{}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	executor := &alternatingEmptyHomeExecutor{}
+	manager.RegisterExecutor(executor)
+
+	_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-execution"}, cliproxyexecutor.Request{Model: "model-a"}, cliproxyexecutor.Options{Stream: true}, 0)
+	if errExecute == nil || !strings.Contains(errExecute.Error(), "transient stream failure") {
+		t.Fatalf("executeStreamMixedOnce() error = %v, want last transient failure", errExecute)
+	}
+	if got := executor.calls.Load(); got != 2 {
+		t.Fatalf("executor calls = %d, want one call per distinct auth", got)
+	}
+	if got := dispatcher.calls.Load(); got != 3 {
+		t.Fatalf("Home RPOP calls = %d, want third dispatch rejected before execution", got)
 	}
 }
 

--- a/sdk/cliproxy/auth/home_selected_auth_callback_test.go
+++ b/sdk/cliproxy/auth/home_selected_auth_callback_test.go
@@ -42,8 +42,9 @@ func (e *callbackPinHomeExecutor) ExecuteStream(_ context.Context, _ *Auth, _ cl
 	if lifecycle, ok := opts.ExecutionLifecycle.(interface{ Retain() }); ok {
 		lifecycle.Retain()
 	}
-	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
-	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(`{"type":"response.completed"}`)}
+	chunks := make(chan cliproxyexecutor.StreamChunk, 2)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(`{"type":"response.output_text.delta","delta":"ok"}`)}
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(`{"type":"response.completed","response":{"status":"completed"}}`)}
 	close(chunks)
 	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
 }

--- a/sdk/cliproxy/auth/request_auth_prepare_test.go
+++ b/sdk/cliproxy/auth/request_auth_prepare_test.go
@@ -98,8 +98,9 @@ func (e *requestPrepareExecutor) ExecuteStream(_ context.Context, auth *Auth, _ 
 	if e.executeErr != nil {
 		return nil, e.executeErr
 	}
-	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
-	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(`{"type":"response.completed"}`)}
+	chunks := make(chan cliproxyexecutor.StreamChunk, 2)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(`{"type":"response.output_text.delta","delta":"ok"}`)}
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(`{"type":"response.completed","response":{"status":"completed"}}`)}
 	close(chunks)
 	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
 }

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -2131,3 +2131,85 @@ func TestSessionAffinitySelectorUsesRequestPayloadWhenOriginalRequestMissing(t *
 		t.Fatalf("request-only conversation changed auth from %q to %q", first.ID, second.ID)
 	}
 }
+
+// recordingFallbackSelector wraps a Selector and records the auth IDs passed to
+// each Pick call, so tests can assert the fallback only receives available auths.
+type recordingFallbackSelector struct {
+	inner Selector
+	mu    sync.Mutex
+	last  []string
+}
+
+func (r *recordingFallbackSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	r.mu.Lock()
+	r.last = make([]string, 0, len(auths))
+	for _, a := range auths {
+		r.last = append(r.last, a.ID)
+	}
+	r.mu.Unlock()
+	return r.inner.Pick(ctx, provider, model, opts, auths)
+}
+
+func (r *recordingFallbackSelector) lastPick() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.last))
+	copy(out, r.last)
+	return out
+}
+
+// TestSessionAffinitySelector_FallbackReselectReceivesOnlyAvailable is a
+// regression test for the fallback reselect path: when the cached auth is no
+// longer available, the fallback must only receive the available auths, not the
+// full list (which could include the now-unavailable cached auth).
+func TestSessionAffinitySelector_FallbackReselectReceivesOnlyAvailable(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingFallbackSelector{inner: &RoundRobinSelector{}}
+	selector := NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: rec,
+		TTL:      time.Minute,
+	})
+	defer selector.Stop()
+
+	auths := []*Auth{
+		{ID: "auth-a"},
+		{ID: "auth-b"},
+		{ID: "auth-c"},
+	}
+
+	payload := []byte(`{"metadata":{"user_id":"user_xxx_account__session_fallback-reselect-test"}}`)
+	opts := cliproxyexecutor.Options{OriginalRequest: payload}
+
+	// First pick establishes the binding (fallback receives the full list here).
+	first, err := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+
+	// Make the bound auth unavailable so it is filtered out of `available`.
+	bound := first.ID
+	for _, a := range auths {
+		if a.ID == bound {
+			a.Unavailable = true
+			a.NextRetryAfter = time.Now().Add(time.Hour)
+		}
+	}
+
+	// Second pick with the SAME full auths list: the cached auth is now filtered
+	// out of available, so the fallback reselect path fires. It must receive
+	// only the two still-available auths, not the full list.
+	if _, err := selector.Pick(context.Background(), "claude", "claude-3", opts, auths); err != nil {
+		t.Fatalf("Pick() after failover error = %v", err)
+	}
+
+	got := rec.lastPick()
+	if len(got) != 2 {
+		t.Fatalf("fallback reselect received %d auths, want 2 (only available); got %v", len(got), got)
+	}
+	for _, id := range got {
+		if id == bound {
+			t.Fatalf("fallback reselect received unavailable cached auth %q; received %v", bound, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Providers occasionally return HTTP 200 with a semantically empty completion — `finish_reason: stop`, zero content, zero tool calls, zero completion tokens (observed on Gemini AI Studio-path providers with long tool-call conversations). Today this counts as success: the client gets a useless empty reply, no retry happens, the auth is never cooled down, and session affinity keeps the session pinned to the broken auth — agent harnesses die on "empty response, finishReason=stop".

This change treats a genuinely empty terminal completion as a retriable failure:

- **Detection** (`empty_completion.go`, new): conservative predicates for OpenAI-style SSE streams and non-stream JSON — empty iff terminal (stop/[DONE]/stream end) AND zero non-whitespace content AND zero tool calls AND zero/absent completion tokens. `reasoning_content` counts as content; unrecognized formats return false (no behavior change).
- **Stream path** (`conductor_stream.go`): when the bootstrap read closes with an empty aggregate — before any byte reaches the client — synthesize a retriable `errEmptyCompletion`, MarkResult(failure), continue the model/auth loop.
- **Non-stream paths** (`conductor_execution.go`, `conductor_home.go` antigravity credits fallback): same judgment on the response payload.
- Effect: the request rotates to the next auth/model, the empty-returning auth is cooled down, and session affinity detaches — instead of pinning the session to a provider that returns nothing.

No new config: the predicate only fires on responses that carry no usable content at all.

## Test plan

- [x] `go build ./...`
- [x] `go test ./sdk/cliproxy/...` — incl. `TestEmptyCompletionPredicate` (11 cases: pure tool call / text / reasoning-only / whitespace-only stop / empty stop / non-OpenAI formats), stream & non-stream auth-rotation tests, selector reselect-from-available regression (`-count=10` green)
- [x] Live E2E: stub provider returning empty streams + healthy providers behind one alias — pinned request yields a clean error instead of a silent empty 200; group requests rotate and return real completions
