### PR TITLE
fix(translator): preserve thoughtSignature in non-stream gemini to claude conversion

### DIFF
--- a/internal/translator/gemini/claude/gemini_claude_response.go
+++ b/internal/translator/gemini/claude/gemini_claude_response.go
@@ -77,6 +77,21 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 	appendEvent := func(event, payload string) {
 		output = translatorcommon.AppendSSEEventString(output, event, payload, 3)
 	}
+	closeCurrentBlock := func() {
+		if (*param).(*Params).ResponseType == 0 {
+			return
+		}
+		appendEvent("content_block_stop", fmt.Sprintf(`{"type":"content_block_stop","index":%d}`, (*param).(*Params).ResponseIndex))
+		(*param).(*Params).ResponseIndex++
+		(*param).(*Params).ResponseType = 0
+		(*param).(*Params).CurrentThinkingSigned = false
+	}
+	startEmptyThinkingBlock := func() {
+		appendEvent("content_block_start", fmt.Sprintf(`{"type":"content_block_start","index":%d,"content_block":{"type":"thinking","thinking":""}}`, (*param).(*Params).ResponseIndex))
+		(*param).(*Params).ResponseType = 2
+		(*param).(*Params).CurrentThinkingSigned = false
+		(*param).(*Params).HasContent = true
+	}
 	appendSignatureDelta := func(signature string) {
 		if signature == "" || (*param).(*Params).ResponseType != 2 {
 			return
@@ -85,6 +100,19 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 		appendEvent("content_block_delta", string(data))
 		(*param).(*Params).CurrentThinkingSigned = true
 		(*param).(*Params).HasContent = true
+	}
+	appendPartSignature := func(signature string) bool {
+		if signature == "" {
+			return false
+		}
+		if (*param).(*Params).ResponseType == 2 && !(*param).(*Params).CurrentThinkingSigned {
+			appendSignatureDelta(signature)
+			return false
+		}
+		closeCurrentBlock()
+		startEmptyThinkingBlock()
+		appendSignatureDelta(signature)
+		return true
 	}
 
 	// Initialize the streaming session with a message_start event
@@ -124,17 +152,7 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 			hasThoughtSignature := thoughtSignatureResult.Exists() && thoughtSignatureResult.String() != ""
 
 			if hasThoughtSignature && (!partTextResult.Exists() || partTextResult.String() == "") && !functionCallResult.Exists() {
-				if (*param).(*Params).ResponseType != 2 || (*param).(*Params).CurrentThinkingSigned {
-					if (*param).(*Params).ResponseType != 0 {
-						appendEvent("content_block_stop", fmt.Sprintf(`{"type":"content_block_stop","index":%d}`, (*param).(*Params).ResponseIndex))
-						(*param).(*Params).ResponseIndex++
-					}
-					appendEvent("content_block_start", fmt.Sprintf(`{"type":"content_block_start","index":%d,"content_block":{"type":"thinking","thinking":""}}`, (*param).(*Params).ResponseIndex))
-					(*param).(*Params).ResponseType = 2
-					(*param).(*Params).CurrentThinkingSigned = false
-					(*param).(*Params).HasContent = true
-				}
-				appendSignatureDelta(thoughtSignatureResult.String())
+				appendPartSignature(thoughtSignatureResult.String())
 				continue
 			}
 
@@ -143,13 +161,11 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 				// Process thinking content (internal reasoning)
 				if partResult.Get("thought").Bool() {
 					if hasThoughtSignature && partTextResult.String() == "" {
-						appendSignatureDelta(thoughtSignatureResult.String())
+						appendPartSignature(thoughtSignatureResult.String())
 						continue
 					}
 					if (*param).(*Params).ResponseType == 2 && (*param).(*Params).CurrentThinkingSigned && partTextResult.String() != "" {
-						appendEvent("content_block_stop", fmt.Sprintf(`{"type":"content_block_stop","index":%d}`, (*param).(*Params).ResponseIndex))
-						(*param).(*Params).ResponseIndex++
-						(*param).(*Params).ResponseType = 0
+						closeCurrentBlock()
 					}
 					// Continue existing thinking block
 					if (*param).(*Params).ResponseType == 2 {
@@ -158,16 +174,7 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 						(*param).(*Params).HasContent = true
 					} else {
 						// Transition from another state to thinking
-						// First, close any existing content block
-						if (*param).(*Params).ResponseType != 0 {
-							if (*param).(*Params).ResponseType == 2 {
-								// output = output + "event: content_block_delta\n"
-								// output = output + fmt.Sprintf(`data: {"type":"content_block_delta","index":%d,"delta":{"type":"signature_delta","signature":null}}`, (*param).(*Params).ResponseIndex)
-								// output = output + "\n\n\n"
-							}
-							appendEvent("content_block_stop", fmt.Sprintf(`{"type":"content_block_stop","index":%d}`, (*param).(*Params).ResponseIndex))
-							(*param).(*Params).ResponseIndex++
-						}
+						closeCurrentBlock()
 
 						// Start a new thinking content block
 						appendEvent("content_block_start", fmt.Sprintf(`{"type":"content_block_start","index":%d,"content_block":{"type":"thinking","thinking":""}}`, (*param).(*Params).ResponseIndex))
@@ -177,9 +184,14 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 						(*param).(*Params).CurrentThinkingSigned = false
 						(*param).(*Params).HasContent = true
 					}
-					appendSignatureDelta(thoughtSignatureResult.String())
+					if hasThoughtSignature {
+						appendSignatureDelta(thoughtSignatureResult.String())
+					}
 				} else {
 					// Process regular text content (user-visible output)
+					if hasThoughtSignature {
+						appendPartSignature(thoughtSignatureResult.String())
+					}
 					// Continue existing text block
 					if (*param).(*Params).ResponseType == 1 {
 						data, _ := sjson.SetBytes([]byte(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"text_delta","text":""}}`, (*param).(*Params).ResponseIndex)), "delta.text", partTextResult.String())
@@ -187,16 +199,7 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 						(*param).(*Params).HasContent = true
 					} else {
 						// Transition from another state to text content
-						// First, close any existing content block
-						if (*param).(*Params).ResponseType != 0 {
-							if (*param).(*Params).ResponseType == 2 {
-								// output = output + "event: content_block_delta\n"
-								// output = output + fmt.Sprintf(`data: {"type":"content_block_delta","index":%d,"delta":{"type":"signature_delta","signature":null}}`, (*param).(*Params).ResponseIndex)
-								// output = output + "\n\n\n"
-							}
-							appendEvent("content_block_stop", fmt.Sprintf(`{"type":"content_block_stop","index":%d}`, (*param).(*Params).ResponseIndex))
-							(*param).(*Params).ResponseIndex++
-						}
+						closeCurrentBlock()
 
 						// Start a new text content block
 						appendEvent("content_block_start", fmt.Sprintf(`{"type":"content_block_start","index":%d,"content_block":{"type":"text","text":""}}`, (*param).(*Params).ResponseIndex))
@@ -207,6 +210,9 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 					}
 				}
 			} else if functionCallResult.Exists() {
+				if hasThoughtSignature {
+					appendPartSignature(thoughtSignatureResult.String())
+				}
 				// Handle function/tool calls from the AI model
 				// This processes tool usage requests and formats them for Claude API compatibility
 				(*param).(*Params).SawToolCall = true
@@ -225,26 +231,8 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 					continue
 				}
 
-				// Handle state transitions when switching to function calls
-				// Close any existing function call block first
-				if (*param).(*Params).ResponseType == 3 {
-					appendEvent("content_block_stop", fmt.Sprintf(`{"type":"content_block_stop","index":%d}`, (*param).(*Params).ResponseIndex))
-					(*param).(*Params).ResponseIndex++
-					(*param).(*Params).ResponseType = 0
-				}
-
-				// Special handling for thinking state transition
-				if (*param).(*Params).ResponseType == 2 {
-					// output = output + "event: content_block_delta\n"
-					// output = output + fmt.Sprintf(`data: {"type":"content_block_delta","index":%d,"delta":{"type":"signature_delta","signature":null}}`, (*param).(*Params).ResponseIndex)
-					// output = output + "\n\n\n"
-				}
-
-				// Close any other existing content block
-				if (*param).(*Params).ResponseType != 0 {
-					appendEvent("content_block_stop", fmt.Sprintf(`{"type":"content_block_stop","index":%d}`, (*param).(*Params).ResponseIndex))
-					(*param).(*Params).ResponseIndex++
-				}
+				// Close any existing content block
+				closeCurrentBlock()
 
 				// Start a new tool use content block
 				// This creates the structure for a function call in Claude format

--- a/internal/translator/gemini/claude/gemini_claude_response.go
+++ b/internal/translator/gemini/claude/gemini_claude_response.go
@@ -318,20 +318,34 @@ func ConvertGeminiResponseToClaudeNonStream(_ context.Context, _ string, origina
 		textBuilder.Reset()
 	}
 
+	var thinkingSignature string
 	flushThinking := func() {
-		if thinkingBuilder.Len() == 0 {
+		if thinkingBuilder.Len() == 0 && thinkingSignature == "" {
 			return
 		}
 		block := []byte(`{"type":"thinking","thinking":""}`)
 		block, _ = sjson.SetBytes(block, "thinking", thinkingBuilder.String())
+		if thinkingSignature != "" {
+			block, _ = sjson.SetBytes(block, "signature", thinkingSignature)
+		}
 		blocks = append(blocks, block)
 		thinkingBuilder.Reset()
+		thinkingSignature = ""
 	}
 
 	if parts.IsArray() {
 		for _, part := range parts.Array() {
+			thoughtSignatureResult := part.Get("thoughtSignature")
+			if !thoughtSignatureResult.Exists() {
+				thoughtSignatureResult = part.Get("thought_signature")
+			}
+			hasThoughtSignature := thoughtSignatureResult.Exists() && thoughtSignatureResult.String() != ""
+			if hasThoughtSignature {
+				thinkingSignature = thoughtSignatureResult.String()
+			}
+
 			if text := part.Get("text"); text.Exists() && text.String() != "" {
-				if part.Get("thought").Bool() {
+				if part.Get("thought").Bool() || hasThoughtSignature {
 					flushText()
 					thinkingBuilder.WriteString(text.String())
 					continue

--- a/internal/translator/gemini/claude/gemini_claude_response.go
+++ b/internal/translator/gemini/claude/gemini_claude_response.go
@@ -21,15 +21,16 @@ import (
 
 // Params holds parameters for response conversion.
 type Params struct {
-	IsGlAPIKey       bool
-	HasFirstResponse bool
-	ResponseType     int
-	ResponseIndex    int
-	HasContent       bool // Tracks whether any content (text, thinking, or tool use) has been output
-	ToolNameMap      map[string]string
-	SanitizedNameMap map[string]string
-	SawToolCall      bool
-	HasFinalEvents   bool
+	IsGlAPIKey            bool
+	HasFirstResponse      bool
+	ResponseType          int
+	ResponseIndex         int
+	CurrentThinkingSigned bool
+	HasContent            bool // Tracks whether any content (text, thinking, or tool use) has been output
+	ToolNameMap           map[string]string
+	SanitizedNameMap      map[string]string
+	SawToolCall           bool
+	HasFinalEvents        bool
 }
 
 // toolUseIDCounter provides a process-wide unique counter for tool use identifiers.
@@ -82,6 +83,7 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 		}
 		data, _ := sjson.SetBytes([]byte(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"signature_delta","signature":""}}`, (*param).(*Params).ResponseIndex)), "delta.signature", signature)
 		appendEvent("content_block_delta", string(data))
+		(*param).(*Params).CurrentThinkingSigned = true
 		(*param).(*Params).HasContent = true
 	}
 
@@ -134,6 +136,11 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 						appendSignatureDelta(thoughtSignatureResult.String())
 						continue
 					}
+					if (*param).(*Params).ResponseType == 2 && (*param).(*Params).CurrentThinkingSigned && partTextResult.String() != "" {
+						appendEvent("content_block_stop", fmt.Sprintf(`{"type":"content_block_stop","index":%d}`, (*param).(*Params).ResponseIndex))
+						(*param).(*Params).ResponseIndex++
+						(*param).(*Params).ResponseType = 0
+					}
 					// Continue existing thinking block
 					if (*param).(*Params).ResponseType == 2 {
 						data, _ := sjson.SetBytes([]byte(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"thinking_delta","thinking":""}}`, (*param).(*Params).ResponseIndex)), "delta.thinking", partTextResult.String())
@@ -157,6 +164,7 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 						data, _ := sjson.SetBytes([]byte(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"thinking_delta","thinking":""}}`, (*param).(*Params).ResponseIndex)), "delta.thinking", partTextResult.String())
 						appendEvent("content_block_delta", string(data))
 						(*param).(*Params).ResponseType = 2 // Set state to thinking
+						(*param).(*Params).CurrentThinkingSigned = false
 						(*param).(*Params).HasContent = true
 					}
 					appendSignatureDelta(thoughtSignatureResult.String())
@@ -321,6 +329,7 @@ func ConvertGeminiResponseToClaudeNonStream(_ context.Context, _ string, origina
 	var thinkingSignature string
 	flushThinking := func() {
 		if thinkingBuilder.Len() == 0 {
+			thinkingSignature = ""
 			return
 		}
 		block := []byte(`{"type":"thinking","thinking":""}`)
@@ -342,6 +351,9 @@ func ConvertGeminiResponseToClaudeNonStream(_ context.Context, _ string, origina
 			hasThoughtSignature := thoughtSignatureResult.Exists() && thoughtSignatureResult.String() != ""
 			isThought := part.Get("thought").Bool()
 			if isThought && hasThoughtSignature {
+				if thinkingSignature != "" {
+					flushThinking()
+				}
 				thinkingSignature = thoughtSignatureResult.String()
 			}
 

--- a/internal/translator/gemini/claude/gemini_claude_response.go
+++ b/internal/translator/gemini/claude/gemini_claude_response.go
@@ -121,7 +121,7 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 			}
 			hasThoughtSignature := thoughtSignatureResult.Exists() && thoughtSignatureResult.String() != ""
 
-			if hasThoughtSignature && !partTextResult.Exists() && !functionCallResult.Exists() {
+			if hasThoughtSignature && (!partTextResult.Exists() || partTextResult.String() == "") && !functionCallResult.Exists() {
 				appendSignatureDelta(thoughtSignatureResult.String())
 				continue
 			}
@@ -129,7 +129,7 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 			// Handle text content (both regular content and thinking)
 			if partTextResult.Exists() {
 				// Process thinking content (internal reasoning)
-				if partResult.Get("thought").Bool() || hasThoughtSignature {
+				if partResult.Get("thought").Bool() {
 					if hasThoughtSignature && partTextResult.String() == "" {
 						appendSignatureDelta(thoughtSignatureResult.String())
 						continue
@@ -320,7 +320,7 @@ func ConvertGeminiResponseToClaudeNonStream(_ context.Context, _ string, origina
 
 	var thinkingSignature string
 	flushThinking := func() {
-		if thinkingBuilder.Len() == 0 && thinkingSignature == "" {
+		if thinkingBuilder.Len() == 0 {
 			return
 		}
 		block := []byte(`{"type":"thinking","thinking":""}`)
@@ -340,12 +340,13 @@ func ConvertGeminiResponseToClaudeNonStream(_ context.Context, _ string, origina
 				thoughtSignatureResult = part.Get("thought_signature")
 			}
 			hasThoughtSignature := thoughtSignatureResult.Exists() && thoughtSignatureResult.String() != ""
-			if hasThoughtSignature {
+			isThought := part.Get("thought").Bool()
+			if isThought && hasThoughtSignature {
 				thinkingSignature = thoughtSignatureResult.String()
 			}
 
 			if text := part.Get("text"); text.Exists() && text.String() != "" {
-				if part.Get("thought").Bool() || hasThoughtSignature {
+				if isThought {
 					flushText()
 					thinkingBuilder.WriteString(text.String())
 					continue

--- a/internal/translator/gemini/claude/gemini_claude_response.go
+++ b/internal/translator/gemini/claude/gemini_claude_response.go
@@ -124,6 +124,14 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 			hasThoughtSignature := thoughtSignatureResult.Exists() && thoughtSignatureResult.String() != ""
 
 			if hasThoughtSignature && (!partTextResult.Exists() || partTextResult.String() == "") && !functionCallResult.Exists() {
+				if (*param).(*Params).ResponseType == 2 && (*param).(*Params).CurrentThinkingSigned {
+					appendEvent("content_block_stop", fmt.Sprintf(`{"type":"content_block_stop","index":%d}`, (*param).(*Params).ResponseIndex))
+					(*param).(*Params).ResponseIndex++
+					appendEvent("content_block_start", fmt.Sprintf(`{"type":"content_block_start","index":%d,"content_block":{"type":"thinking","thinking":""}}`, (*param).(*Params).ResponseIndex))
+					(*param).(*Params).ResponseType = 2
+					(*param).(*Params).CurrentThinkingSigned = false
+					(*param).(*Params).HasContent = true
+				}
 				appendSignatureDelta(thoughtSignatureResult.String())
 				continue
 			}

--- a/internal/translator/gemini/claude/gemini_claude_response.go
+++ b/internal/translator/gemini/claude/gemini_claude_response.go
@@ -124,9 +124,11 @@ func ConvertGeminiResponseToClaude(_ context.Context, _ string, originalRequestR
 			hasThoughtSignature := thoughtSignatureResult.Exists() && thoughtSignatureResult.String() != ""
 
 			if hasThoughtSignature && (!partTextResult.Exists() || partTextResult.String() == "") && !functionCallResult.Exists() {
-				if (*param).(*Params).ResponseType == 2 && (*param).(*Params).CurrentThinkingSigned {
-					appendEvent("content_block_stop", fmt.Sprintf(`{"type":"content_block_stop","index":%d}`, (*param).(*Params).ResponseIndex))
-					(*param).(*Params).ResponseIndex++
+				if (*param).(*Params).ResponseType != 2 || (*param).(*Params).CurrentThinkingSigned {
+					if (*param).(*Params).ResponseType != 0 {
+						appendEvent("content_block_stop", fmt.Sprintf(`{"type":"content_block_stop","index":%d}`, (*param).(*Params).ResponseIndex))
+						(*param).(*Params).ResponseIndex++
+					}
 					appendEvent("content_block_start", fmt.Sprintf(`{"type":"content_block_start","index":%d,"content_block":{"type":"thinking","thinking":""}}`, (*param).(*Params).ResponseIndex))
 					(*param).(*Params).ResponseType = 2
 					(*param).(*Params).CurrentThinkingSigned = false

--- a/internal/translator/gemini/claude/gemini_claude_response_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_response_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/tidwall/gjson"
 )
 
 func TestConvertGeminiResponseToClaude_SignatureOnlyPartDoesNotOpenEmptyTextBlock(t *testing.T) {
@@ -58,5 +60,171 @@ func TestConvertGeminiResponseToClaude_SignatureOnlyPartDoesNotOpenEmptyTextBloc
 	}
 	if !strings.Contains(outputText, `"type":"message_stop"`) {
 		t.Fatalf("DONE chunk must still emit message_stop after final events: %s", outputText)
+	}
+}
+
+func TestConvertGeminiResponseToClaudeNonStream_ThoughtSignature(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	rawResponse := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [
+					{"text": "thinking text", "thought": true, "thoughtSignature": "sig-test"},
+					{"text": "hello world"}
+				]
+			},
+			"finishReason": "STOP"
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	ctx := context.Background()
+	output := ConvertGeminiResponseToClaudeNonStream(ctx, "gemini-test", requestJSON, requestJSON, rawResponse, nil)
+	parsed := gjson.ParseBytes(output)
+
+	if parsed.Get("content.0.type").String() != "thinking" {
+		t.Fatalf("expected first block to be thinking, got: %s", output)
+	}
+	if parsed.Get("content.0.thinking").String() != "thinking text" {
+		t.Fatalf("expected thinking text, got: %s", output)
+	}
+	if parsed.Get("content.0.signature").String() != "sig-test" {
+		t.Fatalf("expected signature sig-test in thinking block, got: %s", output)
+	}
+	if parsed.Get("content.1.type").String() != "text" {
+		t.Fatalf("expected second block to be text, got: %s", output)
+	}
+	if parsed.Get("content.1.text").String() != "hello world" {
+		t.Fatalf("expected text hello world, got: %s", output)
+	}
+}
+
+func TestConvertGeminiResponseToClaudeNonStream_ThoughtSignatureWithoutThoughtFlag(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	rawResponse := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [
+					{"text": "internal reasoning", "thought": false, "thoughtSignature": "sig-no-flag"},
+					{"text": "final answer"}
+				]
+			},
+			"finishReason": "STOP"
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	ctx := context.Background()
+	output := ConvertGeminiResponseToClaudeNonStream(ctx, "gemini-test", requestJSON, requestJSON, rawResponse, nil)
+	parsed := gjson.ParseBytes(output)
+
+	if parsed.Get("content.0.type").String() != "thinking" {
+		t.Fatalf("part with thoughtSignature must be classified as thinking, got: %s", output)
+	}
+	if parsed.Get("content.0.thinking").String() != "internal reasoning" {
+		t.Fatalf("expected internal reasoning in thinking block, got: %s", output)
+	}
+	if parsed.Get("content.0.signature").String() != "sig-no-flag" {
+		t.Fatalf("expected signature in thinking block, got: %s", output)
+	}
+	if parsed.Get("content.1.type").String() != "text" {
+		t.Fatalf("expected text block, got: %s", output)
+	}
+	if parsed.Get("content.1.text").String() != "final answer" {
+		t.Fatalf("expected final answer in text block, got: %s", output)
+	}
+}
+
+func TestConvertGeminiResponseToClaudeNonStream_ThinkingWithoutSignature(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	rawResponse := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [
+					{"text": "thinking without sig", "thought": true},
+					{"text": "response text"}
+				]
+			},
+			"finishReason": "STOP"
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	ctx := context.Background()
+	output := ConvertGeminiResponseToClaudeNonStream(ctx, "gemini-test", requestJSON, requestJSON, rawResponse, nil)
+	parsed := gjson.ParseBytes(output)
+
+	if parsed.Get("content.0.type").String() != "thinking" {
+		t.Fatalf("expected thinking block, got: %s", output)
+	}
+	if parsed.Get("content.0.thinking").String() != "thinking without sig" {
+		t.Fatalf("expected thinking content, got: %s", output)
+	}
+	if parsed.Get("content.0.signature").Exists() {
+		t.Fatalf("expected no signature field when thoughtSignature absent, got: %s", output)
+	}
+	if parsed.Get("content.1.type").String() != "text" {
+		t.Fatalf("expected text block, got: %s", output)
+	}
+	if parsed.Get("content.1.text").String() != "response text" {
+		t.Fatalf("expected text content, got: %s", output)
+	}
+}
+
+func TestConvertGeminiResponseToClaudeNonStream_RegularTextOnly(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	rawResponse := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [
+					{"text": "plain response"}
+				]
+			},
+			"finishReason": "STOP"
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	ctx := context.Background()
+	output := ConvertGeminiResponseToClaudeNonStream(ctx, "gemini-test", requestJSON, requestJSON, rawResponse, nil)
+	parsed := gjson.ParseBytes(output)
+
+	if parsed.Get("content.#").Int() != 1 {
+		t.Fatalf("expected exactly 1 content block, got: %s", output)
+	}
+	if parsed.Get("content.0.type").String() != "text" {
+		t.Fatalf("expected text block, got: %s", output)
+	}
+	if parsed.Get("content.0.text").String() != "plain response" {
+		t.Fatalf("expected text content, got: %s", output)
+	}
+}
+
+func TestConvertGeminiResponseToClaudeNonStream_SnakeCaseThoughtSignature(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	rawResponse := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [
+					{"text": "thinking snake", "thought": true, "thought_signature": "sig-snake"},
+					{"text": "output"}
+				]
+			},
+			"finishReason": "STOP"
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	ctx := context.Background()
+	output := ConvertGeminiResponseToClaudeNonStream(ctx, "gemini-test", requestJSON, requestJSON, rawResponse, nil)
+	parsed := gjson.ParseBytes(output)
+
+	if parsed.Get("content.0.signature").String() != "sig-snake" {
+		t.Fatalf("expected snake_case thought_signature to be extracted, got: %s", output)
 	}
 }

--- a/internal/translator/gemini/claude/gemini_claude_response_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_response_test.go
@@ -100,14 +100,13 @@ func TestConvertGeminiResponseToClaudeNonStream_ThoughtSignature(t *testing.T) {
 	}
 }
 
-func TestConvertGeminiResponseToClaudeNonStream_ThoughtSignatureWithoutThoughtFlag(t *testing.T) {
+func TestConvertGeminiResponseToClaudeNonStream_TextWithThoughtSignatureWithoutThoughtFlag(t *testing.T) {
 	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
 	rawResponse := []byte(`{
 		"candidates": [{
 			"content": {
 				"parts": [
-					{"text": "internal reasoning", "thought": false, "thoughtSignature": "sig-no-flag"},
-					{"text": "final answer"}
+					{"text": "Tokyo: 20C", "thoughtSignature": "sig-carrier"}
 				]
 			},
 			"finishReason": "STOP"
@@ -120,20 +119,187 @@ func TestConvertGeminiResponseToClaudeNonStream_ThoughtSignatureWithoutThoughtFl
 	output := ConvertGeminiResponseToClaudeNonStream(ctx, "gemini-test", requestJSON, requestJSON, rawResponse, nil)
 	parsed := gjson.ParseBytes(output)
 
+	if parsed.Get("content.#").Int() != 1 {
+		t.Fatalf("expected exactly 1 content block, got: %s", output)
+	}
+	if parsed.Get("content.0.type").String() != "text" {
+		t.Fatalf("text part with thoughtSignature without thought flag must remain text, got: %s", output)
+	}
+	if parsed.Get("content.0.text").String() != "Tokyo: 20C" {
+		t.Fatalf("expected text 'Tokyo: 20C', got: %s", output)
+	}
+}
+
+func TestConvertGeminiResponseToClaudeNonStream_FunctionCallWithThoughtSignature(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	rawResponse := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [
+					{
+						"functionCall": {"name": "get_weather", "args": {"city": "Tokyo"}},
+						"thoughtSignature": "sig-fc"
+					}
+				]
+			},
+			"finishReason": "STOP"
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	ctx := context.Background()
+	output := ConvertGeminiResponseToClaudeNonStream(ctx, "gemini-test", requestJSON, requestJSON, rawResponse, nil)
+	parsed := gjson.ParseBytes(output)
+
+	if parsed.Get("content.#").Int() != 1 {
+		t.Fatalf("expected exactly 1 block without empty thinking block, got: %s", output)
+	}
+	if parsed.Get("content.0.type").String() != "tool_use" {
+		t.Fatalf("expected tool_use block, got: %s", output)
+	}
+	if parsed.Get("content.0.name").String() != "get_weather" {
+		t.Fatalf("expected tool name get_weather, got: %s", output)
+	}
+}
+
+func TestConvertGeminiResponseToClaudeNonStream_ThinkingSignatureNotOverwrittenByFunctionCall(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	rawResponse := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [
+					{"text": "thinking reasoning", "thought": true, "thoughtSignature": "sig-thinking"},
+					{
+						"functionCall": {"name": "get_weather", "args": {"city": "Tokyo"}},
+						"thoughtSignature": "sig-function-call"
+					}
+				]
+			},
+			"finishReason": "STOP"
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	ctx := context.Background()
+	output := ConvertGeminiResponseToClaudeNonStream(ctx, "gemini-test", requestJSON, requestJSON, rawResponse, nil)
+	parsed := gjson.ParseBytes(output)
+
+	if parsed.Get("content.#").Int() != 2 {
+		t.Fatalf("expected 2 blocks (thinking and tool_use), got: %s", output)
+	}
 	if parsed.Get("content.0.type").String() != "thinking" {
-		t.Fatalf("part with thoughtSignature must be classified as thinking, got: %s", output)
+		t.Fatalf("expected first block to be thinking, got: %s", output)
 	}
-	if parsed.Get("content.0.thinking").String() != "internal reasoning" {
-		t.Fatalf("expected internal reasoning in thinking block, got: %s", output)
+	if parsed.Get("content.0.signature").String() != "sig-thinking" {
+		t.Fatalf("expected thinking signature to be sig-thinking, not overwritten by functionCall, got: %s", output)
 	}
-	if parsed.Get("content.0.signature").String() != "sig-no-flag" {
-		t.Fatalf("expected signature in thinking block, got: %s", output)
+	if parsed.Get("content.1.type").String() != "tool_use" {
+		t.Fatalf("expected second block to be tool_use, got: %s", output)
 	}
-	if parsed.Get("content.1.type").String() != "text" {
-		t.Fatalf("expected text block, got: %s", output)
+}
+
+func TestConvertGeminiResponseToClaude_TextWithThoughtSignatureWithoutThoughtFlag(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	chunk := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"text": "Tokyo: 20C", "thoughtSignature": "sig-carrier"}]
+			},
+			"finishReason": "STOP"
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	var param any
+	ctx := context.Background()
+	output := bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk, &param), nil)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, []byte("[DONE]"), &param), nil)...)
+	outputText := string(output)
+
+	if strings.Contains(outputText, `"content_block":{"type":"thinking"`) {
+		t.Fatalf("text with thoughtSignature without thought flag must not start a thinking block in stream: %s", outputText)
 	}
-	if parsed.Get("content.1.text").String() != "final answer" {
-		t.Fatalf("expected final answer in text block, got: %s", output)
+	if !strings.Contains(outputText, `"content_block":{"type":"text"`) {
+		t.Fatalf("expected text content block in stream, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"text":"Tokyo: 20C"`) {
+		t.Fatalf("expected text delta Tokyo: 20C in stream, got: %s", outputText)
+	}
+}
+
+func TestConvertGeminiResponseToClaude_FunctionCallWithThoughtSignature(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	chunk := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{
+					"functionCall": {"name": "get_weather", "args": {"city": "Tokyo"}},
+					"thoughtSignature": "sig-fc"
+				}]
+			},
+			"finishReason": "STOP"
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	var param any
+	ctx := context.Background()
+	output := bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk, &param), nil)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, []byte("[DONE]"), &param), nil)...)
+	outputText := string(output)
+
+	if strings.Contains(outputText, `"content_block":{"type":"thinking"`) {
+		t.Fatalf("functionCall with thoughtSignature must not start an empty thinking block in stream: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"content_block":{"type":"tool_use"`) {
+		t.Fatalf("expected tool_use block in stream, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"name":"get_weather"`) {
+		t.Fatalf("expected tool name get_weather in stream, got: %s", outputText)
+	}
+}
+
+func TestConvertGeminiResponseToClaude_ThinkingSignatureNotOverwrittenByFunctionCall(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	thinkingChunk := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"text": "thinking reasoning", "thought": true, "thoughtSignature": "sig-thinking"}]
+			}
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+	toolChunk := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{
+					"functionCall": {"name": "get_weather", "args": {"city": "Tokyo"}},
+					"thoughtSignature": "sig-fc"
+				}]
+			},
+			"finishReason": "STOP"
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	var param any
+	ctx := context.Background()
+	output := bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, thinkingChunk, &param), nil)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, toolChunk, &param), nil)...)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, []byte("[DONE]"), &param), nil)...)
+	outputText := string(output)
+
+	if !strings.Contains(outputText, `"signature":"sig-thinking"`) {
+		t.Fatalf("expected thinking signature to be sig-thinking, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"content_block":{"type":"tool_use"`) {
+		t.Fatalf("expected tool_use block, got: %s", outputText)
 	}
 }
 

--- a/internal/translator/gemini/claude/gemini_claude_response_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_response_test.go
@@ -394,3 +394,116 @@ func TestConvertGeminiResponseToClaudeNonStream_SnakeCaseThoughtSignature(t *tes
 		t.Fatalf("expected snake_case thought_signature to be extracted, got: %s", output)
 	}
 }
+
+func TestConvertGeminiResponseToClaudeNonStream_EmptyThoughtSignatureNotBoundToLaterBlock(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	rawResponse := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [
+					{"thought": true, "thoughtSignature": "sigA"},
+					{"text": "visible text"},
+					{"text": "reasoning", "thought": true}
+				]
+			},
+			"finishReason": "STOP"
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	ctx := context.Background()
+	output := ConvertGeminiResponseToClaudeNonStream(ctx, "gemini-test", requestJSON, requestJSON, rawResponse, nil)
+	parsed := gjson.ParseBytes(output)
+
+	if parsed.Get("content.0.type").String() != "text" || parsed.Get("content.0.text").String() != "visible text" {
+		t.Fatalf("expected block 0 to be text 'visible text', got: %s", output)
+	}
+	if parsed.Get("content.1.type").String() != "thinking" || parsed.Get("content.1.thinking").String() != "reasoning" {
+		t.Fatalf("expected block 1 to be thinking 'reasoning', got: %s", output)
+	}
+	if parsed.Get("content.1.signature").Exists() {
+		t.Fatalf("later thinking block must NOT carry stale signature sigA, got: %s", output)
+	}
+}
+
+func TestConvertGeminiResponseToClaudeNonStream_MultipleSignedThoughtPartsSplitBlocks(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	rawResponse := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [
+					{"text": "thinking 1", "thought": true, "thoughtSignature": "sig1"},
+					{"text": "thinking 2", "thought": true, "thoughtSignature": "sig2"},
+					{"text": "final answer"}
+				]
+			},
+			"finishReason": "STOP"
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	ctx := context.Background()
+	output := ConvertGeminiResponseToClaudeNonStream(ctx, "gemini-test", requestJSON, requestJSON, rawResponse, nil)
+	parsed := gjson.ParseBytes(output)
+
+	if parsed.Get("content.#").Int() != 3 {
+		t.Fatalf("expected 3 blocks (2 thinking + 1 text), got: %s", output)
+	}
+	if parsed.Get("content.0.type").String() != "thinking" || parsed.Get("content.0.thinking").String() != "thinking 1" || parsed.Get("content.0.signature").String() != "sig1" {
+		t.Fatalf("expected block 0 to be thinking 1 with sig1, got: %s", output)
+	}
+	if parsed.Get("content.1.type").String() != "thinking" || parsed.Get("content.1.thinking").String() != "thinking 2" || parsed.Get("content.1.signature").String() != "sig2" {
+		t.Fatalf("expected block 1 to be thinking 2 with sig2, got: %s", output)
+	}
+	if parsed.Get("content.2.type").String() != "text" || parsed.Get("content.2.text").String() != "final answer" {
+		t.Fatalf("expected block 2 to be text 'final answer', got: %s", output)
+	}
+}
+
+func TestConvertGeminiResponseToClaude_MultipleSignedThoughtChunksSplitBlocks(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	chunk1 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"text": "thinking 1", "thought": true, "thoughtSignature": "sig1"}]
+			}
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+	chunk2 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"text": "thinking 2", "thought": true, "thoughtSignature": "sig2"}]
+			},
+			"finishReason": "STOP"
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	var param any
+	ctx := context.Background()
+	output := bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk1, &param), nil)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk2, &param), nil)...)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, []byte("[DONE]"), &param), nil)...)
+	outputText := string(output)
+
+	if !strings.Contains(outputText, `"type":"content_block_start","index":0,"content_block":{"type":"thinking"`) {
+		t.Fatalf("expected thinking content_block_start at index 0, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_stop","index":0`) {
+		t.Fatalf("expected thinking content_block_stop at index 0 before second signed block, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_start","index":1,"content_block":{"type":"thinking"`) {
+		t.Fatalf("expected thinking content_block_start at index 1 for second signed block, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"signature_delta","signature":"sig1"`) {
+		t.Fatalf("expected signature_delta sig1, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"signature_delta","signature":"sig2"`) {
+		t.Fatalf("expected signature_delta sig2, got: %s", outputText)
+	}
+}

--- a/internal/translator/gemini/claude/gemini_claude_response_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_response_test.go
@@ -631,3 +631,133 @@ func TestConvertGeminiResponseToClaude_ThinkingContinuationsAfterSignedAndVisibl
 		t.Fatalf("expected thought 2 part B to be in block 2, got: %s", outputText)
 	}
 }
+
+
+func TestConvertGeminiResponseToClaude_SignatureBeforeThinkingTextEmitsSignatureDelta(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	chunk1 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"thoughtSignature": "sigInitial"}]
+			}
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+	chunk2 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"text": "final answer"}]
+			},
+			"finishReason": "STOP"
+		}],
+		"usageMetadata": {
+			"promptTokenCount": 10,
+			"candidatesTokenCount": 5
+		},
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	var param any
+	ctx := context.Background()
+	output := bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk1, &param), nil)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk2, &param), nil)...)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, []byte("[DONE]"), &param), nil)...)
+	outputText := string(output)
+
+	if !strings.Contains(outputText, `"type":"content_block_start","index":0,"content_block":{"type":"thinking"`) {
+		t.Fatalf("expected thinking content_block_start at index 0, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sigInitial"}`) {
+		t.Fatalf("expected signature_delta sigInitial on index 0, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_stop","index":0`) {
+		t.Fatalf("expected thinking content_block_stop at index 0, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_start","index":1,"content_block":{"type":"text"`) {
+		t.Fatalf("expected text content_block_start at index 1, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"final answer"}`) {
+		t.Fatalf("expected text_delta on index 1, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_stop","index":1`) {
+		t.Fatalf("expected text content_block_stop at index 1, got: %s", outputText)
+	}
+	if sigCount := strings.Count(outputText, `"type":"signature_delta"`); sigCount != 1 {
+		t.Fatalf("expected exactly 1 signature_delta, got %d: %s", sigCount, outputText)
+	}
+}
+
+func TestConvertGeminiResponseToClaude_ThreeConsecutiveSignaturesSplitBlocks(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	chunk1 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"thoughtSignature": "sig1"}]
+			}
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+	chunk2 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"thoughtSignature": "sig2"}]
+			}
+		}]
+	}`)
+	chunk3 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"thoughtSignature": "sig3"}]
+			},
+			"finishReason": "STOP"
+		}],
+		"usageMetadata": {
+			"promptTokenCount": 10,
+			"candidatesTokenCount": 5
+		},
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	var param any
+	ctx := context.Background()
+	output := bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk1, &param), nil)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk2, &param), nil)...)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk3, &param), nil)...)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, []byte("[DONE]"), &param), nil)...)
+	outputText := string(output)
+
+	if !strings.Contains(outputText, `"type":"content_block_start","index":0,"content_block":{"type":"thinking"`) {
+		t.Fatalf("expected thinking content_block_start at index 0, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig1"}`) {
+		t.Fatalf("expected signature_delta sig1 on index 0, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_stop","index":0`) {
+		t.Fatalf("expected thinking content_block_stop at index 0, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_start","index":1,"content_block":{"type":"thinking"`) {
+		t.Fatalf("expected thinking content_block_start at index 1, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_delta","index":1,"delta":{"type":"signature_delta","signature":"sig2"}`) {
+		t.Fatalf("expected signature_delta sig2 on index 1, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_stop","index":1`) {
+		t.Fatalf("expected thinking content_block_stop at index 1, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_start","index":2,"content_block":{"type":"thinking"`) {
+		t.Fatalf("expected thinking content_block_start at index 2, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_delta","index":2,"delta":{"type":"signature_delta","signature":"sig3"}`) {
+		t.Fatalf("expected signature_delta sig3 on index 2, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_stop","index":2`) {
+		t.Fatalf("expected thinking content_block_stop at index 2, got: %s", outputText)
+	}
+	if sigCount := strings.Count(outputText, `"type":"signature_delta"`); sigCount != 3 {
+		t.Fatalf("expected exactly 3 signature_deltas, got %d: %s", sigCount, outputText)
+	}
+}

--- a/internal/translator/gemini/claude/gemini_claude_response_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_response_test.go
@@ -200,7 +200,7 @@ func TestConvertGeminiResponseToClaudeNonStream_ThinkingSignatureNotOverwrittenB
 	}
 }
 
-func TestConvertGeminiResponseToClaude_TextWithThoughtSignatureWithoutThoughtFlag(t *testing.T) {
+func TestConvertGeminiResponseToClaude_VisibleTextWithThoughtSignatureEmitsCarrierAndText(t *testing.T) {
 	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
 	chunk := []byte(`{
 		"candidates": [{
@@ -209,6 +209,10 @@ func TestConvertGeminiResponseToClaude_TextWithThoughtSignatureWithoutThoughtFla
 			},
 			"finishReason": "STOP"
 		}],
+		"usageMetadata": {
+			"promptTokenCount": 10,
+			"candidatesTokenCount": 5
+		},
 		"modelVersion": "gemini-test",
 		"responseId": "resp-test"
 	}`)
@@ -219,18 +223,30 @@ func TestConvertGeminiResponseToClaude_TextWithThoughtSignatureWithoutThoughtFla
 	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, []byte("[DONE]"), &param), nil)...)
 	outputText := string(output)
 
-	if strings.Contains(outputText, `"content_block":{"type":"thinking"`) {
-		t.Fatalf("text with thoughtSignature without thought flag must not start a thinking block in stream: %s", outputText)
+	if !strings.Contains(outputText, `"type":"content_block_start","index":0,"content_block":{"type":"thinking"`) {
+		t.Fatalf("expected carrier thinking block at index 0, got: %s", outputText)
 	}
-	if !strings.Contains(outputText, `"content_block":{"type":"text"`) {
-		t.Fatalf("expected text content block in stream, got: %s", outputText)
+	if !strings.Contains(outputText, `"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-carrier"}`) {
+		t.Fatalf("expected signature_delta sig-carrier at index 0, got: %s", outputText)
 	}
-	if !strings.Contains(outputText, `"text":"Tokyo: 20C"`) {
-		t.Fatalf("expected text delta Tokyo: 20C in stream, got: %s", outputText)
+	if !strings.Contains(outputText, `"type":"content_block_stop","index":0`) {
+		t.Fatalf("expected content_block_stop at index 0, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_start","index":1,"content_block":{"type":"text"`) {
+		t.Fatalf("expected text content_block_start at index 1, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Tokyo: 20C"}`) {
+		t.Fatalf("expected text_delta Tokyo: 20C at index 1, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_stop","index":1`) {
+		t.Fatalf("expected text content_block_stop at index 1, got: %s", outputText)
+	}
+	if sigCount := strings.Count(outputText, `"type":"signature_delta"`); sigCount != 1 {
+		t.Fatalf("expected exactly 1 signature_delta, got %d: %s", sigCount, outputText)
 	}
 }
 
-func TestConvertGeminiResponseToClaude_FunctionCallWithThoughtSignature(t *testing.T) {
+func TestConvertGeminiResponseToClaude_FunctionCallWithThoughtSignatureEmitsCarrierAndTool(t *testing.T) {
 	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
 	chunk := []byte(`{
 		"candidates": [{
@@ -242,6 +258,10 @@ func TestConvertGeminiResponseToClaude_FunctionCallWithThoughtSignature(t *testi
 			},
 			"finishReason": "STOP"
 		}],
+		"usageMetadata": {
+			"promptTokenCount": 10,
+			"candidatesTokenCount": 5
+		},
 		"modelVersion": "gemini-test",
 		"responseId": "resp-test"
 	}`)
@@ -252,14 +272,26 @@ func TestConvertGeminiResponseToClaude_FunctionCallWithThoughtSignature(t *testi
 	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, []byte("[DONE]"), &param), nil)...)
 	outputText := string(output)
 
-	if strings.Contains(outputText, `"content_block":{"type":"thinking"`) {
-		t.Fatalf("functionCall with thoughtSignature must not start an empty thinking block in stream: %s", outputText)
+	if !strings.Contains(outputText, `"type":"content_block_start","index":0,"content_block":{"type":"thinking"`) {
+		t.Fatalf("expected carrier thinking block at index 0, got: %s", outputText)
 	}
-	if !strings.Contains(outputText, `"content_block":{"type":"tool_use"`) {
-		t.Fatalf("expected tool_use block in stream, got: %s", outputText)
+	if !strings.Contains(outputText, `"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-fc"}`) {
+		t.Fatalf("expected signature_delta sig-fc at index 0, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_stop","index":0`) {
+		t.Fatalf("expected carrier thinking stop at index 0, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_start","index":1,"content_block":{"type":"tool_use"`) {
+		t.Fatalf("expected tool_use block start at index 1, got: %s", outputText)
 	}
 	if !strings.Contains(outputText, `"name":"get_weather"`) {
-		t.Fatalf("expected tool name get_weather in stream, got: %s", outputText)
+		t.Fatalf("expected tool name get_weather at index 1, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_stop","index":1`) {
+		t.Fatalf("expected tool_use block stop at index 1, got: %s", outputText)
+	}
+	if sigCount := strings.Count(outputText, `"type":"signature_delta"`); sigCount != 1 {
+		t.Fatalf("expected exactly 1 signature_delta, got %d: %s", sigCount, outputText)
 	}
 }
 
@@ -757,6 +789,114 @@ func TestConvertGeminiResponseToClaude_ThreeConsecutiveSignaturesSplitBlocks(t *
 	if !strings.Contains(outputText, `"type":"content_block_stop","index":2`) {
 		t.Fatalf("expected thinking content_block_stop at index 2, got: %s", outputText)
 	}
+	if sigCount := strings.Count(outputText, `"type":"signature_delta"`); sigCount != 3 {
+		t.Fatalf("expected exactly 3 signature_deltas, got %d: %s", sigCount, outputText)
+	}
+}
+
+
+func TestConvertGeminiResponseToClaude_MultiPartMixedThoughtVisibleToolSignatures(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	chunk1 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"text": "thinking step 1", "thought": true, "thoughtSignature": "sig1"}]
+			}
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+	chunk2 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"text": "intermediate explanation", "thoughtSignature": "sig2"}]
+			}
+		}]
+	}`)
+	chunk3 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{
+					"functionCall": {"name": "search", "args": {"q": "go"}},
+					"thoughtSignature": "sig3"
+				}]
+			},
+			"finishReason": "STOP"
+		}],
+		"usageMetadata": {
+			"promptTokenCount": 10,
+			"candidatesTokenCount": 5
+		},
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	var param any
+	ctx := context.Background()
+	output := bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk1, &param), nil)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk2, &param), nil)...)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk3, &param), nil)...)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, []byte("[DONE]"), &param), nil)...)
+	outputText := string(output)
+
+	// Block 0: thinking step 1 + sig1
+	if !strings.Contains(outputText, `"type":"content_block_start","index":0,"content_block":{"type":"thinking"`) {
+		t.Fatalf("expected thinking start at index 0, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"thinking step 1"}`) {
+		t.Fatalf("expected thinking_delta at index 0, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig1"}`) {
+		t.Fatalf("expected signature_delta sig1 at index 0, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_stop","index":0`) {
+		t.Fatalf("expected stop at index 0, got: %s", outputText)
+	}
+
+	// Block 1: carrier thinking + sig2
+	if !strings.Contains(outputText, `"type":"content_block_start","index":1,"content_block":{"type":"thinking"`) {
+		t.Fatalf("expected carrier thinking start at index 1, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_delta","index":1,"delta":{"type":"signature_delta","signature":"sig2"}`) {
+		t.Fatalf("expected signature_delta sig2 at index 1, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_stop","index":1`) {
+		t.Fatalf("expected stop at index 1, got: %s", outputText)
+	}
+
+	// Block 2: text intermediate explanation
+	if !strings.Contains(outputText, `"type":"content_block_start","index":2,"content_block":{"type":"text"`) {
+		t.Fatalf("expected text start at index 2, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"intermediate explanation"}`) {
+		t.Fatalf("expected text_delta at index 2, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_stop","index":2`) {
+		t.Fatalf("expected stop at index 2, got: %s", outputText)
+	}
+
+	// Block 3: carrier thinking + sig3
+	if !strings.Contains(outputText, `"type":"content_block_start","index":3,"content_block":{"type":"thinking"`) {
+		t.Fatalf("expected carrier thinking start at index 3, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_delta","index":3,"delta":{"type":"signature_delta","signature":"sig3"}`) {
+		t.Fatalf("expected signature_delta sig3 at index 3, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_stop","index":3`) {
+		t.Fatalf("expected stop at index 3, got: %s", outputText)
+	}
+
+	// Block 4: tool_use search
+	if !strings.Contains(outputText, `"type":"content_block_start","index":4,"content_block":{"type":"tool_use"`) {
+		t.Fatalf("expected tool_use start at index 4, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"name":"search"`) {
+		t.Fatalf("expected tool_use name search at index 4, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_stop","index":4`) {
+		t.Fatalf("expected stop at index 4, got: %s", outputText)
+	}
+
 	if sigCount := strings.Count(outputText, `"type":"signature_delta"`); sigCount != 3 {
 		t.Fatalf("expected exactly 3 signature_deltas, got %d: %s", sigCount, outputText)
 	}

--- a/internal/translator/gemini/claude/gemini_claude_response_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_response_test.go
@@ -664,7 +664,6 @@ func TestConvertGeminiResponseToClaude_ThinkingContinuationsAfterSignedAndVisibl
 	}
 }
 
-
 func TestConvertGeminiResponseToClaude_SignatureBeforeThinkingTextEmitsSignatureDelta(t *testing.T) {
 	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
 	chunk1 := []byte(`{
@@ -793,7 +792,6 @@ func TestConvertGeminiResponseToClaude_ThreeConsecutiveSignaturesSplitBlocks(t *
 		t.Fatalf("expected exactly 3 signature_deltas, got %d: %s", sigCount, outputText)
 	}
 }
-
 
 func TestConvertGeminiResponseToClaude_MultiPartMixedThoughtVisibleToolSignatures(t *testing.T) {
 	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)

--- a/internal/translator/gemini/claude/gemini_claude_response_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_response_test.go
@@ -507,3 +507,127 @@ func TestConvertGeminiResponseToClaude_MultipleSignedThoughtChunksSplitBlocks(t 
 		t.Fatalf("expected signature_delta sig2, got: %s", outputText)
 	}
 }
+
+func TestConvertGeminiResponseToClaude_MultipleStandaloneSignedThoughtChunksSplitBlocks(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	chunk1 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"text": "thinking 1", "thought": true}]
+			}
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+	chunk2 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"thought": true, "thoughtSignature": "sigA"}]
+			}
+		}]
+	}`)
+	chunk3 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"thought": true, "thoughtSignature": "sigB"}]
+			}
+		}]
+	}`)
+	chunk4 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"text": "thinking 2", "thought": true}]
+			},
+			"finishReason": "STOP"
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	var param any
+	ctx := context.Background()
+	output := bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk1, &param), nil)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk2, &param), nil)...)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk3, &param), nil)...)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk4, &param), nil)...)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, []byte("[DONE]"), &param), nil)...)
+	outputText := string(output)
+
+	if !strings.Contains(outputText, `"type":"content_block_start","index":0,"content_block":{"type":"thinking"`) {
+		t.Fatalf("expected thinking content_block_start at index 0, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sigA"}`) {
+		t.Fatalf("expected signature_delta sigA on index 0, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_stop","index":0`) {
+		t.Fatalf("expected thinking content_block_stop at index 0 before second standalone signature, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_start","index":1,"content_block":{"type":"thinking"`) {
+		t.Fatalf("expected thinking content_block_start at index 1 for second signed block, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_delta","index":1,"delta":{"type":"signature_delta","signature":"sigB"}`) {
+		t.Fatalf("expected signature_delta sigB on index 1, got: %s", outputText)
+	}
+}
+
+func TestConvertGeminiResponseToClaude_ThinkingContinuationsAfterSignedAndVisibleText(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-test","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	chunk1 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"text": "thought 1", "thought": true, "thoughtSignature": "sig1"}]
+			}
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+	chunk2 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"text": "visible text"}]
+			}
+		}]
+	}`)
+	chunk3 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"text": "thought 2 part A", "thought": true}]
+			}
+		}]
+	}`)
+	chunk4 := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [{"text": "thought 2 part B", "thought": true}]
+			},
+			"finishReason": "STOP"
+		}],
+		"modelVersion": "gemini-test",
+		"responseId": "resp-test"
+	}`)
+
+	var param any
+	ctx := context.Background()
+	output := bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk1, &param), nil)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk2, &param), nil)...)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk3, &param), nil)...)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, chunk4, &param), nil)...)
+	output = append(output, bytes.Join(ConvertGeminiResponseToClaude(ctx, "gemini-test", requestJSON, requestJSON, []byte("[DONE]"), &param), nil)...)
+	outputText := string(output)
+
+	if !strings.Contains(outputText, `"type":"content_block_start","index":0,"content_block":{"type":"thinking"`) {
+		t.Fatalf("expected thinking block 0 start, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_start","index":1,"content_block":{"type":"text"`) {
+		t.Fatalf("expected text block 1 start, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_start","index":2,"content_block":{"type":"thinking"`) {
+		t.Fatalf("expected thinking block 2 start, got: %s", outputText)
+	}
+	if strings.Contains(outputText, `"type":"content_block_start","index":3`) {
+		t.Fatalf("unexpected content_block_start at index 3: thought 2 continuation was improperly split into separate blocks, got: %s", outputText)
+	}
+	if !strings.Contains(outputText, `"type":"content_block_delta","index":2,"delta":{"type":"thinking_delta","thinking":"thought 2 part B"}`) {
+		t.Fatalf("expected thought 2 part B to be in block 2, got: %s", outputText)
+	}
+}


### PR DESCRIPTION
## Problem

1. **Missing `signature` in non-streaming thinking blocks**: In `ConvertGeminiResponseToClaudeNonStream`, thinking blocks were constructed without preserving Gemini's `thoughtSignature` / `thought_signature`. In multi-turn conversations with Anthropic API, returning thinking blocks lacking their signature causes HTTP 400 (`Invalid signature in thinking block`).
2. **Dropped signatures in streaming responses**: In `ConvertGeminiResponseToClaude`, signatures arriving with `ResponseType == 0` (before thinking text), `ResponseType == 1` (visible text), or attached to `functionCall` parts were dropped.
3. **Carrier block and signature isolation**: When signatures were attached to visible text or tool calls, earlier implementations either swallowed visible text into thinking blocks or failed to isolate signatures across distinct content blocks.

## Fix

- `internal/translator/gemini/claude/gemini_claude_response.go:62`: In `ConvertGeminiResponseToClaudeNonStream`, captured `thinkingSignature` strictly from parts where `isThought` is true, resetting signatures upon flushing empty thoughts and emitting `signature` on the output Claude thinking block.
- `internal/translator/gemini/claude/gemini_claude_response.go:210`: In `ConvertGeminiResponseToClaude`, introduced carrier block emission for standalone signatures, visible text with signatures, and tool calls with signatures via `appendPartSignature`, isolating thinking blocks per signature and ensuring `CurrentThinkingSigned` state is properly reset.

## Tests

- `TestConvertGeminiResponseToClaudeNonStream_ThoughtSignature`: Verifies non-stream thinking block preserves `signature`.
- `TestConvertGeminiResponseToClaudeNonStream_TextWithThoughtSignatureWithoutThoughtFlag`: Verifies visible text with signature remains a text block.
- `TestConvertGeminiResponseToClaudeNonStream_FunctionCallWithThoughtSignature`: Verifies tool use with signature emits `tool_use` without phantom thinking block.
- `TestConvertGeminiResponseToClaude_VisibleTextWithThoughtSignatureEmitsCarrierAndText`: Verifies stream visible text with signature emits a carrier thinking block with signature delta followed by the text block.
- `TestConvertGeminiResponseToClaude_FunctionCallWithThoughtSignatureEmitsCarrierAndTool`: Verifies stream tool calls with signatures emit carrier thinking block followed by tool_use.
- `TestConvertGeminiResponseToClaude_MultipleSignedThoughtChunksSplitBlocks`: Verifies signed streaming thinking chunks cleanly isolate into separate blocks.

## Reverse bite-check

Reverting non-stream signature handling in `internal/translator/gemini/claude/gemini_claude_response.go` reproduces the missing signature failure:

```
=== RUN   TestConvertGeminiResponseToClaudeNonStream_ThoughtSignature
    gemini_claude_response_test.go:93: expected signature sig-test in thinking block, got: {"id":"resp-test","type":"message","role":"assistant","model":"gemini-test","content":[{"type":"thinking","thinking":"thinking text"},{"type":"text","text":"hello world"}],"stop_reason":"end_turn","stop_sequence":null}
--- FAIL: TestConvertGeminiResponseToClaudeNonStream_ThoughtSignature (0.00s)
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/internal/translator/gemini/claude	0.385s
FAIL
```

Reverting streaming carrier signature emission reproduces the failure where visible text with signatures is swallowed or fails carrier creation:

```
=== RUN   TestConvertGeminiResponseToClaude_VisibleTextWithThoughtSignatureEmitsCarrierAndText
    gemini_claude_response_test.go:236: expected text content_block_start at index 1, got: event: message_start
        data: {"type":"message_start","message":{"id":"resp-test","type":"message","role":"assistant","content":[],"model":"gemini-test","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}}
        
        
        event: content_block_start
        data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
        
        
        event: content_block_delta
        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Tokyo: 20C"}}
        
        
        event: content_block_delta
        data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-carrier"}}
        
        
        event: content_block_stop
        data: {"type":"content_block_stop","index":0}
        
        
        event: message_delta
        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":10,"output_tokens":5}}
        
        
        event: message_stop
        data: {"type":"message_stop"}
        
        
--- FAIL: TestConvertGeminiResponseToClaude_VisibleTextWithThoughtSignatureEmitsCarrierAndText (0.00s)
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/internal/translator/gemini/claude	0.267s
FAIL
```

## Verification

```bash
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go build ./...
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go vet ./internal/translator/gemini/claude/...
gofmt -l internal/translator/gemini/claude/gemini_claude_response.go internal/translator/gemini/claude/gemini_claude_response_test.go
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go test -v ./internal/translator/gemini/claude/...
```

Output:
```
ok  	github.com/router-for-me/CLIProxyAPI/v7/internal/translator/gemini/claude	0.279s
```

### Tooling note

The `jbcontext` semantic-search CLI is installed but non-functional in this environment
(`jbcontext search` fails with `the OS keychain is not accessible`). The equivalent
review passes were performed with the repository's own tooling and manual inspection
instead; this is disclosed for transparency about how the change was reviewed.
