### PR TITLE
fix(auth): ignore id-only tool-call scaffolds in empty completion check

### DIFF
--- a/sdk/cliproxy/auth/empty_completion.go
+++ b/sdk/cliproxy/auth/empty_completion.go
@@ -381,6 +381,7 @@ type openAIResponseOutputItem struct {
 	Text             string                      `json:"text"`
 	Arguments        string                      `json:"arguments"`
 	Result           string                      `json:"result"`
+	Action           json.RawMessage             `json:"action"`
 	Content          []openAIResponseContentPart `json:"content"`
 	EncryptedContent string                      `json:"encrypted_content"`
 	Summary          json.RawMessage             `json:"summary"`
@@ -774,7 +775,8 @@ func hasMeaningfulResponsesCallItem(item openAIResponseOutputItem) bool {
 	return strings.TrimSpace(item.Name) != "" ||
 		hasMeaningfulJSONArguments(item.Arguments) ||
 		strings.TrimSpace(item.Input) != "" ||
-		strings.TrimSpace(item.Result) != ""
+		strings.TrimSpace(item.Result) != "" ||
+		nonEmptyJSONPayload(item.Action)
 }
 
 func (a *emptyCompletionAccum) evalOpenAIResponseOutput(items []openAIResponseOutputItem) {

--- a/sdk/cliproxy/auth/empty_completion.go
+++ b/sdk/cliproxy/auth/empty_completion.go
@@ -271,9 +271,6 @@ func isMeaningfulToolCall(raw json.RawMessage) bool {
 		}
 		return false
 	}
-	if strings.TrimSpace(call.ID) != "" {
-		return true
-	}
 	if strings.TrimSpace(call.Function.Name) != "" || hasMeaningfulJSONArguments(call.Function.Arguments) {
 		return true
 	}
@@ -774,9 +771,7 @@ func (a *emptyCompletionAccum) evalOpenAIResponseRawOutput(raw json.RawMessage) 
 }
 
 func hasMeaningfulResponsesCallItem(item openAIResponseOutputItem) bool {
-	return strings.TrimSpace(item.ID) != "" ||
-		strings.TrimSpace(item.CallID) != "" ||
-		strings.TrimSpace(item.Name) != "" ||
+	return strings.TrimSpace(item.Name) != "" ||
 		hasMeaningfulJSONArguments(item.Arguments) ||
 		strings.TrimSpace(item.Input) != "" ||
 		strings.TrimSpace(item.Result) != ""

--- a/sdk/cliproxy/auth/empty_completion_test.go
+++ b/sdk/cliproxy/auth/empty_completion_test.go
@@ -192,7 +192,27 @@ func TestEmptyCompletionPredicate(t *testing.T) {
 		},
 		{
 			name:     "tool calls are not empty",
+			payload:  []byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"x\",\"function\":{\"name\":\"lookup\"}}]},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name:     "openai sse semantically empty tool_calls id only",
 			payload:  []byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"x\"}]},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
+			expected: true,
+		},
+		{
+			name:     "openai json semantically empty tool_calls id only",
+			payload:  []byte(`{"choices":[{"message":{"tool_calls":[{"id":"call_123"}]},"finish_reason":"tool_calls"}]}`),
+			expected: true,
+		},
+		{
+			name:     "openai sse meaningful tool_calls name only",
+			payload:  []byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"\",\"function\":{\"name\":\"lookup\"}}]},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name:     "openai json meaningful tool_calls name only",
+			payload:  []byte(`{"choices":[{"message":{"tool_calls":[{"id":"","type":"function","function":{"name":"lookup","arguments":""}}]},"finish_reason":"tool_calls"}]}`),
 			expected: false,
 		},
 		{
@@ -604,6 +624,31 @@ func TestEmptyCompletionPredicate(t *testing.T) {
 			name:     "codex responses-api sse with function_call is not empty",
 			payload:  []byte("data: {\"type\":\"response.output_item.done\",\"output\":{\"type\":\"function_call\",\"name\":\"get_weather\",\"arguments\":\"{}\",\"call_id\":\"call_1\"}}\n\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"r\",\"status\":\"completed\",\"output\":[{\"type\":\"function_call\",\"name\":\"get_weather\",\"arguments\":\"{}\",\"call_id\":\"call_1\"}],\"usage\":{\"output_tokens\":5}}}\n\ndata: [DONE]\n\n"),
 			expected: false,
+		},
+		{
+			name:     "codex responses-api non-stream in_progress with function_call id only is empty",
+			payload:  []byte(`{"object":"response","id":"r","status":"in_progress","output":[{"type":"function_call","id":"call_123","call_id":"call_123","name":"","arguments":""}]}`),
+			expected: true,
+		},
+		{
+			name:     "codex responses-api sse with function_call id only is empty",
+			payload:  []byte("data: {\"type\":\"response.output_item.done\",\"output\":{\"type\":\"function_call\",\"id\":\"call_123\",\"call_id\":\"call_123\",\"name\":\"\",\"arguments\":\"\"}}\n\ndata: [DONE]\n\n"),
+			expected: true,
+		},
+		{
+			name:     "codex responses-api non-stream with function_call name only is not empty",
+			payload:  []byte(`{"object":"response","id":"r","status":"completed","output":[{"type":"function_call","name":"get_weather","arguments":""}],"usage":{"output_tokens":0}}`),
+			expected: false,
+		},
+		{
+			name:     "codex responses-api sse with function_call name only is not empty",
+			payload:  []byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"function_call\",\"name\":\"get_weather\"}}\n\ndata: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[],\"usage\":{\"output_tokens\":0}}}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name:     "codex responses-api custom_tool_call id only is empty",
+			payload:  []byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"custom_tool_call\",\"id\":\"call_123\",\"call_id\":\"call_123\",\"name\":\"\",\"input\":\"\"}}\n\ndata: [DONE]\n\n"),
+			expected: true,
 		},
 		{
 			name:     "codex responses-api non-stream with custom_tool_call is not empty",
@@ -2818,23 +2863,55 @@ func TestResponsesEmptyToolCallScaffold(t *testing.T) {
 		}
 	})
 
-	t.Run("scaffold with non-empty id marks meaningful and forwards", func(t *testing.T) {
+	t.Run("scaffold with non-empty id does not mark meaningful and allows bootstrap error failover", func(t *testing.T) {
 		var detector StreamBootstrapDetector
-		if !detector.Observe(funcWithID) {
-			t.Fatal("detector.Observe() = false for function_call with id, want true")
+		if detector.Observe(funcWithID) {
+			t.Fatal("detector.Observe() = true for function_call with id, want false")
 		}
-		if !detector.HasMeaningfulOutput() {
-			t.Fatal("detector.HasMeaningfulOutput() = false for function_call with id, want true")
+		if detector.HasMeaningfulOutput() {
+			t.Fatal("detector.HasMeaningfulOutput() = true for function_call with id, want false")
+		}
+
+		errUpstream := errors.New("upstream failed immediately after function_call id scaffold")
+		ch := make(chan cliproxyexecutor.StreamChunk, 2)
+		ch <- cliproxyexecutor.StreamChunk{Payload: funcWithID}
+		ch <- cliproxyexecutor.StreamChunk{Err: errUpstream}
+		close(ch)
+		buffered, closed, err := readStreamBootstrap(context.Background(), ch)
+		if !errors.Is(err, errUpstream) {
+			t.Fatalf("readStreamBootstrap error = %v, want %v for failover", err, errUpstream)
+		}
+		if len(buffered) != 0 {
+			t.Fatalf("readStreamBootstrap buffered = %d, want 0 on failover error", len(buffered))
+		}
+		if closed {
+			t.Fatal("readStreamBootstrap returned closed = true, want false on error")
 		}
 	})
 
-	t.Run("scaffold with non-empty call_id marks meaningful and forwards", func(t *testing.T) {
+	t.Run("scaffold with non-empty call_id does not mark meaningful and allows bootstrap error failover", func(t *testing.T) {
 		var detector StreamBootstrapDetector
-		if !detector.Observe(funcWithCallID) {
-			t.Fatal("detector.Observe() = false for function_call with call_id, want true")
+		if detector.Observe(funcWithCallID) {
+			t.Fatal("detector.Observe() = true for function_call with call_id, want false")
 		}
-		if !detector.HasMeaningfulOutput() {
-			t.Fatal("detector.HasMeaningfulOutput() = false for function_call with call_id, want true")
+		if detector.HasMeaningfulOutput() {
+			t.Fatal("detector.HasMeaningfulOutput() = true for function_call with call_id, want false")
+		}
+
+		errUpstream := errors.New("upstream failed immediately after function_call call_id scaffold")
+		ch := make(chan cliproxyexecutor.StreamChunk, 2)
+		ch <- cliproxyexecutor.StreamChunk{Payload: funcWithCallID}
+		ch <- cliproxyexecutor.StreamChunk{Err: errUpstream}
+		close(ch)
+		buffered, closed, err := readStreamBootstrap(context.Background(), ch)
+		if !errors.Is(err, errUpstream) {
+			t.Fatalf("readStreamBootstrap error = %v, want %v for failover", err, errUpstream)
+		}
+		if len(buffered) != 0 {
+			t.Fatalf("readStreamBootstrap buffered = %d, want 0 on failover error", len(buffered))
+		}
+		if closed {
+			t.Fatal("readStreamBootstrap returned closed = true, want false on error")
 		}
 	})
 
@@ -3111,4 +3188,112 @@ func TestEmptyCompletionResponsesImageGenerationCallResult(t *testing.T) {
 	if got := wsDetector.Observe([]byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"image_generation_call\",\"status\":\"completed\",\"result\":\"   \"}}\n\n")); got != false {
 		t.Fatalf("StreamBootstrapDetector.Observe(whitespace result) = %v, want false", got)
 	}
+}
+
+func TestToolCallIDOnlyRegression(t *testing.T) {
+	t.Run("openai tool_call id only is empty and not meaningful", func(t *testing.T) {
+		payloadSSE := []byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"call_abc123\"}]}}]}\n\n")
+		var detector StreamBootstrapDetector
+		if detector.Observe(payloadSSE) {
+			t.Fatal("StreamBootstrapDetector.Observe() = true for id-only tool_call, want false")
+		}
+		if detector.HasMeaningfulOutput() {
+			t.Fatal("detector.HasMeaningfulOutput() = true for id-only tool_call, want false")
+		}
+
+		payloadTerm := []byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"call_abc123\"}]},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n")
+		if !IsEmptyCompletionPayload(payloadTerm) {
+			t.Fatal("IsEmptyCompletionPayload() = false for id-only tool_call, want true")
+		}
+
+		payloadJSON := []byte(`{"choices":[{"message":{"tool_calls":[{"id":"call_abc123"}]},"finish_reason":"tool_calls"}]}`)
+		if !IsEmptyCompletionPayload(payloadJSON) {
+			t.Fatal("IsEmptyCompletionPayload() = false for id-only tool_call JSON, want true")
+		}
+	})
+
+	t.Run("openai tool_call with name is meaningful and forwards", func(t *testing.T) {
+		payloadSSE := []byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"call_abc123\",\"function\":{\"name\":\"lookup\"}}]}}]}\n\n")
+		var detector StreamBootstrapDetector
+		if !detector.Observe(payloadSSE) {
+			t.Fatal("StreamBootstrapDetector.Observe() = false for tool_call with name, want true")
+		}
+		if !detector.HasMeaningfulOutput() {
+			t.Fatal("detector.HasMeaningfulOutput() = false for tool_call with name, want true")
+		}
+
+		payloadJSON := []byte(`{"choices":[{"message":{"tool_calls":[{"id":"","type":"function","function":{"name":"lookup","arguments":""}}]},"finish_reason":"tool_calls"}]}`)
+		if IsEmptyCompletionPayload(payloadJSON) {
+			t.Fatal("IsEmptyCompletionPayload() = true for tool_call with name, want false")
+		}
+	})
+
+	t.Run("openai tool_call with name and empty object arguments is meaningful and forwards", func(t *testing.T) {
+		payloadSSE := []byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"call_abc123\",\"function\":{\"name\":\"lookup\",\"arguments\":\"{}\"}}]}}]}\n\n")
+		var detector StreamBootstrapDetector
+		if !detector.Observe(payloadSSE) {
+			t.Fatal("StreamBootstrapDetector.Observe() = false for tool_call with name and empty object args, want true")
+		}
+		if !detector.HasMeaningfulOutput() {
+			t.Fatal("detector.HasMeaningfulOutput() = false for tool_call with name and empty object args, want true")
+		}
+
+		payloadJSON := []byte(`{"choices":[{"message":{"tool_calls":[{"id":"call_abc123","type":"function","function":{"name":"lookup","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}`)
+		if IsEmptyCompletionPayload(payloadJSON) {
+			t.Fatal("IsEmptyCompletionPayload() = true for tool_call with name and empty object args, want false")
+		}
+	})
+
+	t.Run("responses api function_call id only is empty and not meaningful", func(t *testing.T) {
+		payloadSSE := []byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"function_call\",\"id\":\"call_123\",\"call_id\":\"call_123\",\"name\":\"\",\"arguments\":\"\"}}\n\n")
+		var detector StreamBootstrapDetector
+		if detector.Observe(payloadSSE) {
+			t.Fatal("StreamBootstrapDetector.Observe() = true for Responses function_call id only, want false")
+		}
+		if detector.HasMeaningfulOutput() {
+			t.Fatal("detector.HasMeaningfulOutput() = true for Responses function_call id only, want false")
+		}
+
+		payloadTerm := []byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"function_call\",\"id\":\"call_123\",\"call_id\":\"call_123\",\"name\":\"\",\"arguments\":\"\"}}\n\ndata: [DONE]\n\n")
+		if !IsEmptyCompletionPayload(payloadTerm) {
+			t.Fatal("IsEmptyCompletionPayload() = false for Responses function_call id only, want true")
+		}
+
+		payloadJSON := []byte(`{"object":"response","id":"r","status":"in_progress","output":[{"type":"function_call","id":"call_123","call_id":"call_123","name":"","arguments":""}]}`)
+		if !IsEmptyCompletionPayload(payloadJSON) {
+			t.Fatal("IsEmptyCompletionPayload() = false for Responses function_call id only JSON, want true")
+		}
+	})
+
+	t.Run("responses api function_call with name is meaningful and forwards", func(t *testing.T) {
+		payloadSSE := []byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"function_call\",\"name\":\"get_weather\"}}\n\n")
+		var detector StreamBootstrapDetector
+		if !detector.Observe(payloadSSE) {
+			t.Fatal("StreamBootstrapDetector.Observe() = false for Responses function_call with name, want true")
+		}
+		if !detector.HasMeaningfulOutput() {
+			t.Fatal("detector.HasMeaningfulOutput() = false for Responses function_call with name, want true")
+		}
+
+		payloadJSON := []byte(`{"object":"response","id":"r","status":"completed","output":[{"type":"function_call","name":"get_weather","arguments":""}],"usage":{"output_tokens":0}}`)
+		if IsEmptyCompletionPayload(payloadJSON) {
+			t.Fatal("IsEmptyCompletionPayload() = true for Responses function_call with name, want false")
+		}
+	})
+
+	t.Run("responses api function_call with name and empty object arguments is meaningful and forwards", func(t *testing.T) {
+		payloadSSE := []byte("data: {\"type\":\"response.output_item.done\",\"output\":{\"type\":\"function_call\",\"name\":\"get_weather\",\"arguments\":\"{}\",\"call_id\":\"call_1\"}}\n\n")
+		var detector StreamBootstrapDetector
+		if !detector.Observe(payloadSSE) {
+			t.Fatal("StreamBootstrapDetector.Observe() = false for Responses function_call with name and empty object args, want true")
+		}
+		if !detector.HasMeaningfulOutput() {
+			t.Fatal("detector.HasMeaningfulOutput() = false for Responses function_call with name and empty object args, want true")
+		}
+
+		payloadJSON := []byte(`{"object":"response","id":"r","status":"completed","output":[{"type":"function_call","name":"get_weather","arguments":"{}","call_id":"call_1"}],"usage":{"output_tokens":5}}`)
+		if IsEmptyCompletionPayload(payloadJSON) {
+			t.Fatal("IsEmptyCompletionPayload() = true for Responses function_call with name and empty object args, want false")
+		}
+	})
 }

--- a/sdk/cliproxy/auth/empty_completion_test.go
+++ b/sdk/cliproxy/auth/empty_completion_test.go
@@ -661,6 +661,51 @@ func TestEmptyCompletionPredicate(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "codex responses-api non-stream in_progress with web_search_call action is not empty",
+			payload:  []byte(`{"object":"response","id":"r","status":"in_progress","output":[{"type":"web_search_call","action":{"query":"golang testing"}}]}`),
+			expected: false,
+		},
+		{
+			name:     "codex responses-api sse with web_search_call action is not empty",
+			payload:  []byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"web_search_call\",\"action\":{\"query\":\"golang testing\"}}}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name:     "codex responses-api non-stream in_progress with computer_call action is not empty",
+			payload:  []byte(`{"object":"response","id":"r","status":"in_progress","output":[{"type":"computer_call","action":{"type":"click","x":100,"y":200}}]}`),
+			expected: false,
+		},
+		{
+			name:     "codex responses-api sse with computer_call action is not empty",
+			payload:  []byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"computer_call\",\"action\":{\"type\":\"click\",\"x\":100,\"y\":200}}}\n\ndata: [DONE]\n\n"),
+			expected: false,
+		},
+		{
+			name:     "codex responses-api non-stream web_search_call with empty object action is empty",
+			payload:  []byte(`{"object":"response","id":"r","status":"in_progress","output":[{"type":"web_search_call","id":"call_123","action":{}}]}`),
+			expected: true,
+		},
+		{
+			name:     "codex responses-api sse web_search_call with empty object action is empty",
+			payload:  []byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"web_search_call\",\"id\":\"call_123\",\"call_id\":\"call_123\",\"action\":{}}}\n\ndata: [DONE]\n\n"),
+			expected: true,
+		},
+		{
+			name:     "codex responses-api non-stream computer_call with null action is empty",
+			payload:  []byte(`{"object":"response","id":"r","status":"in_progress","output":[{"type":"computer_call","id":"call_123","action":null}]}`),
+			expected: true,
+		},
+		{
+			name:     "codex responses-api sse computer_call with null action is empty",
+			payload:  []byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"computer_call\",\"id\":\"call_123\",\"call_id\":\"call_123\",\"action\":null}}\n\ndata: [DONE]\n\n"),
+			expected: true,
+		},
+		{
+			name:     "codex responses-api sse web_search_call id only is empty",
+			payload:  []byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"web_search_call\",\"id\":\"call_123\",\"call_id\":\"call_123\"}}\n\ndata: [DONE]\n\n"),
+			expected: true,
+		},
+		{
 			name:     "codex responses-api non-stream with image_generation_call is not empty",
 			payload:  []byte(`{"object":"response","status":"completed","output":[{"type":"image_generation_call","status":"completed","result":"image-data"}],"usage":{"output_tokens":0}}`),
 			expected: false,
@@ -2826,6 +2871,9 @@ func TestResponsesEmptyToolCallScaffold(t *testing.T) {
 	funcWithName := []byte("event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":0,\"output_index\":0,\"item\":{\"id\":\"\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"\",\"name\":\"lookup\"}}\n\n")
 	funcWithArgs := []byte("event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":0,\"output_index\":0,\"item\":{\"id\":\"\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"{\\\"q\\\":\\\"search\\\"}\",\"call_id\":\"\",\"name\":\"\"}}\n\n")
 	customToolWithInput := []byte("event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":0,\"output_index\":0,\"item\":{\"id\":\"\",\"type\":\"custom_tool_call\",\"status\":\"in_progress\",\"input\":\"{\\\"cmd\\\":\\\"run\\\"}\",\"call_id\":\"\",\"name\":\"\"}}\n\n")
+	webSearchWithAction := []byte("event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":0,\"output_index\":0,\"item\":{\"id\":\"\",\"type\":\"web_search_call\",\"status\":\"in_progress\",\"action\":{\"query\":\"test\"},\"call_id\":\"\",\"name\":\"\"}}\n\n")
+	computerCallWithAction := []byte("event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":0,\"output_index\":0,\"item\":{\"id\":\"\",\"type\":\"computer_call\",\"status\":\"in_progress\",\"action\":{\"type\":\"click\"},\"call_id\":\"\",\"name\":\"\"}}\n\n")
+	webSearchWithEmptyAction := []byte("event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":0,\"output_index\":0,\"item\":{\"id\":\"call_123\",\"type\":\"web_search_call\",\"status\":\"in_progress\",\"action\":{},\"call_id\":\"\",\"name\":\"\"}}\n\n")
 
 	t.Run("empty function_call scaffold does not mark meaningful and allows bootstrap error failover", func(t *testing.T) {
 		var detector StreamBootstrapDetector
@@ -2945,12 +2993,44 @@ func TestResponsesEmptyToolCallScaffold(t *testing.T) {
 		}
 	})
 
+	t.Run("web_search_call with non-empty action marks meaningful and forwards", func(t *testing.T) {
+		var detector StreamBootstrapDetector
+		if !detector.Observe(webSearchWithAction) {
+			t.Fatal("detector.Observe() = false for web_search_call with action, want true")
+		}
+		if !detector.HasMeaningfulOutput() {
+			t.Fatal("detector.HasMeaningfulOutput() = false for web_search_call with action, want true")
+		}
+	})
+
+	t.Run("computer_call with non-empty action marks meaningful and forwards", func(t *testing.T) {
+		var detector StreamBootstrapDetector
+		if !detector.Observe(computerCallWithAction) {
+			t.Fatal("detector.Observe() = false for computer_call with action, want true")
+		}
+		if !detector.HasMeaningfulOutput() {
+			t.Fatal("detector.HasMeaningfulOutput() = false for computer_call with action, want true")
+		}
+	})
+
+	t.Run("web_search_call with empty action does not mark meaningful and allows bootstrap error failover", func(t *testing.T) {
+		var detector StreamBootstrapDetector
+		if detector.Observe(webSearchWithEmptyAction) {
+			t.Fatal("detector.Observe() = true for web_search_call with empty action, want false")
+		}
+		if detector.HasMeaningfulOutput() {
+			t.Fatal("detector.HasMeaningfulOutput() = true for web_search_call with empty action, want false")
+		}
+	})
+
 	t.Run("output_item.done with empty function_call does not mark meaningful and allows bootstrap error failover", func(t *testing.T) {
 		emptyDoneFuncItems := [][]byte{
 			[]byte("event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\"}}\n\n"),
 			[]byte("event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"\",\"call_id\":\"\",\"name\":\"\"}}\n\n"),
 			[]byte("event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"output_index\":0,\"output\":{\"type\":\"function_call\"}}\n\n"),
 			[]byte("event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"custom_tool_call\"}}\n\n"),
+			[]byte("event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"call_123\",\"type\":\"web_search_call\",\"status\":\"completed\",\"action\":{}}}\n\n"),
+			[]byte("event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"call_123\",\"type\":\"computer_call\",\"status\":\"completed\",\"action\":null}}\n\n"),
 		}
 		for i, payload := range emptyDoneFuncItems {
 			var detector StreamBootstrapDetector


### PR DESCRIPTION
## Problem

1. **ID-Only Tool Call Scaffolds Suppress Failover**: OpenAI and Responses API streams can emit early tool-call deltas or output items containing only an `id` or `call_id` without a function name or arguments. Previously, `isMeaningfulToolCall` and `hasMeaningfulResponsesCallItem` treated any non-empty ID as meaningful output (`hasMeaningfulOutput() = true`). When an upstream stream encountered an error after this scaffold, `readStreamBootstrap` treated the stream as having successfully started (`bootstrapErr == nil`), suppressing model failover and returning an unusable empty tool call to the client.
2. **Responses API `action` Payloads Misclassified as Empty**: Responses API tool call items (such as `web_search_call` and `computer_call`) provide their payload in the `action` field instead of `arguments` or `input`. When ID-only matching was removed, these calls were incorrectly classified as empty completions and discarded.

## Fix

- `sdk/cliproxy/auth/empty_completion.go:271`: In `isMeaningfulToolCall`, removed the check on `call.ID` so ID-only scaffolds without function name or arguments are not marked meaningful.
- `sdk/cliproxy/auth/empty_completion.go:384`: Added `Action json.RawMessage` to `openAIResponseOutputItem`.
- `sdk/cliproxy/auth/empty_completion.go:772`: In `hasMeaningfulResponsesCallItem`, removed `item.ID` / `item.CallID` checks and added `nonEmptyJSONPayload(item.Action)` to correctly recognize `web_search_call` and `computer_call` output items as meaningful.

## Tests

- `TestToolCallIDOnlyRegression`: Verifies that ID-only tool call fragments in both OpenAI and Responses API formats are treated as empty (allowing upstream failover), while fragments with function names, arguments, or action payloads are recognized as meaningful.
- `TestEmptyCompletionPredicate`: Extensively tests payload predicates across OpenAI, Responses API, Gemini, and Claude formats for ID-only vs meaningful tool calls and actions.

## Reverse bite-check

Reverting `sdk/cliproxy/auth/empty_completion.go` to the pre-fix state reproduces the failure where ID-only tool calls are misclassified as meaningful:

```
=== RUN   TestToolCallIDOnlyRegression
=== RUN   TestToolCallIDOnlyRegression/openai_tool_call_id_only_is_empty_and_not_meaningful
    empty_completion_test.go:3278: StreamBootstrapDetector.Observe() = true for id-only tool_call, want false
=== RUN   TestToolCallIDOnlyRegression/openai_tool_call_with_name_is_meaningful_and_forwards
=== RUN   TestToolCallIDOnlyRegression/openai_tool_call_with_name_and_empty_object_arguments_is_meaningful_and_forwards
=== RUN   TestToolCallIDOnlyRegression/responses_api_function_call_id_only_is_empty_and_not_meaningful
    empty_completion_test.go:3331: StreamBootstrapDetector.Observe() = true for Responses function_call id only, want false
=== RUN   TestToolCallIDOnlyRegression/responses_api_function_call_with_name_is_meaningful_and_forwards
=== RUN   TestToolCallIDOnlyRegression/responses_api_function_call_with_name_and_empty_object_arguments_is_meaningful_and_forwards
--- FAIL: TestToolCallIDOnlyRegression (0.00s)
    --- FAIL: TestToolCallIDOnlyRegression/openai_tool_call_id_only_is_empty_and_not_meaningful (0.00s)
    --- PASS: TestToolCallIDOnlyRegression/openai_tool_call_with_name_is_meaningful_and_forwards (0.00s)
    --- PASS: TestToolCallIDOnlyRegression/openai_tool_call_with_name_and_empty_object_arguments_is_meaningful_and_forwards (0.00s)
    --- FAIL: TestToolCallIDOnlyRegression/responses_api_function_call_id_only_is_empty_and_not_meaningful (0.00s)
    --- PASS: TestToolCallIDOnlyRegression/responses_api_function_call_with_name_is_meaningful_and_forwards (0.00s)
    --- PASS: TestToolCallIDOnlyRegression/responses_api_function_call_with_name_and_empty_object_arguments_is_meaningful_and_forwards (0.00s)
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth	0.457s
FAIL
```

## Verification

```bash
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go build ./...
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go vet ./sdk/cliproxy/auth/...
gofmt -l sdk/cliproxy/auth/empty_completion.go sdk/cliproxy/auth/empty_completion_test.go
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go test -v -run "TestToolCallIDOnlyRegression" ./sdk/cliproxy/auth/...
```

Output:
```
=== RUN   TestToolCallIDOnlyRegression
=== RUN   TestToolCallIDOnlyRegression/openai_tool_call_id_only_is_empty_and_not_meaningful
=== RUN   TestToolCallIDOnlyRegression/openai_tool_call_with_name_is_meaningful_and_forwards
=== RUN   TestToolCallIDOnlyRegression/openai_tool_call_with_name_and_empty_object_arguments_is_meaningful_and_forwards
=== RUN   TestToolCallIDOnlyRegression/responses_api_function_call_id_only_is_empty_and_not_meaningful
=== RUN   TestToolCallIDOnlyRegression/responses_api_function_call_with_name_is_meaningful_and_forwards
=== RUN   TestToolCallIDOnlyRegression/responses_api_function_call_with_name_and_empty_object_arguments_is_meaningful_and_forwards
--- PASS: TestToolCallIDOnlyRegression (0.00s)
    --- PASS: TestToolCallIDOnlyRegression/openai_tool_call_id_only_is_empty_and_not_meaningful (0.00s)
    --- PASS: TestToolCallIDOnlyRegression/openai_tool_call_with_name_is_meaningful_and_forwards (0.00s)
    --- PASS: TestToolCallIDOnlyRegression/openai_tool_call_with_name_and_empty_object_arguments_is_meaningful_and_forwards (0.00s)
    --- PASS: TestToolCallIDOnlyRegression/responses_api_function_call_id_only_is_empty_and_not_meaningful (0.00s)
    --- PASS: TestToolCallIDOnlyRegression/responses_api_function_call_with_name_is_meaningful_and_forwards (0.00s)
    --- PASS: TestToolCallIDOnlyRegression/responses_api_function_call_with_name_and_empty_object_arguments_is_meaningful_and_forwards (0.00s)
PASS
ok  	github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth	0.442s
```

### Tooling note

The `jbcontext` semantic-search CLI is installed but non-functional in this environment
(`jbcontext search` fails with `the OS keychain is not accessible`). The equivalent
review passes were performed with the repository's own tooling and manual inspection
instead; this is disclosed for transparency about how the change was reviewed.
