### PR TITLE
refactor(logging): rename FileBodySource.WriteTo to MergeTo; document stream cancel ownership

### DIFF
--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -703,7 +703,7 @@ func mergeFileBodySource(payload []byte, source *logging.FileBodySource) ([]byte
 		}
 		buf.WriteByte('\n')
 	}
-	if errWrite := source.WriteTo(&buf); errWrite != nil {
+	if errWrite := source.MergeTo(&buf); errWrite != nil {
 		return nil, errWrite
 	}
 	return buf.Bytes(), nil

--- a/internal/logging/request_logger_body_source.go
+++ b/internal/logging/request_logger_body_source.go
@@ -166,8 +166,8 @@ func (s *FileBodySource) Paths() []string {
 	return out
 }
 
-// WriteTo merges all ordered parts into w.
-func (s *FileBodySource) WriteTo(w io.Writer) error {
+// MergeTo merges all ordered parts into w.
+func (s *FileBodySource) MergeTo(w io.Writer) error {
 	if s == nil || w == nil {
 		return nil
 	}
@@ -207,7 +207,7 @@ func (s *FileBodySource) WriteTo(w io.Writer) error {
 // Bytes merges all ordered parts into memory.
 func (s *FileBodySource) Bytes() ([]byte, error) {
 	var buf bytes.Buffer
-	if errWrite := s.WriteTo(&buf); errWrite != nil {
+	if errWrite := s.MergeTo(&buf); errWrite != nil {
 		return nil, errWrite
 	}
 	return buf.Bytes(), nil

--- a/internal/logging/request_logger_format.go
+++ b/internal/logging/request_logger_format.go
@@ -311,7 +311,7 @@ func writeAPISectionWithSource(w io.Writer, sectionHeader string, sectionPrefix 
 		}
 	}
 	tracker := &trailingNewlineTrackingWriter{writer: w}
-	if errWrite := source.WriteTo(tracker); errWrite != nil {
+	if errWrite := source.MergeTo(tracker); errWrite != nil {
 		return errWrite
 	}
 	if errWrite := writeSectionSpacing(w, tracker.trailingNewlines); errWrite != nil {
@@ -330,7 +330,7 @@ func writePreformattedAPISectionWithSource(w io.Writer, sectionHeader string, se
 		}
 	}
 	tracker := &trailingNewlineTrackingWriter{writer: w}
-	if errWrite := source.WriteTo(tracker); errWrite != nil {
+	if errWrite := source.MergeTo(tracker); errWrite != nil {
 		return errWrite
 	}
 	if errWrite := writeSectionSpacing(w, tracker.trailingNewlines); errWrite != nil {

--- a/internal/pluginhost/host_callbacks.go
+++ b/internal/pluginhost/host_callbacks.go
@@ -162,6 +162,8 @@ func (h *Host) callHostHTTPDoStream(ctx context.Context, request []byte) ([]byte
 		ctx = context.Background()
 	}
 	streamCtx, cancel := context.WithCancel(ctx)
+	// cancel transfers to the stream bridge on success below.
+	_ = cancel
 	resp, errDo := h.newHTTPClient(nil).DoStream(streamCtx, httpReq)
 	if errDo != nil {
 		cancel()

--- a/internal/pluginhost/host_model_stream_callbacks.go
+++ b/internal/pluginhost/host_model_stream_callbacks.go
@@ -27,6 +27,8 @@ func (h *Host) callHostModelExecuteStream(ctx context.Context, request []byte) (
 	}
 	// Detach request cancellation while preserving callback values; callback cleanup owns the model stream lifetime.
 	streamCtx, cancel := context.WithCancel(context.WithoutCancel(callbackCtx))
+	// cancel transfers to the stream bridge on success below.
+	_ = cancel
 	stream, errMsg := executor.ExecuteModelStream(streamCtx, modelExecutionRequestFromPlugin(req.HostModelExecutionRequest, skipPluginID))
 	if errMsg != nil {
 		cancel()


### PR DESCRIPTION
## Summary

Fixes `go vet` warning about `FileBodySource.WriteTo` shadowing the `io.WriterTo` interface method and documents the cancel-ownership transfer pattern in the plugin host stream bridge.

## Changes

### 1. Rename `FileBodySource.WriteTo` → `MergeTo` (`internal/logging`)

`FileBodySource.WriteTo(w io.Writer) error` has a different signature than `io.WriterTo.WriteTo(w io.Writer) (int64, error)`. This shadows the standard interface method and triggers `go vet` warnings. Renamed to `MergeTo` — semantically accurate (the method merges ordered log parts into a writer) and avoids the signature collision.

Updated all 5 call sites:
- `request_logger_body_source.go` — method definition + `Bytes()` helper
- `request_logger_format.go` — `writeAPISectionWithSource`, `writePreformattedAPISectionWithSource`
- `response_writer.go` — `mergeFileBodySource`

### 2. Document cancel-ownership in plugin host (`internal/pluginhost`)

`host_callbacks.go` and `host_model_stream_callbacks.go` both create a `context.WithCancel` whose `cancel` func transfers ownership to the stream bridge on the success path. Without a comment, `go vet` (and human reviewers) see `cancel` assigned but never called on the success path and flag it as a leak. Added `_ = cancel` with a comment explaining the ownership transfer.

## Verification

- `go vet ./...` clean
- `go build ./...` clean
- `go test -count=1 ./internal/logging/... ./internal/pluginhost/... ./internal/api/middleware/...`

## Mirror

CPA: router-for-me/CLIProxyAPI#4943 (identical changes)