### PR TITLE
test(util): skip build caches in source walker

### DIFF
--- a/internal/util/nocopy_invariant_test.go
+++ b/internal/util/nocopy_invariant_test.go
@@ -18,6 +18,15 @@ var inPlaceSJSONTokens = []string{"ReplaceInPlace", "Optimistic"}
 // from the same buffer can still be alive at that point.
 var inPlaceSJSONAllowlist = map[string]struct{}{}
 
+// skippedWalkDirs are directories the source walker never descends into. The
+// build and tool dirs are excluded because they hold cloned third-party or
+// generated Go sources (build output, caches, temporary GOPATH/module trees)
+// that must not be treated as product code governed by these invariants.
+var skippedWalkDirs = map[string]struct{}{
+	".git": {}, "vendor": {}, "node_modules": {}, "testdata": {},
+	".tmp_build": {}, ".go-cache": {}, ".go-tmp": {}, ".gocache": {},
+}
+
 // forEachSourceFile visits every non-test Go file in the repository.
 func forEachSourceFile(t *testing.T, root string, visit func(rel string, data []byte)) {
 	t.Helper()
@@ -26,8 +35,7 @@ func forEachSourceFile(t *testing.T, root string, visit func(rel string, data []
 			return err
 		}
 		if d.IsDir() {
-			switch d.Name() {
-			case ".git", "vendor", "node_modules", "testdata":
+			if _, skip := skippedWalkDirs[d.Name()]; skip {
 				return filepath.SkipDir
 			}
 			return nil
@@ -48,6 +56,50 @@ func forEachSourceFile(t *testing.T, root string, visit func(rel string, data []
 	})
 	if err != nil {
 		t.Fatalf("walk repository: %v", err)
+	}
+}
+
+// TestForEachSourceFileSkipsBuildDirs pins the walker's directory exclusions
+// and its non-exclusion of arbitrary hidden dirs. Every listed build/tool dir
+// must be skipped even when it holds a poisoned *.go file, while a hidden
+// source dir with no special meaning must still be scanned.
+func TestForEachSourceFileSkipsBuildDirs(t *testing.T) {
+	root := t.TempDir()
+	poison := "-- FORBIDDEN: ReplaceInPlace --\n"
+	// Every dir the walker must skip, seeded with a poisoned Go file.
+	for name := range skippedWalkDirs {
+		dir := filepath.Join(root, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "x.go"), []byte(poison), 0o644); err != nil {
+			t.Fatalf("write skip fixture: %v", err)
+		}
+	}
+	// A hidden dir with no special meaning must still be scanned.
+	hidden := filepath.Join(root, ".hidden-source")
+	if err := os.MkdirAll(hidden, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", hidden, err)
+	}
+	if err := os.WriteFile(filepath.Join(hidden, "x.go"), []byte("// .hidden-source scanned\n"), 0o644); err != nil {
+		t.Fatalf("write hidden fixture: %v", err)
+	}
+
+	var skipped, kept []string
+	forEachSourceFile(t, root, func(rel string, data []byte) {
+		if strings.Contains(string(data), "FORBIDDEN") {
+			skipped = append(skipped, rel)
+			return
+		}
+		if strings.Contains(string(data), ".hidden-source scanned") {
+			kept = append(kept, rel)
+		}
+	})
+	if len(skipped) != 0 {
+		t.Fatalf("blocked dirs were walked: %v", skipped)
+	}
+	if len(kept) != 1 {
+		t.Fatalf("expected hidden-source dir to be scanned once, got %v", kept)
 	}
 }
 


### PR DESCRIPTION
## Summary

**test(util): skip build caches in source walker**

The no-copy invariant source walker (`forEachSourceFile`) hard-coded a small
set of directories to skip before descending (`.git`, `vendor`,
`node_modules`, `testdata`). It did not skip the workspace's own build/tool
directories (`.tmp_build`, `.go-cache`, `.go-tmp`, `.gocache`), so the scan
could walk cloned or generated Go sources that must not be treated as product
code.

This PR generalizes the exclusion into a named `skippedWalkDirs` map and adds
the four build/tool dirs to it. Existing entries keep their exact behavior
(the switch becomes an equivalent map lookup, no walker behavior change for
entries already present).

## Exact skip set

`.git`, `vendor`, `node_modules`, `testdata`, `.tmp_build`, `.go-cache`,
`.go-tmp`, `.gocache`

This is an explicit allow/skip list — **not** a broad "skip all hidden dirs"
weakening. Arbitrary hidden source directories (e.g. `.hidden-source`) are
still scanned by the walker.

## Regression coverage

`TestForEachSourceFileSkipsBuildDirs`:
- seeds every listed skip dir under a temp root with a poisoned `*.go` file,
- asserts none of those dirs are walked (no `FORBIDDEN` content observed),
- seeds a `.hidden-source` dir and asserts it **is** scanned exactly once —
  guarding against an over-broad hidden-dir skip.

## Verification (worktree-local `GOCACHE`, `GOTMPDIR`, `TMPDIR`)

- `gofmt -l internal/util/nocopy_invariant_test.go` — clean
- focused test normal, `-race`, `-race -count=3` — PASS
- `go test ./internal/util` — `ok`; `-race` — `ok`
- `go test ./...` — all packages `ok`
- `go build ./...` — clean
- `go vet ./internal/util` — exit 0

> Note: on this machine two packages (`sdk/cliproxy`, `test`) initially
> failed with `link: mkdir /tmp/go-link-*: operation not permitted` — a system
> `/tmp` permission issue unrelated to this change. Both pass when `TMPDIR` is
> redirected to a writable directory.

## Changes

- `internal/util/nocopy_invariant_test.go` (+54 / −2)

## Mirror

CPA: router-for-me/CLIProxyAPI#4947 (identical changes)