### PR TITLE
fix(cursor): flatten turns in non-stream requests and guard stream stalls

### DIFF
--- a/internal/auth/cursor/proto/decode.go
+++ b/internal/auth/cursor/proto/decode.go
@@ -75,6 +75,21 @@ type DecodedServerMessage struct {
 	CheckpointData []byte
 }
 
+// isReplyRequiredType reports whether the decoded message type carries a
+// server request that must receive an inline client reply.
+func isReplyRequiredType(t ServerMessageType) bool {
+	switch t {
+	case ServerMsgKvGetBlob, ServerMsgKvSetBlob,
+		ServerMsgExecRequestCtx, ServerMsgExecMcpArgs,
+		ServerMsgExecShellArgs, ServerMsgExecReadArgs, ServerMsgExecWriteArgs,
+		ServerMsgExecDeleteArgs, ServerMsgExecLsArgs, ServerMsgExecGrepArgs,
+		ServerMsgExecFetchArgs, ServerMsgExecDiagnostics, ServerMsgExecShellStream,
+		ServerMsgExecBgShellSpawn, ServerMsgExecWriteShellStdin, ServerMsgExecOther:
+		return true
+	}
+	return false
+}
+
 // DecodeAgentServerMessage parses an AgentServerMessage and returns
 // a structured representation of the first meaningful message found.
 func DecodeAgentServerMessage(data []byte) (*DecodedServerMessage, error) {
@@ -100,8 +115,16 @@ func DecodeAgentServerMessage(data []byte) (*DecodedServerMessage, error) {
 
 			switch num {
 			case ASM_InteractionUpdate:
-				log.Debugf("DecodeAgentServerMessage: calling decodeInteractionUpdate")
-				decodeInteractionUpdate(val, msg)
+				if isReplyRequiredType(msg.Type) {
+					// A co-threaded exec/KV request decoded earlier in this
+					// frame must not be clobbered by a trailing interaction
+					// update: dropping it would strand the server waiting for
+					// the inline reply it expects.
+					log.Debugf("DecodeAgentServerMessage: skipping trailing InteractionUpdate to preserve %v", msg.Type)
+				} else {
+					log.Debugf("DecodeAgentServerMessage: calling decodeInteractionUpdate")
+					decodeInteractionUpdate(val, msg)
+				}
 			case ASM_ExecServerMessage:
 				log.Debugf("DecodeAgentServerMessage: calling decodeExecServerMessage")
 				decodeExecServerMessage(val, msg)

--- a/internal/auth/cursor/proto/h2stream.go
+++ b/internal/auth/cursor/proto/h2stream.go
@@ -13,6 +13,10 @@ import (
 	"golang.org/x/net/http2/hpack"
 )
 
+// h2WindowWaitTimeout bounds how long a writer parks on a closed flow-control
+// window before erroring out instead of hanging the pipeline.
+const h2WindowWaitTimeout = 30 * time.Second
+
 const (
 	defaultInitialWindowSize = 65535 // HTTP/2 default
 	maxFramePayload          = 16384 // HTTP/2 default max frame size
@@ -171,10 +175,24 @@ func (s *H2Stream) Write(data []byte) error {
 			chunk = data[:maxFramePayload]
 		}
 
-		// Wait for flow control window
+		// Wait for flow control window, bounded: a server that never reopens
+		// the window would otherwise park this goroutine (and, via the read
+		// loop's backpressure, the whole pipeline) forever.
 		s.windowMu.Lock()
+		waitDeadline := time.Now().Add(h2WindowWaitTimeout)
 		for s.sendWindow <= 0 || s.connWindow <= 0 {
+			remaining := time.Until(waitDeadline)
+			if remaining <= 0 {
+				s.windowMu.Unlock()
+				return fmt.Errorf("h2stream: flow-control window did not reopen within %v", h2WindowWaitTimeout)
+			}
+			timer := time.NewTimer(remaining)
+			go func() {
+				<-timer.C
+				s.windowCond.Broadcast()
+			}()
 			s.windowCond.Wait()
+			timer.Stop()
 		}
 		// Limit chunk to available window
 		allowed := int(s.sendWindow)

--- a/internal/runtime/executor/cursor_executor.go
+++ b/internal/runtime/executor/cursor_executor.go
@@ -22,6 +22,7 @@ import (
 	cursorproto "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/cursor/proto"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
@@ -38,6 +39,7 @@ const (
 	cursorAuthType          = "cursor"
 	cursorHeartbeatInterval = 5 * time.Second
 	cursorSessionTTL        = 5 * time.Minute
+	cursorFrameIdleTimeout  = 90 * time.Second
 	cursorCheckpointTTL     = 30 * time.Minute
 	cursorStreamFlushDelay  = 16 * time.Millisecond
 	cursorStreamMaxBatch    = 512
@@ -425,6 +427,10 @@ func (e *CursorExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		payload = sdktranslator.TranslateRequest(from, to, req.Model, bytes.Clone(payload), false)
 	}
 
+	usageReporter := helps.NewExecutorUsageReporter(ctx, e, req.Model, auth)
+	defer usageReporter.EnsurePublished(ctx)
+	defer usageReporter.TrackFailure(ctx, &err)
+
 	parsed := parseOpenAIRequest(payload)
 	sessionID := extractClaudeCodeSessionId(req.Payload)
 	conversationID := deriveConversationId(apiKeyFromContext(ctx), sessionID, parsed.SystemPrompt)
@@ -432,6 +438,14 @@ func (e *CursorExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if openAICompatible && len(parsed.ToolResults) > 0 {
 		e.retireConversationState(conversationID)
 		log.Infof("cursor: using cold continuation for %d non-stream tool result(s)", len(parsed.ToolResults))
+		flattenConversationIntoUserText(parsed)
+	} else if len(parsed.Turns) > 0 {
+		// Mirror ExecuteStream's no-checkpoint branch: Cursor's Run endpoint
+		// rejects structured turns on a conversation without server-side state
+		// with "Connect error internal", but always accepts a flattened
+		// UserText transcript. Execute never attaches a checkpoint, so every
+		// multi-message non-streaming request must be flattened.
+		log.Debugf("cursor: non-stream request with %d turn(s), flattening into user text", len(parsed.Turns))
 		flattenConversationIntoUserText(parsed)
 	}
 	params := buildRunRequestParams(parsed, conversationID, req.Model)
@@ -519,6 +533,9 @@ func (e *CursorExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		},
 	}
 	result, marshalErr := json.Marshal(body)
+	if marshalErr == nil {
+		usageReporter.Publish(ctx, helps.ParseOpenAIUsage(result))
+	}
 	if marshalErr != nil {
 		return resp, fmt.Errorf("cursor: encode non-stream response: %w", marshalErr)
 	}
@@ -538,6 +555,9 @@ func isOpenAICompatibleSourceFormat(format sdktranslator.Format) bool {
 // a parked MCP/H2 session; OpenAI-compatible tool results use a fresh request
 // rebuilt from the complete client transcript.
 func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	usageReporter := helps.NewExecutorUsageReporter(ctx, e, req.Model, auth)
+	defer usageReporter.EnsurePublished(ctx)
+	defer usageReporter.TrackFailure(ctx, &err)
 	log.Debugf("cursor ExecuteStream: model=%s sourceFormat=%s payloadLen=%d", req.Model, opts.SourceFormat, len(req.Payload))
 	defer func() {
 		if r := recover(); r != nil {
@@ -954,6 +974,7 @@ func (e *CursorExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		fr := `"stop"`
 		openaiJSON := fmt.Sprintf(`{"id":"%s","object":"chat.completion.chunk","created":%d,"model":"%s","choices":[{"index":0,"delta":{},"finish_reason":%s}],"usage":{"prompt_tokens":%d,"completion_tokens":%d,"total_tokens":%d}}`,
 			chatId, created, parsed.Model, fr, inputTok, outputTok, inputTok+outputTok)
+		usageReporter.Publish(ctx, helps.ParseOpenAIUsage([]byte(openaiJSON)))
 		sseLine := []byte("data: " + openaiJSON + "\n")
 		if needsTranslate {
 			translated := sdktranslator.TranslateStream(ctx, to, from, req.Model, originalPayload, payload, sseLine, &streamParam)
@@ -1286,6 +1307,15 @@ func (u *cursorTokenUsage) get() (input, output int64) {
 	return u.inputTokensEst, u.outputTokens
 }
 
+// writeCursorReply sends an inline Connect reply. A failed reply strands the
+// server-side request and hangs the whole turn, so the error must surface.
+func writeCursorReply(stream cursorStream, payload []byte) error {
+	if err := stream.Write(cursorproto.FrameConnectMessage(payload, 0)); err != nil {
+		return fmt.Errorf("cursor: reply write failed: %w", err)
+	}
+	return nil
+}
+
 func processH2SessionFrames(
 	ctx context.Context,
 	stream cursorStream,
@@ -1300,12 +1330,20 @@ func processH2SessionFrames(
 	var buf bytes.Buffer
 	rejectReason := "Tool not available in this environment. Use the MCP tools provided instead."
 	log.Debugf("cursor: processH2SessionFrames started for streamID=%s, waiting for data...", stream.ID())
+	idleTimer := time.NewTimer(cursorFrameIdleTimeout)
+	defer idleTimer.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			log.Debugf("cursor: processH2SessionFrames exiting: context done")
 			return ctx.Err()
+		case <-idleTimer.C:
+			// Heartbeats arrive every few seconds; a gap this long means a
+			// server request went unanswered (or the pipeline froze) and the
+			// turn would otherwise hang forever.
+			return fmt.Errorf("cursor: no frames for %v (stranded server request?)", cursorFrameIdleTimeout)
 		case data, ok := <-stream.Data():
+			idleTimer.Reset(cursorFrameIdleTimeout)
 			if !ok {
 				log.Debugf("cursor: processH2SessionFrames[%s]: exiting: stream data channel closed", stream.ID())
 				return stream.Err() // may be RST_STREAM, GOAWAY, or nil for clean close
@@ -1383,17 +1421,23 @@ func processH2SessionFrames(
 					blobKey := cursorproto.BlobIdHex(msg.BlobId)
 					data := blobStore[blobKey]
 					resp := cursorproto.EncodeKvGetBlobResult(msg.KvId, data)
-					stream.Write(cursorproto.FrameConnectMessage(resp, 0))
+					if errReply := writeCursorReply(stream, resp); errReply != nil {
+						return errReply
+					}
 
 				case cursorproto.ServerMsgKvSetBlob:
 					blobKey := cursorproto.BlobIdHex(msg.BlobId)
 					blobStore[blobKey] = append([]byte(nil), msg.BlobData...)
 					resp := cursorproto.EncodeKvSetBlobResult(msg.KvId)
-					stream.Write(cursorproto.FrameConnectMessage(resp, 0))
+					if errReply := writeCursorReply(stream, resp); errReply != nil {
+						return errReply
+					}
 
 				case cursorproto.ServerMsgExecRequestCtx:
 					resp := cursorproto.EncodeExecRequestContextResult(msg.ExecMsgId, msg.ExecId, mcpTools)
-					stream.Write(cursorproto.FrameConnectMessage(resp, 0))
+					if errReply := writeCursorReply(stream, resp); errReply != nil {
+						return errReply
+					}
 
 				case cursorproto.ServerMsgExecMcpArgs:
 					if onMcpExec != nil {
@@ -1420,11 +1464,15 @@ func processH2SessionFrames(
 						// Inline mode: wait for tool result while handling KV/heartbeat
 						log.Debugf("cursor: waiting for tool result on channel (inline mode)...")
 						var toolResults []toolResultInfo
+						waitIdle := time.NewTimer(cursorFrameIdleTimeout)
+						defer waitIdle.Stop()
 					waitLoop:
 						for {
 							select {
 							case <-ctx.Done():
 								return ctx.Err()
+							case <-waitIdle.C:
+								return fmt.Errorf("cursor: no frames for %v while waiting for tool result (stranded server request?)", cursorFrameIdleTimeout)
 							case results, ok := <-toolResultCh:
 								if !ok {
 									return nil
@@ -1435,6 +1483,7 @@ func processH2SessionFrames(
 								if !ok {
 									return stream.Err()
 								}
+								waitIdle.Reset(cursorFrameIdleTimeout)
 								buf.Write(waitData)
 								for {
 									cb := buf.Bytes()
@@ -1457,13 +1506,19 @@ func processH2SessionFrames(
 									case cursorproto.ServerMsgKvGetBlob:
 										blobKey := cursorproto.BlobIdHex(wmsg.BlobId)
 										d := blobStore[blobKey]
-										stream.Write(cursorproto.FrameConnectMessage(cursorproto.EncodeKvGetBlobResult(wmsg.KvId, d), 0))
+										if errReply := writeCursorReply(stream, cursorproto.EncodeKvGetBlobResult(wmsg.KvId, d)); errReply != nil {
+											return errReply
+										}
 									case cursorproto.ServerMsgKvSetBlob:
 										blobKey := cursorproto.BlobIdHex(wmsg.BlobId)
 										blobStore[blobKey] = append([]byte(nil), wmsg.BlobData...)
-										stream.Write(cursorproto.FrameConnectMessage(cursorproto.EncodeKvSetBlobResult(wmsg.KvId), 0))
+										if errReply := writeCursorReply(stream, cursorproto.EncodeKvSetBlobResult(wmsg.KvId)); errReply != nil {
+											return errReply
+										}
 									case cursorproto.ServerMsgExecRequestCtx:
-										stream.Write(cursorproto.FrameConnectMessage(cursorproto.EncodeExecRequestContextResult(wmsg.ExecMsgId, wmsg.ExecId, mcpTools), 0))
+										if errReply := writeCursorReply(stream, cursorproto.EncodeExecRequestContextResult(wmsg.ExecMsgId, wmsg.ExecId, mcpTools)); errReply != nil {
+											return errReply
+										}
 									case cursorproto.ServerMsgCheckpoint:
 										if onCheckpoint != nil && len(wmsg.CheckpointData) > 0 {
 											onCheckpoint(wmsg.CheckpointData)
@@ -1480,7 +1535,9 @@ func processH2SessionFrames(
 							if tr.ToolCallId == pending.ToolCallId {
 								log.Debugf("cursor: sending inline MCP result for tool=%s", pending.ToolName)
 								resultBytes := cursorproto.EncodeExecMcpResult(pending.ExecMsgId, pending.ExecId, tr.Content, false)
-								stream.Write(cursorproto.FrameConnectMessage(resultBytes, 0))
+								if errReply := writeCursorReply(stream, resultBytes); errReply != nil {
+									return errReply
+								}
 								break
 							}
 						}
@@ -1488,25 +1545,45 @@ func processH2SessionFrames(
 					}
 
 				case cursorproto.ServerMsgExecReadArgs:
-					stream.Write(cursorproto.FrameConnectMessage(cursorproto.EncodeExecReadRejected(msg.ExecMsgId, msg.ExecId, msg.Path, rejectReason), 0))
+					if errReply := writeCursorReply(stream, cursorproto.EncodeExecReadRejected(msg.ExecMsgId, msg.ExecId, msg.Path, rejectReason)); errReply != nil {
+						return errReply
+					}
 				case cursorproto.ServerMsgExecWriteArgs:
-					stream.Write(cursorproto.FrameConnectMessage(cursorproto.EncodeExecWriteRejected(msg.ExecMsgId, msg.ExecId, msg.Path, rejectReason), 0))
+					if errReply := writeCursorReply(stream, cursorproto.EncodeExecWriteRejected(msg.ExecMsgId, msg.ExecId, msg.Path, rejectReason)); errReply != nil {
+						return errReply
+					}
 				case cursorproto.ServerMsgExecDeleteArgs:
-					stream.Write(cursorproto.FrameConnectMessage(cursorproto.EncodeExecDeleteRejected(msg.ExecMsgId, msg.ExecId, msg.Path, rejectReason), 0))
+					if errReply := writeCursorReply(stream, cursorproto.EncodeExecDeleteRejected(msg.ExecMsgId, msg.ExecId, msg.Path, rejectReason)); errReply != nil {
+						return errReply
+					}
 				case cursorproto.ServerMsgExecLsArgs:
-					stream.Write(cursorproto.FrameConnectMessage(cursorproto.EncodeExecLsRejected(msg.ExecMsgId, msg.ExecId, msg.Path, rejectReason), 0))
+					if errReply := writeCursorReply(stream, cursorproto.EncodeExecLsRejected(msg.ExecMsgId, msg.ExecId, msg.Path, rejectReason)); errReply != nil {
+						return errReply
+					}
 				case cursorproto.ServerMsgExecGrepArgs:
-					stream.Write(cursorproto.FrameConnectMessage(cursorproto.EncodeExecGrepError(msg.ExecMsgId, msg.ExecId, rejectReason), 0))
+					if errReply := writeCursorReply(stream, cursorproto.EncodeExecGrepError(msg.ExecMsgId, msg.ExecId, rejectReason)); errReply != nil {
+						return errReply
+					}
 				case cursorproto.ServerMsgExecShellArgs, cursorproto.ServerMsgExecShellStream:
-					stream.Write(cursorproto.FrameConnectMessage(cursorproto.EncodeExecShellRejected(msg.ExecMsgId, msg.ExecId, msg.Command, msg.WorkingDirectory, rejectReason), 0))
+					if errReply := writeCursorReply(stream, cursorproto.EncodeExecShellRejected(msg.ExecMsgId, msg.ExecId, msg.Command, msg.WorkingDirectory, rejectReason)); errReply != nil {
+						return errReply
+					}
 				case cursorproto.ServerMsgExecBgShellSpawn:
-					stream.Write(cursorproto.FrameConnectMessage(cursorproto.EncodeExecBackgroundShellSpawnRejected(msg.ExecMsgId, msg.ExecId, msg.Command, msg.WorkingDirectory, rejectReason), 0))
+					if errReply := writeCursorReply(stream, cursorproto.EncodeExecBackgroundShellSpawnRejected(msg.ExecMsgId, msg.ExecId, msg.Command, msg.WorkingDirectory, rejectReason)); errReply != nil {
+						return errReply
+					}
 				case cursorproto.ServerMsgExecFetchArgs:
-					stream.Write(cursorproto.FrameConnectMessage(cursorproto.EncodeExecFetchError(msg.ExecMsgId, msg.ExecId, msg.Url, rejectReason), 0))
+					if errReply := writeCursorReply(stream, cursorproto.EncodeExecFetchError(msg.ExecMsgId, msg.ExecId, msg.Url, rejectReason)); errReply != nil {
+						return errReply
+					}
 				case cursorproto.ServerMsgExecDiagnostics:
-					stream.Write(cursorproto.FrameConnectMessage(cursorproto.EncodeExecDiagnosticsResult(msg.ExecMsgId, msg.ExecId), 0))
+					if errReply := writeCursorReply(stream, cursorproto.EncodeExecDiagnosticsResult(msg.ExecMsgId, msg.ExecId)); errReply != nil {
+						return errReply
+					}
 				case cursorproto.ServerMsgExecWriteShellStdin:
-					stream.Write(cursorproto.FrameConnectMessage(cursorproto.EncodeExecWriteShellStdinError(msg.ExecMsgId, msg.ExecId, rejectReason), 0))
+					if errReply := writeCursorReply(stream, cursorproto.EncodeExecWriteShellStdinError(msg.ExecMsgId, msg.ExecId, rejectReason)); errReply != nil {
+						return errReply
+					}
 				}
 			}
 

--- a/internal/runtime/executor/cursor_executor_test.go
+++ b/internal/runtime/executor/cursor_executor_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -918,3 +919,73 @@ func TestCursorOpenAIExecutorEmitsNoDoneChunk(t *testing.T) {
 
 // Alias keeps test processor signatures readable without weakening production types.
 type anyMCPTools = []cursorproto.McpToolDef
+
+// recordingCursorStream captures written request frames for assertions.
+type recordingCursorStream struct {
+	inner   *fakeCursorStream
+	capture *[]byte
+}
+
+func (s *recordingCursorStream) ID() string          { return s.inner.ID() }
+func (s *recordingCursorStream) Data() <-chan []byte { return s.inner.Data() }
+func (s *recordingCursorStream) Done() <-chan struct{} {
+	return s.inner.Done()
+}
+func (s *recordingCursorStream) Err() error { return s.inner.Err() }
+func (s *recordingCursorStream) Close()     { s.inner.Close() }
+func (s *recordingCursorStream) Write(p []byte) error {
+	*s.capture = append(*s.capture, p...)
+	return s.inner.Write(p)
+}
+
+// TestCursorExecuteNonStreamFlattensConversationTurns guards the fix for the
+// deterministic multi-message failure: Execute never attaches a checkpoint, and
+// Cursor's Run endpoint rejects structured turns on a checkpoint-less
+// conversation with "Connect error internal", so the wire request must carry a
+// flattened UserText transcript instead of Turns (#183).
+func TestCursorExecuteNonStreamFlattensConversationTurns(t *testing.T) {
+	var written []byte
+	e := NewCursorExecutor(nil)
+	e.openStream = func(string) (cursorStream, error) {
+		return &recordingCursorStream{inner: newFakeCursorStream(), capture: &written}, nil
+	}
+	e.processFrames = func(_ context.Context, _ cursorStream, _ map[string][]byte, _ anyMCPTools, onText func(string, bool), _ func(pendingMcpExec), _ <-chan []toolResultInfo, _ *cursorTokenUsage, _ func([]byte)) error {
+		onText("answer", false)
+		return nil
+	}
+
+	payload := []byte(`{"model":"cursor-test-model","messages":[` +
+		`{"role":"user","content":"hi"},` +
+		`{"role":"assistant","content":"Hello."},` +
+		`{"role":"user","content":"capital of France?"}]}`)
+	req := cliproxyexecutor.Request{Model: "cursor-test-model", Payload: payload}
+
+	if _, err := e.Execute(context.Background(), cursorTestAuth(), req, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAI}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	_, wire, _, ok := cursorproto.ParseConnectFrame(written)
+	if !ok || len(wire) == 0 {
+		t.Fatalf("no connect frame captured (written=%d bytes)", len(written))
+	}
+
+	control := parseOpenAIRequest(payload)
+	flattenConversationIntoUserText(control)
+	if len(control.Turns) != 0 || control.UserText == "" {
+		t.Fatalf("control flatten produced turns=%d userText=%q", len(control.Turns), control.UserText)
+	}
+
+	// The wire request must carry the flattened transcript inside UserText and
+	// must not byte-match an encoding built from the structured turns.
+	transcript := control.UserText
+	if !strings.Contains(string(wire), transcript) {
+		t.Fatalf("wire request does not contain the flattened transcript %q", transcript)
+	}
+	plain := parseOpenAIRequest(payload)
+	apiKey := apiKeyFromContext(context.Background())
+	convID := deriveConversationId(apiKey, extractClaudeCodeSessionId(payload), plain.SystemPrompt)
+	withTurns := cursorproto.EncodeRunRequest(buildRunRequestParams(plain, convID, req.Model))
+	if bytes.Equal(wire, withTurns) {
+		t.Fatalf("wire matches the unflattened turns encoding; flatten fix not applied")
+	}
+}


### PR DESCRIPTION
Fixes #183

## Problem 1 — deterministic non-stream multi-turn failure
Root cause: `Execute()` sent structured conversation `Turns` on the wire, but Cursor's Run endpoint rejects structured turns on a checkpoint-less conversation with `Connect error internal`. `ExecuteStream()` always flattens to `UserText` (and checkpoint encoding ignores turns), which is why streaming worked. Fix: `Execute()` now flattens whenever `parsed.Turns` is non-empty, mirroring the streaming path. This also fixes native-Claude non-stream requests with tool results. Regression test asserts the encoded wire request carries the flattened transcript and does not byte-match the structured-turns encoding.

## Problem 2 — streaming with tools hangs after message_start
Cursor's agent protocol is request/reply when tools are registered; four unguarded stall points converted any dropped/failed reply into a permanent silent hang:
1. The decoder let a trailing InteractionUpdate clobber an exec/KV request batched into the same frame — now guarded (`isReplyRequiredType` wins).
2. Inline reply writes ignored errors — all reply sites now propagate write failures and terminate the turn.
3. Neither frame loop had an idle watchdog — both now error after 90s of frame silence (heartbeats arrive every few seconds, so only genuine stalls trip it).
4. `H2Stream.Write` could park forever on a closed flow-control window — now bounded to 30s.

These guards turn the probabilistic hang into a visible, retryable error; the watchdog log line will also identify which stall shape occurs in production.

## Also
- Cursor requests now publish usage records via the standard `UsageReporter` (both `Execute` and `ExecuteStream` completion), so `cursor-*`/`composer-*` finally appear in `usage_events`.
- For the ~1min credential lockout noted in the issue: that is the standard transient-error cooldown (500-class classification, `transient-error-cooldown-seconds`, `disable-cooling` knobs); with Problem 1 fixed, non-stream multi-turn requests stop generating those failures.

## Verification
- `go build ./...`, `go vet` clean; full `go test ./...` green including the new regression test.