### PR TITLE
fix(translator): support message.reasoning fallback in responses non-stream

### DIFF
--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -886,8 +886,12 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 
 	// Build output list from choices[...]
 	var outputItems [][]byte
-	// Detect and capture reasoning content if present
-	rcText := gjson.GetBytes(rawJSON, "choices.0.message.reasoning_content").String()
+	// Detect and capture reasoning content if present (with fallback to reasoning)
+	rc := gjson.GetBytes(rawJSON, "choices.0.message.reasoning_content")
+	if !rc.Exists() || rc.String() == "" {
+		rc = gjson.GetBytes(rawJSON, "choices.0.message.reasoning")
+	}
+	rcText := rc.String()
 	includeReasoning := rcText != ""
 	if !includeReasoning && len(requestRawJSON) > 0 {
 		includeReasoning = gjson.GetBytes(requestRawJSON, "reasoning").Exists()

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
@@ -1260,7 +1260,6 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_FinishRe
 	}
 }
 
-
 func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
@@ -1259,3 +1259,94 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_FinishRe
 		t.Fatalf("output.0.status = %q, want incomplete; out=%s", got, out)
 	}
 }
+
+
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback(t *testing.T) {
+	tests := []struct {
+		name          string
+		rawJSON       string
+		requestJSON   string
+		wantReasoning bool
+		wantText      string
+	}{
+		{
+			name:          "reasoning_content field present",
+			rawJSON:       `{"id":"chatcmpl_rc","object":"chat.completion","created":1773896263,"model":"o3-mini","choices":[{"index":0,"message":{"role":"assistant","content":"hello","reasoning_content":"thought from reasoning_content"},"finish_reason":"stop"}]}`,
+			wantReasoning: true,
+			wantText:      "thought from reasoning_content",
+		},
+		{
+			name:          "reasoning fallback field present",
+			rawJSON:       `{"id":"chatcmpl_r","object":"chat.completion","created":1773896263,"model":"o3-mini","choices":[{"index":0,"message":{"role":"assistant","content":"hello","reasoning":"thought from reasoning"},"finish_reason":"stop"}]}`,
+			wantReasoning: true,
+			wantText:      "thought from reasoning",
+		},
+		{
+			name:          "both reasoning_content and reasoning present (reasoning_content priority)",
+			rawJSON:       `{"id":"chatcmpl_both","object":"chat.completion","created":1773896263,"model":"o3-mini","choices":[{"index":0,"message":{"role":"assistant","content":"hello","reasoning_content":"priority thought","reasoning":"ignored thought"},"finish_reason":"stop"}]}`,
+			wantReasoning: true,
+			wantText:      "priority thought",
+		},
+		{
+			name:          "empty reasoning_content falls back to reasoning",
+			rawJSON:       `{"id":"chatcmpl_empty_rc","object":"chat.completion","created":1773896263,"model":"o3-mini","choices":[{"index":0,"message":{"role":"assistant","content":"hello","reasoning_content":"","reasoning":"fallback thought"},"finish_reason":"stop"}]}`,
+			wantReasoning: true,
+			wantText:      "fallback thought",
+		},
+		{
+			name:          "neither field present without request reasoning",
+			rawJSON:       `{"id":"chatcmpl_none","object":"chat.completion","created":1773896263,"model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}`,
+			wantReasoning: false,
+		},
+		{
+			name:          "neither field present with request reasoning produces empty summary",
+			rawJSON:       `{"id":"chatcmpl_req_only","object":"chat.completion","created":1773896263,"model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}`,
+			requestJSON:   `{"model":"gpt-4o","reasoning":{"effort":"medium"}}`,
+			wantReasoning: true,
+			wantText:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var reqBytes []byte
+			if tt.requestJSON != "" {
+				reqBytes = []byte(tt.requestJSON)
+			}
+			out := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "o3-mini", reqBytes, reqBytes, []byte(tt.rawJSON), nil)
+			data := gjson.ParseBytes(out)
+
+			var reasoningItem gjson.Result
+			found := false
+			data.Get("output").ForEach(func(_, item gjson.Result) bool {
+				if item.Get("type").String() == "reasoning" {
+					found = true
+					reasoningItem = item
+					return false
+				}
+				return true
+			})
+
+			if tt.wantReasoning != found {
+				t.Fatalf("reasoning found = %v, want %v; out=%s", found, tt.wantReasoning, out)
+			}
+
+			if tt.wantReasoning {
+				if tt.wantText != "" {
+					gotText := reasoningItem.Get("summary.0.text").String()
+					if gotText != tt.wantText {
+						t.Fatalf("summary.0.text = %q, want %q; out=%s", gotText, tt.wantText, out)
+					}
+					gotType := reasoningItem.Get("summary.0.type").String()
+					if gotType != "summary_text" {
+						t.Fatalf("summary.0.type = %q, want summary_text; out=%s", gotType, out)
+					}
+				} else {
+					if len(reasoningItem.Get("summary").Array()) != 0 {
+						t.Fatalf("summary = %s, want empty array; out=%s", reasoningItem.Get("summary").Raw, out)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When translating OpenAI Chat Completions responses to OpenAI Responses API in non-streaming mode (`ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream`), reasoning content was extracted solely from `choices.0.message.reasoning_content`. When upstream providers (such as o1/o3 via compatible gateways, Grok, DeepSeek, OpenRouter, or third-party OpenAI endpoints) return reasoning under `choices.0.message.reasoning`, the reasoning text was completely omitted from the converted Responses output.

In the same file, the streaming converter (`ConvertOpenAIChatCompletionsResponseToOpenAIResponses`) already fell back to `reasoning` when `reasoning_content` was absent or empty, causing an unintended discrepancy between streaming and non-streaming responses.

## Fix

- `internal/translator/openai/openai/responses/openai_openai-responses_response.go:889`: Updated `ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream` to check `choices.0.message.reasoning_content` and fall back to `choices.0.message.reasoning` if missing or empty, establishing stream/non-stream parity while preserving `reasoning_content` priority.

## Tests

- `TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback`:
  - `reasoning_content field present`: Verifies standard `reasoning_content` extraction.
  - `reasoning fallback field present`: Verifies fallback to `reasoning` when `reasoning_content` is absent.
  - `both reasoning_content and reasoning present (reasoning_content priority)`: Verifies priority.
  - `empty reasoning_content falls back to reasoning`: Verifies fallback when `reasoning_content` is `""`.
  - `neither field present without request reasoning`: Verifies no reasoning item is emitted.
  - `neither field present with request reasoning produces empty summary`: Verifies empty summary when requested.

## Reverse bite-check

Reverting `internal/translator/openai/openai/responses/openai_openai-responses_response.go` to the pre-fix state causes `TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback` to fail on both fallback subtests:

```
=== RUN   TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback
=== RUN   TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/reasoning_content_field_present
=== RUN   TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/reasoning_fallback_field_present
    openai_openai-responses_response_test.go:1331: reasoning found = false, want true; out={"id":"chatcmpl_r","object":"response","created_at":1773896263,"status":"completed","background":false,"error":null,"incomplete_details":null,"model":"o3-mini","output":[{"id":"msg_chatcmpl_r_0","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"hello"}],"role":"assistant"}]}
=== RUN   TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/both_reasoning_content_and_reasoning_present_(reasoning_content_priority)
=== RUN   TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/empty_reasoning_content_falls_back_to_reasoning
    openai_openai-responses_response_test.go:1331: reasoning found = false, want true; out={"id":"chatcmpl_empty_rc","object":"response","created_at":1773896263,"status":"completed","background":false,"error":null,"incomplete_details":null,"model":"o3-mini","output":[{"id":"msg_chatcmpl_empty_rc_0","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"hello"}],"role":"assistant"}]}
=== RUN   TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/neither_field_present_without_request_reasoning
=== RUN   TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/neither_field_present_with_request_reasoning_produces_empty_summary
--- FAIL: TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback (0.00s)
    --- PASS: TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/reasoning_content_field_present (0.00s)
    --- FAIL: TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/reasoning_fallback_field_present (0.00s)
    --- PASS: TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/both_reasoning_content_and_reasoning_present_(reasoning_content_priority) (0.00s)
    --- FAIL: TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/empty_reasoning_content_falls_back_to_reasoning (0.00s)
    --- PASS: TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/neither_field_present_without_request_reasoning (0.00s)
    --- PASS: TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/neither_field_present_with_request_reasoning_produces_empty_summary (0.00s)
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/internal/translator/openai/openai/responses	0.372s
FAIL
```

## Verification

```bash
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go build ./...
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go vet ./internal/translator/openai/openai/responses/...
gofmt -l internal/translator/openai/openai/responses/openai_openai-responses_response.go internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go test -v -run "TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback" ./internal/translator/openai/openai/responses/...
```

Output:
```
=== RUN   TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback
=== RUN   TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/reasoning_content_field_present
=== RUN   TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/reasoning_fallback_field_present
=== RUN   TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/both_reasoning_content_and_reasoning_present_(reasoning_content_priority)
=== RUN   TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/empty_reasoning_content_falls_back_to_reasoning
=== RUN   TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/neither_field_present_without_request_reasoning
=== RUN   TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/neither_field_present_with_request_reasoning_produces_empty_summary
--- PASS: TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback (0.00s)
    --- PASS: TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/reasoning_content_field_present (0.00s)
    --- PASS: TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/reasoning_fallback_field_present (0.00s)
    --- PASS: TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/both_reasoning_content_and_reasoning_present_(reasoning_content_priority) (0.00s)
    --- PASS: TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/empty_reasoning_content_falls_back_to_reasoning (0.00s)
    --- PASS: TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/neither_field_present_without_request_reasoning (0.00s)
    --- PASS: TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback/neither_field_present_with_request_reasoning_produces_empty_summary (0.00s)
PASS
ok  	github.com/router-for-me/CLIProxyAPI/v7/internal/translator/openai/openai/responses	0.389s
```

### Tooling note

The `jbcontext` semantic-search CLI is installed but non-functional in this environment
(`jbcontext search` fails with `the OS keychain is not accessible`). The equivalent
review passes were performed with the repository's own tooling and manual inspection
instead; this is disclosed for transparency about how the change was reviewed.
