### PR TITLE
fix(translator/antigravity): support max_completion_tokens in openai chat completions

### DIFF
--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
@@ -69,8 +69,10 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 	if tkr := gjson.GetBytes(rawJSON, "top_k"); tkr.Exists() && tkr.Type == gjson.Number {
 		out, _ = sjson.SetBytes(out, "request.generationConfig.topK", tkr.Num)
 	}
-	if maxTok := gjson.GetBytes(rawJSON, "max_tokens"); maxTok.Exists() && maxTok.Type == gjson.Number {
-		out, _ = sjson.SetBytes(out, "request.generationConfig.maxOutputTokens", maxTok.Num)
+	if mt := gjson.GetBytes(rawJSON, "max_tokens"); mt.Exists() && mt.Type == gjson.Number {
+		out, _ = sjson.SetBytes(out, "request.generationConfig.maxOutputTokens", mt.Num)
+	} else if mct := gjson.GetBytes(rawJSON, "max_completion_tokens"); mct.Exists() && mct.Type == gjson.Number {
+		out, _ = sjson.SetBytes(out, "request.generationConfig.maxOutputTokens", mct.Num)
 	}
 
 	// Map OpenAI response_format to Antigravity structured output settings.

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request_test.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request_test.go
@@ -456,7 +456,6 @@ func TestConvertOpenAIRequestToAntigravityTranslatesVideoURL(t *testing.T) {
 	}
 }
 
-
 func TestConvertOpenAIRequestToAntigravityMapsMaxTokens(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request_test.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request_test.go
@@ -455,3 +455,66 @@ func TestConvertOpenAIRequestToAntigravityTranslatesVideoURL(t *testing.T) {
 		t.Fatalf("inlineData.data = %q, want AAAAIGZ0eXBtcDQy. Output: %s", got, out)
 	}
 }
+
+
+func TestConvertOpenAIRequestToAntigravityMapsMaxTokens(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantSet    bool
+		wantTokens int64
+	}{
+		{
+			name:       "only max_tokens",
+			body:       `{"model":"gemini-2.5-pro","messages":[{"role":"user","content":"hi"}],"max_tokens":30}`,
+			wantSet:    true,
+			wantTokens: 30,
+		},
+		{
+			name:       "only max_completion_tokens",
+			body:       `{"model":"gemini-2.5-pro","messages":[{"role":"user","content":"hi"}],"max_completion_tokens":40}`,
+			wantSet:    true,
+			wantTokens: 40,
+		},
+		{
+			name:       "max_tokens preferred over max_completion_tokens",
+			body:       `{"model":"gemini-2.5-pro","messages":[{"role":"user","content":"hi"}],"max_tokens":30,"max_completion_tokens":40}`,
+			wantSet:    true,
+			wantTokens: 30,
+		},
+		{
+			name:    "neither present",
+			body:    `{"model":"gemini-2.5-pro","messages":[{"role":"user","content":"hi"}]}`,
+			wantSet: false,
+		},
+		{
+			name:    "non-numeric max_tokens ignored",
+			body:    `{"model":"gemini-2.5-pro","messages":[{"role":"user","content":"hi"}],"max_tokens":"30"}`,
+			wantSet: false,
+		},
+		{
+			name:    "non-numeric max_completion_tokens ignored",
+			body:    `{"model":"gemini-2.5-pro","messages":[{"role":"user","content":"hi"}],"max_completion_tokens":"40"}`,
+			wantSet: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := ConvertOpenAIRequestToAntigravity("gemini-2.5-pro", []byte(tt.body), false)
+			res := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens")
+			if !tt.wantSet {
+				if res.Exists() {
+					t.Fatalf("expected maxOutputTokens to not be set, got %v. Output: %s", res.Value(), out)
+				}
+				return
+			}
+			if !res.Exists() {
+				t.Fatalf("expected maxOutputTokens to be set, but it was missing. Output: %s", out)
+			}
+			if got := res.Int(); got != tt.wantTokens {
+				t.Fatalf("maxOutputTokens = %d, want %d. Output: %s", got, tt.wantTokens, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

OpenAI deprecated `max_tokens` in favor of `max_completion_tokens` for reasoning models (`o1`, `o3-mini`, newer `gpt-4o` versions), and modern OpenAI client libraries send `max_completion_tokens` by default.

When translating OpenAI Chat Completions requests to Antigravity (`ConvertOpenAIRequestToAntigravity`), only `max_tokens` was inspected. When a client supplied `max_completion_tokens` without `max_tokens`, `request.generationConfig.maxOutputTokens` was omitted from the upstream Antigravity payload, causing upstream models to ignore client token limits.

## Fix

- `internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go:72`: Updated `ConvertOpenAIRequestToAntigravity` to read `max_tokens` first, and if absent/non-numeric, fall back to `max_completion_tokens` (matching the mapping pattern used in `gemini_openai_request.go`).

## Tests

- `TestConvertOpenAIRequestToAntigravityMapsMaxTokens`:
  - `only max_tokens`: Verifies `max_tokens` sets `maxOutputTokens`.
  - `only max_completion_tokens`: Verifies `max_completion_tokens` sets `maxOutputTokens`.
  - `max_tokens preferred over max_completion_tokens`: Verifies `max_tokens` precedence when both are provided.
  - `neither present`: Verifies `maxOutputTokens` is omitted.
  - `non-numeric max_tokens ignored`: Verifies string `max_tokens` is ignored.
  - `non-numeric max_completion_tokens ignored`: Verifies string `max_completion_tokens` is ignored.

## Reverse bite-check

Reverting `internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go` to the pre-fix state reproduces the failure where `max_completion_tokens` is ignored:

```
=== RUN   TestConvertOpenAIRequestToAntigravityMapsMaxTokens
=== RUN   TestConvertOpenAIRequestToAntigravityMapsMaxTokens/only_max_tokens
=== RUN   TestConvertOpenAIRequestToAntigravityMapsMaxTokens/only_max_completion_tokens
    antigravity_openai_request_test.go:513: expected maxOutputTokens to be set, but it was missing. Output: {"project":"","request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}],"safetySettings":[{"category":"HARM_CATEGORY_HARASSMENT","threshold":"OFF"},{"category":"HARM_CATEGORY_HATE_SPEECH","threshold":"OFF"},{"category":"HARM_CATEGORY_SEXUALLY_EXPLICIT","threshold":"OFF"},{"category":"HARM_CATEGORY_DANGEROUS_CONTENT","threshold":"OFF"},{"category":"HARM_CATEGORY_CIVIC_INTEGRITY","threshold":"BLOCK_NONE"}]},"model":"gemini-2.5-pro"}
=== RUN   TestConvertOpenAIRequestToAntigravityMapsMaxTokens/max_tokens_preferred_over_max_completion_tokens
=== RUN   TestConvertOpenAIRequestToAntigravityMapsMaxTokens/neither_present
=== RUN   TestConvertOpenAIRequestToAntigravityMapsMaxTokens/non-numeric_max_tokens_ignored
=== RUN   TestConvertOpenAIRequestToAntigravityMapsMaxTokens/non-numeric_max_completion_tokens_ignored
--- FAIL: TestConvertOpenAIRequestToAntigravityMapsMaxTokens (0.00s)
    --- PASS: TestConvertOpenAIRequestToAntigravityMapsMaxTokens/only_max_tokens (0.00s)
    --- FAIL: TestConvertOpenAIRequestToAntigravityMapsMaxTokens/only_max_completion_tokens (0.00s)
    --- PASS: TestConvertOpenAIRequestToAntigravityMapsMaxTokens/max_tokens_preferred_over_max_completion_tokens (0.00s)
    --- PASS: TestConvertOpenAIRequestToAntigravityMapsMaxTokens/neither_present (0.00s)
    --- PASS: TestConvertOpenAIRequestToAntigravityMapsMaxTokens/non-numeric_max_tokens_ignored (0.00s)
    --- PASS: TestConvertOpenAIRequestToAntigravityMapsMaxTokens/non-numeric_max_completion_tokens_ignored (0.00s)
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/internal/translator/antigravity/openai/chat-completions	0.407s
FAIL
```

## Verification

```bash
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go build ./...
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go vet ./internal/translator/antigravity/openai/chat-completions/...
gofmt -l internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go internal/translator/antigravity/openai/chat-completions/antigravity_openai_request_test.go
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go test -v -run "TestConvertOpenAIRequestToAntigravityMapsMaxTokens" ./internal/translator/antigravity/openai/chat-completions/...
```

Output:
```
=== RUN   TestConvertOpenAIRequestToAntigravityMapsMaxTokens
=== RUN   TestConvertOpenAIRequestToAntigravityMapsMaxTokens/only_max_tokens
=== RUN   TestConvertOpenAIRequestToAntigravityMapsMaxTokens/only_max_completion_tokens
=== RUN   TestConvertOpenAIRequestToAntigravityMapsMaxTokens/max_tokens_preferred_over_max_completion_tokens
=== RUN   TestConvertOpenAIRequestToAntigravityMapsMaxTokens/neither_present
=== RUN   TestConvertOpenAIRequestToAntigravityMapsMaxTokens/non-numeric_max_tokens_ignored
=== RUN   TestConvertOpenAIRequestToAntigravityMapsMaxTokens/non-numeric_max_completion_tokens_ignored
--- PASS: TestConvertOpenAIRequestToAntigravityMapsMaxTokens (0.00s)
    --- PASS: TestConvertOpenAIRequestToAntigravityMapsMaxTokens/only_max_tokens (0.00s)
    --- PASS: TestConvertOpenAIRequestToAntigravityMapsMaxTokens/only_max_completion_tokens (0.00s)
    --- PASS: TestConvertOpenAIRequestToAntigravityMapsMaxTokens/max_tokens_preferred_over_max_completion_tokens (0.00s)
    --- PASS: TestConvertOpenAIRequestToAntigravityMapsMaxTokens/neither_present (0.00s)
    --- PASS: TestConvertOpenAIRequestToAntigravityMapsMaxTokens/non-numeric_max_tokens_ignored (0.00s)
    --- PASS: TestConvertOpenAIRequestToAntigravityMapsMaxTokens/non-numeric_max_completion_tokens_ignored (0.00s)
PASS
ok  	github.com/router-for-me/CLIProxyAPI/v7/internal/translator/antigravity/openai/chat-completions	0.384s
```

### Tooling note

The `jbcontext` semantic-search CLI is installed but non-functional in this environment
(`jbcontext search` fails with `the OS keychain is not accessible`). The equivalent
review passes were performed with the repository's own tooling and manual inspection
instead; this is disclosed for transparency about how the change was reviewed.
