### PR TITLE
test(openai): set Gin mode once per package

### DIFF
--- a/sdk/api/handlers/openai/gin_testmode_test.go
+++ b/sdk/api/handlers/openai/gin_testmode_test.go
@@ -1,0 +1,18 @@
+package openai
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestMain sets gin.TestMode once before any test runs. The per-test
+// gin.SetMode(gin.TestMode) calls were removed because they race: parallel
+// tests write the package-global gin mode while other parallel tests read it
+// through gin.New/CreateTestContext. Setting it once up front removes the
+// concurrent write.
+func TestMain(m *testing.M) {
+	gin.SetMode(gin.TestMode)
+	os.Exit(m.Run())
+}

--- a/sdk/api/handlers/openai/gitlab_duo_handler_test.go
+++ b/sdk/api/handlers/openai/gitlab_duo_handler_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestOpenAIChatCompletionsWithGitLabDuoOpenAIGateway(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	var gotPath, gotAuthHeader, gotRealmHeader string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -64,7 +63,6 @@ func TestOpenAIChatCompletionsWithGitLabDuoOpenAIGateway(t *testing.T) {
 }
 
 func TestOpenAIResponsesStreamWithGitLabDuoOpenAIGateway(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	var gotPath, gotAuthHeader string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -22,7 +22,6 @@ import (
 func performImagesEndpointRequest(t *testing.T, endpointPath string, contentType string, body io.Reader, handler gin.HandlerFunc) *httptest.ResponseRecorder {
 	t.Helper()
 
-	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	router.POST(endpointPath, handler)
 

--- a/sdk/api/handlers/openai/openai_responses_compact_test.go
+++ b/sdk/api/handlers/openai/openai_responses_compact_test.go
@@ -50,7 +50,6 @@ func (e *compactCaptureExecutor) HttpRequest(context.Context, *coreauth.Auth, *h
 }
 
 func TestOpenAIResponsesCompactRejectsStream(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	executor := &compactCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
@@ -83,7 +82,6 @@ func TestOpenAIResponsesCompactRejectsStream(t *testing.T) {
 }
 
 func TestOpenAIResponsesCompactExecute(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	executor := &compactCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
@@ -122,7 +120,6 @@ func TestOpenAIResponsesCompactExecute(t *testing.T) {
 }
 
 func TestOpenAIResponsesCompactDecodesZstdRequestBody(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	executor := &compactCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_error_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_error_test.go
@@ -18,7 +18,6 @@ import (
 // request-shape failures reach the client. Credential, quota and transport
 // failures end the stream silently so the client retries on its own.
 func TestForwardResponsesStreamExposesOnlyClientErrors(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
 		name        string
@@ -91,7 +90,6 @@ func TestForwardResponsesStreamExposesOnlyClientErrors(t *testing.T) {
 }
 
 func TestForwardResponsesStreamUsesResponseFailedForCodex(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
 	h := NewOpenAIResponsesAPIHandler(base)
@@ -128,7 +126,6 @@ func TestForwardResponsesStreamUsesResponseFailedForCodex(t *testing.T) {
 }
 
 func TestForwardResponsesStreamTerminalErrorFollowsPartialOutputSequence(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
 	h := NewOpenAIResponsesAPIHandler(base)
@@ -168,7 +165,6 @@ func TestForwardResponsesStreamTerminalErrorFollowsPartialOutputSequence(t *test
 }
 
 func TestForwardChatAsResponsesStreamTerminalErrorFollowsConvertedOutputSequence(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
 	h := NewOpenAIResponsesAPIHandler(base)
@@ -224,7 +220,6 @@ func TestForwardChatAsResponsesStreamTerminalErrorFollowsConvertedOutputSequence
 }
 
 func TestForwardChatAsResponsesStreamUsesResponsesTerminalErrors(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
 		name      string

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -17,7 +17,6 @@ import (
 func TestOpenAIChatStreamOwnsExactlyOneDoneMarker(t *testing.T) {
 	newHandler := func(t *testing.T) (*OpenAIAPIHandler, *httptest.ResponseRecorder, *gin.Context, http.Flusher) {
 		t.Helper()
-		gin.SetMode(gin.TestMode)
 		h := NewOpenAIAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil))
 		recorder := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(recorder)
@@ -63,7 +62,6 @@ func TestOpenAIChatStreamOwnsExactlyOneDoneMarker(t *testing.T) {
 func newResponsesStreamTestHandler(t *testing.T) (*OpenAIResponsesAPIHandler, *httptest.ResponseRecorder, *gin.Context, http.Flusher) {
 	t.Helper()
 
-	gin.SetMode(gin.TestMode)
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
 	h := NewOpenAIResponsesAPIHandler(base)
 

--- a/sdk/api/handlers/openai/openai_responses_multi_agent_test.go
+++ b/sdk/api/handlers/openai/openai_responses_multi_agent_test.go
@@ -23,7 +23,6 @@ import (
 func TestPrepareCodexMultiAgentV2ToolsAtResponsesBoundary(t *testing.T) {
 	t.Parallel()
 
-	gin.SetMode(gin.TestMode)
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{CodexOptimizeMultiAgentV2: true}, nil)
 	handler := NewOpenAIResponsesAPIHandler(base)
 	request := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
@@ -131,7 +130,6 @@ func newResponsesMultiAgentTestHandler(t *testing.T, executor *responsesMultiAge
 }
 
 func TestResponsesWebsocketPreparesCodexMultiAgentV2Tools(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	executor := &websocketDirectCaptureExecutor{provider: "codex"}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
@@ -183,7 +181,6 @@ func TestResponsesWebsocketPreparesCodexMultiAgentV2Tools(t *testing.T) {
 func TestPrepareCodexMultiAgentV2ToolsAtResponsesBoundarySkipsOtherClients(t *testing.T) {
 	t.Parallel()
 
-	gin.SetMode(gin.TestMode)
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{CodexOptimizeMultiAgentV2: true}, nil)
 	handler := NewOpenAIResponsesAPIHandler(base)
 	request := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)

--- a/sdk/api/handlers/openai/openai_responses_signature_test.go
+++ b/sdk/api/handlers/openai/openai_responses_signature_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestOpenAIResponsesForwardsInvalidReasoningEncryptedContentToExecutor(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	executor := &compactCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)
@@ -49,7 +48,6 @@ func TestOpenAIResponsesForwardsInvalidReasoningEncryptedContentToExecutor(t *te
 }
 
 func TestOpenAIResponsesCompactForwardsInvalidReasoningEncryptedContentToExecutor(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	executor := &compactCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
 	manager.RegisterExecutor(executor)

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -95,7 +95,6 @@ func (*homeResponsesWebsocketExecutor) HttpRequest(context.Context, *coreauth.Au
 }
 
 func TestResponsesWebsocketHomeSelectedAuthCallbackPinsAndReusesFirstSelection(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	dispatcher := &homeResponsesWebsocketDispatcher{}
 	executor := &homeResponsesWebsocketExecutor{}
@@ -460,7 +459,6 @@ func TestTruncateWebsocketCloseReason(t *testing.T) {
 }
 
 func TestForwardResponsesWebsocketMirrorsMappedMessageTooBig(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	serverErrCh := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -529,7 +527,6 @@ func TestForwardResponsesWebsocketMirrorsMappedMessageTooBig(t *testing.T) {
 }
 
 func TestForwardResponsesWebsocketMirrorsPayloadMessageTooBig(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	serverErrCh := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1787,7 +1784,6 @@ func TestAppendWebsocketTimelineEvent(t *testing.T) {
 }
 
 func TestSetWebsocketTimelineBody(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
 
@@ -1811,7 +1807,6 @@ func TestSetWebsocketTimelineBody(t *testing.T) {
 }
 
 func TestWebsocketTimelineLogFallsBackToMemoryWithoutSource(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
 	ts := time.Date(2026, time.April, 1, 12, 34, 56, 789000000, time.UTC)
@@ -2188,7 +2183,6 @@ func TestRecordResponsesWebsocketCustomToolCallsFromOutputItemDoneWithCache(t *t
 }
 
 func TestForwardResponsesWebsocketRestoresAndForwardsCompletedOutput(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	serverErrCh := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2292,7 +2286,6 @@ func TestForwardResponsesWebsocketRestoresAndForwardsCompletedOutput(t *testing.
 }
 
 func TestForwardResponsesWebsocketTreatsResponseDoneAsTerminalWithoutRewriting(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	serverErrCh := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2462,7 +2455,6 @@ func TestResponsesUpstreamErrorBodyDrivesExposure(t *testing.T) {
 }
 
 func TestForwardResponsesWebsocketTreatsErrorPayloadAsTerminal(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	serverErrCh := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2548,7 +2540,6 @@ func TestRecordPendingToolCallIDsFromPayloadDropsSatisfiedCalls(t *testing.T) {
 }
 
 func TestForwardResponsesWebsocketLogsAttemptedResponseOnWriteFailure(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	serverErrCh := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2613,7 +2604,6 @@ func TestForwardResponsesWebsocketLogsAttemptedResponseOnWriteFailure(t *testing
 }
 
 func TestResponsesWebsocketTimelineRecordsDisconnectEvent(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	manager := coreauth.NewManager(nil, nil, nil)
 	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, manager)
@@ -2676,7 +2666,6 @@ func TestResponsesWebsocketTimelineRecordsDisconnectEvent(t *testing.T) {
 }
 
 func TestResponsesWebsocketMirrorsUpstreamMessageTooBigDisconnect(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	for _, provider := range []string{"codex", "xai"} {
 		t.Run(provider, func(t *testing.T) {
@@ -2727,7 +2716,6 @@ func TestResponsesWebsocketMirrorsUpstreamMessageTooBigDisconnect(t *testing.T) 
 }
 
 func TestResponsesWebsocketSendsJSONErrorOnUpstreamCyberPolicyDisconnect(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &websocketUpstreamDisconnectExecutor{provider: "codex", subscribed: make(chan string, 1)}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -2787,7 +2775,6 @@ func TestResponsesWebsocketSendsJSONErrorOnUpstreamCyberPolicyDisconnect(t *test
 }
 
 func TestResponsesWebsocketHidesNonClientUpstreamDisconnectErrors(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
 		name string
@@ -2870,7 +2857,6 @@ func TestResponsesWebsocketHidesNonClientUpstreamDisconnectErrors(t *testing.T) 
 // with status 400 on the stream path and 502 through the disconnect channel. Both
 // must reach the client, because no credential rotation can satisfy the request.
 func TestResponsesWebsocketExposesCyberPolicyRegardlessOfStatus(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	const cyberPolicyBody = `{"error":{"type":"invalid_request","code":"cyber_policy","message":"This content was flagged for possible cybersecurity risk.","param":null}}`
 
@@ -2996,7 +2982,6 @@ func TestResponsesWebsocketTerminalErrorWrittenOnceAcrossForwardAndDisconnect(t 
 }
 
 func TestResponsesWebsocketCodexWebsocketPassthroughPassesCompactedRequestWithoutTranscriptMerge(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &websocketDirectCaptureExecutor{done: make(chan struct{})}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -3075,7 +3060,6 @@ func TestResponsesWebsocketCodexWebsocketPassthroughPassesCompactedRequestWithou
 }
 
 func TestResponsesWebsocketXAIWebsocketPassthroughKeepsNativeIncrementalRequest(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	modelName := "xai-websocket-passthrough-model"
 	executor := &websocketDirectCaptureExecutor{provider: "xai", done: make(chan struct{})}
@@ -3160,7 +3144,6 @@ func TestResponsesWebsocketXAIWebsocketPassthroughKeepsNativeIncrementalRequest(
 }
 
 func TestResponsesWebsocketFullRequestCanRouteFromNativeWebsocketToBuiltInProvider(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	const sourceModel = "codex-provider-route-source"
 	const targetModel = "claude-provider-route-target"
@@ -3239,7 +3222,6 @@ func TestResponsesWebsocketFullRequestCanRouteFromNativeWebsocketToBuiltInProvid
 }
 
 func TestResponsesWebsocketHidesProviderRouteAuthFailure(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	const sourceModel = "codex-provider-route-failure-source"
 	const targetModel = "claude-provider-route-target"
@@ -3306,7 +3288,6 @@ func TestResponsesWebsocketHidesProviderRouteAuthFailure(t *testing.T) {
 }
 
 func TestResponsesWebsocketDeltaRouteToBuiltInProviderRequiresFullReplay(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	const sourceModel = "codex-provider-route-delta-source"
 	const targetModel = "claude-provider-route-target"
@@ -3373,7 +3354,6 @@ func TestResponsesWebsocketDeltaRouteToBuiltInProviderRequiresFullReplay(t *test
 }
 
 func TestResponsesWebsocketClosesForHTTPReplayWhenWebsocketEligibilityChanges(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	modelName := "xai-websocket-mode-change-model"
 	executor := &websocketDirectCaptureExecutor{provider: "xai", done: make(chan struct{})}
@@ -3499,7 +3479,6 @@ func TestResponsesWebsocketClosesForHTTPReplayWhenWebsocketEligibilityChanges(t 
 }
 
 func TestResponsesWebsocketRejectsUnknownPreviousResponseOnNewSocket(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	modelName := "xai-websocket-reconnect-model"
 	executor := &websocketDirectCaptureExecutor{provider: "xai"}
@@ -3576,7 +3555,6 @@ func TestResponsesWebsocketRejectsUnknownPreviousResponseOnNewSocket(t *testing.
 }
 
 func TestResponsesWebsocketClosesAfterNonRetryableClientError(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	modelName := "xai-websocket-rollback-model"
 	executor := &websocketCanonicalRollbackExecutor{}
@@ -3653,7 +3631,6 @@ const itemNotPersistedUpstreamMessage = "Item with id 'rs_0b5f3eb6f51f175c0169ca
 // conversation must survive: after reconnecting with the full input the turn
 // succeeds, and no stale per-socket transcript leaks into the new connection.
 func TestResponsesWebsocketExposesItemNotPersistedAndRecoversOnReconnect(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	modelName := "xai-item-miss-model"
 	executor := &websocketCanonicalRollbackExecutor{
@@ -3766,7 +3743,6 @@ func TestResponsesWebsocketSwitchesPinnedAuthAcrossProviders(t *testing.T) {
 		{name: "xai websocket different model", xaiWebsockets: true, returnToDifferentXAIModel: true},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			gin.SetMode(gin.TestMode)
 
 			xaiModel := "xai-provider-switch-" + strings.ReplaceAll(testCase.name, " ", "-")
 			returnXAIModel := xaiModel
@@ -4048,7 +4024,6 @@ func TestWebsocketUpstreamSupportsCompactionReplayForModelFalseWhenMixedBackends
 }
 
 func TestResponsesWebsocketPrewarmHandledLocallyForSSEUpstream(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &websocketCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -4155,7 +4130,6 @@ func TestResponsesWebsocketPrewarmHandledLocallyForSSEUpstream(t *testing.T) {
 }
 
 func TestResponsesWebsocketMergesTranscriptForNonPassthroughUpstream(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &websocketCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -4227,7 +4201,6 @@ func TestResponsesWebsocketMergesTranscriptForNonPassthroughUpstream(t *testing.
 }
 
 func TestResponsesWebsocketDoesNotInjectPreviousResponseIDWhenPendingToolOutputMissing(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &websocketCompactionCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -4303,7 +4276,6 @@ func TestResponsesWebsocketDoesNotInjectPreviousResponseIDWhenPendingToolOutputM
 }
 
 func TestResponsesWebsocketStripsGenerateWhenWebsocketAttemptFallsBackToHTTP(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	selector := &orderedWebsocketSelector{order: []string{"auth-ws", "auth-http", "auth-http"}}
 	executor := &websocketBootstrapFallbackExecutor{}
@@ -4399,7 +4371,6 @@ func TestResponsesWebsocketStripsGenerateWhenWebsocketAttemptFallsBackToHTTP(t *
 }
 
 func TestWebsocketClientAddressUsesGinClientIP(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	recorder := httptest.NewRecorder()
 	c, engine := gin.CreateTestContext(recorder)
@@ -4424,7 +4395,6 @@ func TestWebsocketClientAddressReturnsEmptyForNilContext(t *testing.T) {
 }
 
 func TestResponsesWebsocketPinsOnlyWebsocketCapableAuth(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	selector := &orderedWebsocketSelector{order: []string{"auth-sse", "auth-ws"}}
 	executor := &websocketAuthCaptureExecutor{}
@@ -4494,7 +4464,6 @@ func TestResponsesWebsocketPinsOnlyWebsocketCapableAuth(t *testing.T) {
 }
 
 func TestResponsesWebsocketUsesNativeIncrementalAfterPinningWebsocketAuthFromMixedPool(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	modelName := "xai-mixed-pool-model"
 	selector := &orderedWebsocketSelector{order: []string{"auth-http", "auth-ws"}}
@@ -4569,7 +4538,6 @@ func TestResponsesWebsocketUsesNativeIncrementalAfterPinningWebsocketAuthFromMix
 }
 
 func TestResponsesWebsocketReplaysImmediatelyAfterPinnedAuthFailure(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
 		name            string
@@ -4796,7 +4764,6 @@ func (e *websocketPinnedPrematureCloseExecutor) Payloads(authID string) [][]byte
 }
 
 func TestResponsesWebsocketReleasesPinnedAuthAfterStreamClosed408(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	selector := &orderedWebsocketSelector{order: []string{"auth-a", "auth-b"}}
 	executor := &websocketPinnedPrematureCloseExecutor{}
@@ -5087,7 +5054,6 @@ func TestDedupeResponsesWebsocketInputItemsByIDKeepsReferencedToolCall(t *testin
 }
 
 func TestResponsesWebsocketCompactionResetsTurnStateOnCustomToolTranscriptReplacement(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &websocketCompactionCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)
@@ -5191,7 +5157,6 @@ func TestResponsesWebsocketCompactionResetsTurnStateOnCustomToolTranscriptReplac
 }
 
 func TestResponsesWebsocketCompactionResetsTurnStateOnTranscriptReplacement(t *testing.T) {
-	gin.SetMode(gin.TestMode)
 
 	executor := &websocketCompactionCaptureExecutor{}
 	manager := coreauth.NewManager(nil, nil, nil)

--- a/sdk/api/handlers/openai/openai_videos_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_videos_handlers_test.go
@@ -23,7 +23,6 @@ import (
 func performVideosEndpointRequest(t *testing.T, method string, endpointPath string, contentType string, body io.Reader, handler gin.HandlerFunc) *httptest.ResponseRecorder {
 	t.Helper()
 
-	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	switch method {
 	case http.MethodGet:
@@ -44,7 +43,6 @@ func performVideosEndpointRequest(t *testing.T, method string, endpointPath stri
 func performVideosRouteRequest(t *testing.T, method string, routePath string, requestPath string, contentType string, body io.Reader, handler gin.HandlerFunc) *httptest.ResponseRecorder {
 	t.Helper()
 
-	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	switch method {
 	case http.MethodGet:
@@ -445,7 +443,6 @@ func TestWriteVideoContentFromURL(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	gin.SetMode(gin.TestMode)
 	resp := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(resp)
 	ctx.Request = httptest.NewRequest(http.MethodGet, "/openai/v1/videos/video_123/content", nil)
@@ -495,7 +492,6 @@ func TestWriteVideoContentFromURLUsesPinnedAuthProxy(t *testing.T) {
 	handler := NewOpenAIAPIHandler(base)
 	videoAuthBindings.set("video_123", authID, time.Hour)
 
-	gin.SetMode(gin.TestMode)
 	resp := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(resp)
 	ctx.Params = gin.Params{{Key: "video_id", Value: "video_123"}}
@@ -524,7 +520,6 @@ func TestWriteVideoContentFromURLFallsBackToGlobalProxy(t *testing.T) {
 	base := apihandlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{ProxyURL: "http://global-proxy.example.com:8080"}, nil)
 	handler := NewOpenAIAPIHandler(base)
 
-	gin.SetMode(gin.TestMode)
 	resp := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(resp)
 	ctx.Params = gin.Params{{Key: "video_id", Value: "video_456"}}
@@ -1005,7 +1000,6 @@ func TestVideosCreateFormRequest(t *testing.T) {
 }
 
 func videosCreateRequestFromFormContext(body string) ([]byte, error) {
-	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	var rawJSON []byte
 	var err error


### PR DESCRIPTION
## Summary
Port the accepted CPA gin test-mode race fix to CPAPlus. Sets `gin.TestMode` **once** in a package-level `TestMain` and removes **59** per-test `gin.SetMode(gin.TestMode)` calls across 9 test files in `sdk/api/handlers/openai`.

## Why (race)
The per-test `gin.SetMode(gin.TestMode)` calls race under parallel tests: parallel tests write the **package-global** gin mode (`gin` package `mode` var) while other parallel tests read it through `gin.New` / `gin.CreateTestContext`. The result is a data race flagged by `go test -race`.

### Reproduced pre-fix (unmodified base, this branch's base `4823235a`)
`go test -race -count=2 -run 'TestPrepareCodexMultiAgentV2ToolsAtResponsesBoundary$|TestResponsesPreparesCodexMultiAgentV2ToolsForHTTPAndSSE|TestPrepareCodexMultiAgentV2ToolsAtResponsesBoundarySkipsOtherClients' ./sdk/api/handlers/openai/`

```
WARNING: DATA RACE
Write at 0x... by goroutine 20:
  gin.SetMode() gin@v1.10.1/mode.go:72
  openai.TestPrepareCodexMultiAgentV2ToolsAtResponsesBoundarySkipsOtherClients() openai_responses_multi_agent_test.go:186
Previous write at 0x... by goroutine 18:
  gin.SetMode() gin@v1.10.1/mode.go:72
  openai.TestPrepareCodexMultiAgentV2ToolsAtResponsesBoundary() openai_responses_multi_agent_test.go:26
--- FAIL: <3 parallel tests> race detected during execution of test
```

## Change
- **Add** `sdk/api/handlers/openai/gin_testmode_test.go` — package `openai`, `TestMain` that calls `gin.SetMode(gin.TestMode)` once before `os.Exit(m.Run())`.
- **Remove** all per-test `gin.SetMode(gin.TestMode)` calls (write-write race source) from:
  - `gitlab_duo_handler_test.go` (2)
  - `openai_images_handlers_test.go` (1)
  - `openai_responses_compact_test.go` (3)
  - `openai_responses_handlers_stream_error_test.go` (5)
  - `openai_responses_handlers_stream_test.go` (2)
  - `openai_responses_multi_agent_test.go` (3)
  - `openai_responses_signature_test.go` (2)
  - `openai_responses_websocket_test.go` (35)
  - `openai_videos_handlers_test.go` (6)
- All 3 `t.Parallel()` and all `gin` imports preserved (still used by `gin.New`/`gin.CreateTestContext`).

Stat: `10 files changed, 18 insertions(+), 59 deletions(-)`.

## Verification (all green)
- Post-fix focused race `-count=3` (the 3 parallel multi-agent tests): `ok`, no DATA RACE.
- Full package race `-count=1`: `ok`.
- Package normal: `ok`.
- Full `go test ./...`: exit 0.
- `go build ./...`: exit 0.
- `go vet ./sdk/api/handlers/openai/`: exit 0.
- `gofmt` clean; `git diff --check` clean.
- Invariant: exactly 1 `TestMain`, exactly 1 real `gin.SetMode(gin.TestMode)` (in `TestMain`), zero per-test calls.

Functionally isolated from #175 (author-failover-recovery) — different branch (`fix/gin-testmode-race`), test-infrastructure only, no production code.

## Mirror

CPA: router-for-me/CLIProxyAPI#4948 (identical changes)