### PR TITLE
fix(auth): scope model suspension reasons to prevent stale sibling resume

### DIFF
--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -738,11 +738,25 @@ func (r *ModelRegistry) ClearModelQuotaExceeded(clientID, modelID string) {
 }
 
 // SuspendClientModel marks a client's model as temporarily unavailable until explicitly resumed.
+// When the client is already suspended for the model, the existing reason is never replaced.
 // Parameters:
 //   - clientID: The client to suspend
 //   - modelID: The model affected by the suspension
 //   - reason: Optional description for observability
 func (r *ModelRegistry) SuspendClientModel(clientID, modelID, reason string) {
+	r.SuspendClientModelReplacingReasons(clientID, modelID, reason)
+}
+
+// SuspendClientModelReplacingReasons marks a client's model as temporarily unavailable. When the
+// client is already suspended for the model, the stored reason is replaced only if the existing
+// reason matches one of replaceable; otherwise the existing (more specific) reason is preserved.
+// Calling it without replaceable reasons is equivalent to SuspendClientModel.
+// Parameters:
+//   - clientID: The client to suspend
+//   - modelID: The model affected by the suspension
+//   - reason: Optional description for observability
+//   - replaceable: Suspension reasons that may be overwritten by reason
+func (r *ModelRegistry) SuspendClientModelReplacingReasons(clientID, modelID, reason string, replaceable ...string) {
 	if clientID == "" || modelID == "" {
 		return
 	}
@@ -757,8 +771,20 @@ func (r *ModelRegistry) SuspendClientModel(clientID, modelID, reason string) {
 	if registration.SuspendedClients == nil {
 		registration.SuspendedClients = make(map[string]string)
 	}
-	if _, already := registration.SuspendedClients[clientID]; already {
-		return
+	if existingReason, already := registration.SuspendedClients[clientID]; already {
+		if existingReason == reason {
+			return
+		}
+		canReplace := false
+		for _, rep := range replaceable {
+			if existingReason == rep {
+				canReplace = true
+				break
+			}
+		}
+		if !canReplace {
+			return
+		}
 	}
 	registration.SuspendedClients[clientID] = reason
 	registration.LastUpdated = time.Now()
@@ -793,6 +819,46 @@ func (r *ModelRegistry) ResumeClientModel(clientID, modelID string) {
 	registration.LastUpdated = time.Now()
 	r.invalidateAvailableModelsCacheLocked()
 	log.Debugf("Resumed client %s for model %s", clientID, modelID)
+}
+
+// ResumeClientModelIfReason atomically verifies that clientID is suspended for modelID with one
+// of the given reason(s) and, only if so, resumes it (removing the suspension) under a single
+// lock. It reports whether a resume happened. This avoids the TOCTOU of a separate
+// GetClientModelSuspensionReason check followed by ResumeClientModel racing with a newer
+// suspension recorded between the two.
+func (r *ModelRegistry) ResumeClientModelIfReason(clientID, modelID string, resumableReasons ...string) bool {
+	clientID = strings.TrimSpace(clientID)
+	modelID = strings.TrimSpace(modelID)
+	if clientID == "" || modelID == "" {
+		return false
+	}
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.ensureAvailableModelsCacheLocked()
+
+	registration, exists := r.models[modelID]
+	if !exists || registration == nil || registration.SuspendedClients == nil {
+		return false
+	}
+	reason, suspended := registration.SuspendedClients[clientID]
+	if !suspended {
+		return false
+	}
+	resumable := false
+	for _, rr := range resumableReasons {
+		if reason == rr {
+			resumable = true
+			break
+		}
+	}
+	if !resumable {
+		return false
+	}
+	delete(registration.SuspendedClients, clientID)
+	registration.LastUpdated = time.Now()
+	r.invalidateAvailableModelsCacheLocked()
+	log.Debugf("Resumed client %s for model %s (reason %s)", clientID, modelID, reason)
+	return true
 }
 
 // GetClientModelSuspensionReason returns the reason a client model was suspended, or empty string if not suspended.

--- a/internal/registry/model_registry_resume_reason_test.go
+++ b/internal/registry/model_registry_resume_reason_test.go
@@ -1,0 +1,85 @@
+package registry
+
+import "testing"
+
+// TestResumeClientModelIfReason_RacePreservesNewerSuspension is a red-proof regression test for
+// the TOCTOU in the cooldown resume path. Under concurrent requests for the same credential, an
+// explicit reason check (GetClientModelSuspensionReason == "invalid_api_key") followed by a
+// separate ResumeClientModel transaction would delete a newer suspension recorded between the
+// two. ResumeClientModelIfReason verifies and removes the suspension under one registry lock, so
+// a suspension whose reason changed in the interim is left intact.
+func TestResumeClientModelIfReason_RacePreservesNewerSuspension(t *testing.T) {
+	r := newTestModelRegistry()
+	const (
+		clientID = "auth-1"
+		modelID  = "provider/model-1"
+	)
+	r.RegisterClient(clientID, "provider", []*ModelInfo{{ID: modelID}})
+	r.SuspendClientModel(clientID, modelID, "invalid_api_key")
+
+	// A concurrent request records a model-specific failure after the initial reason read but
+	// before the resume transaction, changing the suspension reason. SuspendClientModel refuses to
+	// overwrite an existing suspension, so this mirrors the interleaved-failure window directly.
+	r.mutex.Lock()
+	r.models[modelID].SuspendedClients[clientID] = "budget_exceeded"
+	r.mutex.Unlock()
+
+	// The conditional resume must refuse: the current reason is no longer invalid_api_key.
+	if resumed := r.ResumeClientModelIfReason(clientID, modelID, "invalid_api_key"); resumed {
+		t.Fatalf("ResumeClientModelIfReason resumed a model whose current suspension should remain, want no-op")
+	}
+	if reason := r.GetClientModelSuspensionReason(clientID, modelID); reason != "budget_exceeded" {
+		t.Fatalf("newer suspension reason = %q, want budget_exceeded (must survive)", reason)
+	}
+
+	// A matching reason resumes normally (after the earlier budget_exceeded suspension clears).
+	r.SuspendClientModel(clientID, modelID, "budget_exceeded")
+	r.mutex.Lock()
+	r.models[modelID].SuspendedClients[clientID] = "invalid_api_key"
+	r.mutex.Unlock()
+	if resumed := r.ResumeClientModelIfReason(clientID, modelID, "invalid_api_key"); !resumed {
+		t.Fatalf("ResumeClientModelIfReason with matching reason did not resume")
+	}
+	if reason := r.GetClientModelSuspensionReason(clientID, modelID); reason != "" {
+		t.Fatalf("suspension reason after resume = %q, want empty", reason)
+	}
+}
+
+func TestSuspendClientModelReplacingReasons(t *testing.T) {
+	r := newTestModelRegistry()
+	const (
+		clientID = "auth-1"
+		modelID  = "provider/model-1"
+	)
+	r.RegisterClient(clientID, "provider", []*ModelInfo{{ID: modelID}})
+
+	// 1. Initial suspension inserts reason.
+	r.SuspendClientModelReplacingReasons(clientID, modelID, "invalid_api_key")
+	if reason := r.GetClientModelSuspensionReason(clientID, modelID); reason != "invalid_api_key" {
+		t.Fatalf("initial suspension reason = %q, want invalid_api_key", reason)
+	}
+
+	// 2. Already suspended with a replaceable reason -> reason replaced.
+	r.SuspendClientModelReplacingReasons(clientID, modelID, "not_found", "invalid_api_key")
+	if reason := r.GetClientModelSuspensionReason(clientID, modelID); reason != "not_found" {
+		t.Fatalf("suspension reason after replacement = %q, want not_found", reason)
+	}
+
+	// 3. Already suspended with a non-replaceable reason -> reason preserved.
+	r.SuspendClientModelReplacingReasons(clientID, modelID, "invalid_api_key", "quota")
+	if reason := r.GetClientModelSuspensionReason(clientID, modelID); reason != "not_found" {
+		t.Fatalf("suspension reason after non-matching replacement = %q, want not_found (preserved)", reason)
+	}
+
+	// 4. Already suspended with no replaceable args -> reason preserved (behaves like SuspendClientModel).
+	r.SuspendClientModelReplacingReasons(clientID, modelID, "invalid_api_key")
+	if reason := r.GetClientModelSuspensionReason(clientID, modelID); reason != "not_found" {
+		t.Fatalf("suspension reason without replaceable args = %q, want not_found (preserved)", reason)
+	}
+
+	// 5. SuspendClientModel delegation preserves existing reason.
+	r.SuspendClientModel(clientID, modelID, "invalid_api_key")
+	if reason := r.GetClientModelSuspensionReason(clientID, modelID); reason != "not_found" {
+		t.Fatalf("suspension reason via SuspendClientModel = %q, want not_found (preserved)", reason)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_availability_test.go
+++ b/sdk/cliproxy/auth/conductor_availability_test.go
@@ -319,6 +319,63 @@ func TestManager_ModelSpecificSuspensionSurvivesSiblingSuccess(t *testing.T) {
 	}
 }
 
+func TestManager_ModelNotSupportedSuspensionResumesOnOwnSuccess(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	ctx := context.Background()
+	authID := "model-not-supported-resume-auth"
+	model := "model-a"
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "openai", []*registry.ModelInfo{
+		{ID: model},
+	})
+	t.Cleanup(func() {
+		reg.UnregisterClient(authID)
+	})
+
+	if _, errRegister := manager.Register(ctx, &Auth{
+		ID:       authID,
+		Provider: "openai",
+		Status:   StatusActive,
+		ModelStates: map[string]*ModelState{
+			model: {Status: StatusActive},
+		},
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	// Fail model with model_not_supported -> model should be suspended in registry
+	manager.MarkResult(ctx, Result{
+		AuthID:   authID,
+		Provider: "openai",
+		Model:    model,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusBadRequest, Code: "model_not_supported", Message: "model not supported"},
+	})
+
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("registry model count for model after suspension = %d, want 0", count)
+	}
+	if reason := reg.GetClientModelSuspensionReason(authID, model); reason != "model_not_supported" {
+		t.Fatalf("suspension reason = %q, want model_not_supported", reason)
+	}
+
+	// Success on model -> should resume model in registry
+	manager.MarkResult(ctx, Result{
+		AuthID:   authID,
+		Provider: "openai",
+		Model:    model,
+		Success:  true,
+	})
+
+	if count := reg.GetModelCount(model); count != 1 {
+		t.Fatalf("registry model count for model after success = %d, want 1", count)
+	}
+	if reason := reg.GetClientModelSuspensionReason(authID, model); reason != "" {
+		t.Fatalf("suspension reason after success = %q, want empty", reason)
+	}
+}
+
 // TestManager_ModelSpecificResumableSiblingSuspensionSurvivesSiblingSuccess verifies that a
 // sibling model suspended for a resumable model-specific reason (not_found, quota,
 // payment_required) keeps its registry suspension when a different model of the same credential

--- a/sdk/cliproxy/auth/conductor_availability_test.go
+++ b/sdk/cliproxy/auth/conductor_availability_test.go
@@ -318,3 +318,188 @@ func TestManager_ModelSpecificSuspensionSurvivesSiblingSuccess(t *testing.T) {
 		t.Fatalf("registry model count for modelB after modelA success = %d, want 0 (suspension should survive)", count)
 	}
 }
+
+// TestManager_ModelSpecificResumableSiblingSuspensionSurvivesSiblingSuccess verifies that a
+// sibling model suspended for a resumable model-specific reason (not_found, quota,
+// payment_required) keeps its registry suspension when a different model of the same credential
+// succeeds. Only credential-wide reasons like invalid_api_key justify cross-model resumption.
+func TestManager_ModelSpecificResumableSiblingSuspensionSurvivesSiblingSuccess(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	ctx := context.Background()
+	authID := "sibling-resumable-suspension-auth"
+	modelA := "model-a2"
+	modelB := "model-b2"
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "openai", []*registry.ModelInfo{
+		{ID: modelA},
+		{ID: modelB},
+	})
+	t.Cleanup(func() {
+		reg.UnregisterClient(authID)
+	})
+
+	if _, errRegister := manager.Register(ctx, &Auth{
+		ID:       authID,
+		Provider: "openai",
+		Status:   StatusActive,
+		ModelStates: map[string]*ModelState{
+			modelA: {Status: StatusActive},
+			modelB: {Status: StatusActive},
+		},
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	// Fail modelB with a resumable, model-specific reason (not_found).
+	manager.MarkResult(ctx, Result{
+		AuthID:   authID,
+		Provider: "openai",
+		Model:    modelB,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusNotFound, Code: "not_found", Message: "model b not found"},
+	})
+	if count := reg.GetModelCount(modelB); count != 0 {
+		t.Fatalf("registry model count for modelB after suspension = %d, want 0", count)
+	}
+
+	// Success on modelA -> must NOT resume modelB (model-specific reason).
+	manager.MarkResult(ctx, Result{
+		AuthID:   authID,
+		Provider: "openai",
+		Model:    modelA,
+		Success:  true,
+	})
+	if count := reg.GetModelCount(modelB); count != 0 {
+		t.Fatalf("registry model count for modelB after modelA success = %d, want 0 (model-specific suspension should survive)", count)
+	}
+	if count := reg.GetModelCount(modelA); count != 1 {
+		t.Fatalf("registry model count for modelA after success = %d, want 1", count)
+	}
+}
+
+// TestManager_CredentialWideSiblingSuspensionResumesOnSiblingSuccess verifies that a sibling
+// suspended for a credential-wide reason (invalid_api_key) is resumed by a successful request on
+// another model of the same credential.
+func TestManager_CredentialWideSiblingSuspensionResumesOnSiblingSuccess(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	ctx := context.Background()
+	authID := "sibling-credentialwide-resume-auth"
+	modelA := "model-a3"
+	modelB := "model-b3"
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "openai", []*registry.ModelInfo{
+		{ID: modelA},
+		{ID: modelB},
+	})
+	t.Cleanup(func() {
+		reg.UnregisterClient(authID)
+	})
+
+	if _, errRegister := manager.Register(ctx, &Auth{
+		ID:       authID,
+		Provider: "openai",
+		Status:   StatusActive,
+		ModelStates: map[string]*ModelState{
+			modelA: {Status: StatusActive},
+			modelB: {Status: StatusActive},
+		},
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	// Suspend sibling modelB with a genuine credential-wide reason (invalid_api_key) directly in
+	// the registry. A live invalid_api_key failure would also mark the credential with an active
+	// credential_quota cooldown that legitimately suppresses the resume path; suspending the sibling
+	// directly isolates the sibling-resume loop's reason scoping.
+	reg.SuspendClientModel(authID, modelB, "invalid_api_key")
+	if count := reg.GetModelCount(modelB); count != 0 {
+		t.Fatalf("registry model count for modelB after suspension = %d, want 0", count)
+	}
+
+	// Success on modelA -> resumes modelB (credential-wide reason).
+	manager.MarkResult(ctx, Result{
+		AuthID:   authID,
+		Provider: "openai",
+		Model:    modelA,
+		Success:  true,
+	})
+	if count := reg.GetModelCount(modelB); count != 1 {
+		t.Fatalf("registry model count for modelB after modelA success = %d, want 1 (credential-wide suspension should resume)", count)
+	}
+}
+
+// TestManager_ModelSpecificFailureOverwritesCredentialWideSuspension reproduces the scenario
+// where a credential-wide invalid_api_key fanout suspends all models, and model B later encounters
+// a model-specific failure (e.g. not_found). Model B's suspension reason must be updated to the
+// model-specific reason so that a subsequent success on model A does not erroneously resume model B.
+func TestManager_ModelSpecificFailureOverwritesCredentialWideSuspension(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	ctx := context.Background()
+	authID := "sibling-overwrite-suspension-auth"
+	modelA := "model-a4"
+	modelB := "model-b4"
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "openai", []*registry.ModelInfo{
+		{ID: modelA},
+		{ID: modelB},
+	})
+	t.Cleanup(func() {
+		reg.UnregisterClient(authID)
+	})
+
+	if _, errRegister := manager.Register(ctx, &Auth{
+		ID:       authID,
+		Provider: "openai",
+		Status:   StatusActive,
+		ModelStates: map[string]*ModelState{
+			modelA: {Status: StatusActive},
+			modelB: {Status: StatusActive},
+		},
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	// 1. Initial credential-wide suspension on all models (invalid_api_key).
+	// To isolate the suspension reason overwrite and sibling-resume behavior without active
+	// credential_quota cooldown gating, suspend modelB directly with invalid_api_key as the
+	// fanout produces.
+	reg.SuspendClientModel(authID, modelB, "invalid_api_key")
+	if reason := reg.GetClientModelSuspensionReason(authID, modelB); reason != "invalid_api_key" {
+		t.Fatalf("modelB initial suspension reason = %q, want invalid_api_key", reason)
+	}
+
+	// 2. Model B records a model-specific failure (404 not_found).
+	manager.MarkResult(ctx, Result{
+		AuthID:   authID,
+		Provider: "openai",
+		Model:    modelB,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusNotFound, Code: "not_found", Message: "model b not found"},
+	})
+	if reason := reg.GetClientModelSuspensionReason(authID, modelB); reason != "not_found" {
+		t.Fatalf("modelB suspension reason after 404 = %q, want not_found", reason)
+	}
+	if count := reg.GetModelCount(modelB); count != 0 {
+		t.Fatalf("registry model count for modelB after 404 = %d, want 0", count)
+	}
+
+	// 3. Model A succeeds -> sibling-resume loop runs. Model B must STAY suspended.
+	manager.MarkResult(ctx, Result{
+		AuthID:   authID,
+		Provider: "openai",
+		Model:    modelA,
+		Success:  true,
+	})
+	if reason := reg.GetClientModelSuspensionReason(authID, modelB); reason != "not_found" {
+		t.Fatalf("modelB suspension reason after modelA success = %q, want not_found (must survive)", reason)
+	}
+	if count := reg.GetModelCount(modelB); count != 0 {
+		t.Fatalf("registry model count for modelB after modelA success = %d, want 0 (must stay suspended)", count)
+	}
+	if count := reg.GetModelCount(modelA); count != 1 {
+		t.Fatalf("registry model count for modelA after success = %d, want 1", count)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -24,6 +24,25 @@ var quotaCooldownDisabled atomic.Bool
 
 var transientErrorCooldownSeconds atomic.Int64
 
+// resumableCooldownReasons are the registry suspension reasons a successful result can clear for
+// the model that just succeeded (they include model-specific reasons like not_found and quota).
+var resumableCooldownReasons = []string{
+	"invalid_api_key",
+	"invalid_grant",
+	"unauthorized",
+	"payment_required",
+	"not_found",
+	"quota",
+}
+
+// credentialWideCooldownReasons are the suspension reasons that span every model of a credential
+// and may therefore be cleared on sibling models when a different model of the same credential
+// succeeds. Only invalid_api_key is propagated credential-wide by SuspendClientModel; invalid_grant,
+// unauthorized, and model-specific reasons are recorded per-model and must not resume siblings.
+var credentialWideCooldownReasons = []string{
+	"invalid_api_key",
+}
+
 // SetQuotaCooldownDisabled toggles auth/model cooldown scheduling globally.
 func SetQuotaCooldownDisabled(disable bool) {
 	quotaCooldownDisabled.Store(disable)
@@ -963,13 +982,14 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 		registry.GetGlobalRegistry().SetModelQuotaExceeded(result.AuthID, modelKey)
 	}
 	if shouldResumeModel {
+		// Sibling models resume only for credential-wide reasons (invalid_api_key); model-specific
+		// suspensions (not_found, quota, payment_required, ...) must survive until that sibling
+		// succeeds on its own.
 		for _, m := range modelsForRegisteredAuth(result.AuthID) {
-			if registry.GetGlobalRegistry().GetClientModelSuspensionReason(result.AuthID, m) == "invalid_api_key" {
-				registry.GetGlobalRegistry().ResumeClientModel(result.AuthID, m)
-			}
+			registry.GetGlobalRegistry().ResumeClientModelIfReason(result.AuthID, m, credentialWideCooldownReasons...)
 		}
 		if modelKey != "" {
-			registry.GetGlobalRegistry().ResumeClientModel(result.AuthID, modelKey)
+			registry.GetGlobalRegistry().ResumeClientModelIfReason(result.AuthID, modelKey, resumableCooldownReasons...)
 		}
 	} else if shouldSuspendModel {
 		if suspendReason == "invalid_api_key" {
@@ -980,7 +1000,9 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				registry.GetGlobalRegistry().SuspendClientModel(result.AuthID, modelKey, suspendReason)
 			}
 		} else {
-			registry.GetGlobalRegistry().SuspendClientModel(result.AuthID, modelKey, suspendReason)
+			// A model-specific reason must overwrite a stale credential-wide one, otherwise the
+			// sibling-resume loop above would clear this suspension when another model succeeds.
+			registry.GetGlobalRegistry().SuspendClientModelReplacingReasons(result.AuthID, modelKey, suspendReason, credentialWideCooldownReasons...)
 		}
 	}
 

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -32,6 +32,7 @@ var resumableCooldownReasons = []string{
 	"unauthorized",
 	"payment_required",
 	"not_found",
+	"model_not_supported",
 	"quota",
 }
 


### PR DESCRIPTION
## Problem

When multiple models share a single credential, model failure and recovery handling in `MarkResult` suffered from two severe defects:

1. **TOCTOU Race & Stale Sibling Resumption**: `MarkResult` checked `GetClientModelSuspensionReason` and compared it to `"invalid_api_key"` before calling `ResumeClientModel`. Under concurrent requests, the suspension reason could change between check and resume. Furthermore, unrelated sibling model successes could erroneously clear model-specific suspensions (e.g. `not_found`, `quota`, `payment_required`), putting dead endpoints back into active rotation and preventing proper failover.
2. **Permanent Suspension of `model_not_supported`**: `MarkResult` suspends unsupported models with reason `model_not_supported` and a 12-hour retry window. When reason-scoping was introduced, `model_not_supported` was omitted from the resumable per-model set, causing models to remain permanently suspended even after subsequent successful requests on the same model.

## Fix

- `internal/registry/model_registry.go:749`: Added `SuspendClientModelReplacingReasons` to allow model-specific reasons to atomically overwrite credential-wide ones.
- `internal/registry/model_registry.go:828`: Added `ResumeClientModelIfReason` to atomically inspect the recorded suspension reason and remove the suspension under a single lock only if the reason matches the permitted set.
- `sdk/cliproxy/auth/conductor_cooldown.go:29`: Defined `resumableCooldownReasons` (including `model_not_supported`, `not_found`, `quota`, `invalid_api_key`, `invalid_grant`, `unauthorized`, `payment_required`) and `credentialWideCooldownReasons` (`invalid_api_key`).
- `sdk/cliproxy/auth/conductor_cooldown.go:990`: Updated `MarkResult` to atomically resume sibling models only for credential-wide reasons (`ResumeClientModelIfReason`), resume own model for all valid per-model reasons, and overwrite credential-wide suspensions when a specific failure occurs (`SuspendClientModelReplacingReasons`).

## Tests

- `TestResumeClientModelIfReason_RacePreservesNewerSuspension`: Pins atomic reason checking in registry, verifying that a newer suspension reason is preserved and not accidentally cleared.
- `TestSuspendClientModelReplacingReasons`: Pins reason replacement rules when suspending clients.
- `TestManager_ModelNotSupportedSuspensionResumesOnOwnSuccess`: Pins that `model_not_supported` suspensions are cleared upon own-model success.
- `TestManager_ModelSpecificResumableSiblingSuspensionSurvivesSiblingSuccess`: Pins that model-specific suspensions (`not_found`, `quota`) survive sibling model success.
- `TestManager_CredentialWideSiblingSuspensionResumesOnSiblingSuccess`: Pins that credential-wide suspensions (`invalid_api_key`) resume when a sibling succeeds.
- `TestManager_ModelSpecificFailureOverwritesCredentialWideSuspension`: Pins that a model-specific failure replaces a stale credential-wide suspension.

## Reverse bite-check

Reverting `model_not_supported` from `resumableCooldownReasons` in `sdk/cliproxy/auth/conductor_cooldown.go` causes `TestManager_ModelNotSupportedSuspensionResumesOnOwnSuccess` to fail immediately:

```
=== RUN   TestManager_ModelNotSupportedSuspensionResumesOnOwnSuccess
    conductor_availability_test.go:372: registry model count for model after success = 0, want 1
--- FAIL: TestManager_ModelNotSupportedSuspensionResumesOnOwnSuccess (0.00s)
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth	0.461s
FAIL
```

Reverting reason verification in `ResumeClientModelIfReason` (`internal/registry/model_registry.go`) so it unconditionally clears suspensions causes `TestResumeClientModelIfReason_RacePreservesNewerSuspension` to fail:

```
=== RUN   TestResumeClientModelIfReason_RacePreservesNewerSuspension
    model_registry_resume_reason_test.go:29: ResumeClientModelIfReason resumed a model whose current suspension should remain, want no-op
--- FAIL: TestResumeClientModelIfReason_RacePreservesNewerSuspension (0.00s)
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/internal/registry	0.386s
FAIL
```

## Verification

```bash
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go build ./...
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go vet ./internal/registry/... ./sdk/cliproxy/auth/...
gofmt -l internal/registry/model_registry.go internal/registry/model_registry_resume_reason_test.go sdk/cliproxy/auth/conductor_availability_test.go sdk/cliproxy/auth/conductor_cooldown.go
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go test -v ./internal/registry/... ./sdk/cliproxy/auth/...
```

Output:
```
ok  	github.com/router-for-me/CLIProxyAPI/v7/internal/registry	0.309s
ok  	github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth	11.377s
```

### Tooling note

The `jbcontext` semantic-search CLI is installed but non-functional in this environment
(`jbcontext search` fails with `the OS keychain is not accessible`). The equivalent
review passes were performed with the repository's own tooling and manual inspection
instead; this is disclosed for transparency about how the change was reviewed.
