### PR TITLE
fix(claude): use canonical reasoning_content in non-stream response

### DIFF
--- a/internal/translator/claude/openai/chat-completions/claude_openai_response.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_response.go
@@ -434,7 +434,7 @@ func ConvertClaudeResponseToOpenAINonStream(_ context.Context, _ string, origina
 	if len(reasoningParts) > 0 {
 		reasoningContent := strings.Join(reasoningParts, "")
 		// Add reasoning as a separate field in the message
-		out, _ = sjson.SetBytes(out, "choices.0.message.reasoning", reasoningContent)
+		out, _ = sjson.SetBytes(out, "choices.0.message.reasoning_content", reasoningContent)
 	}
 
 	// Set tool calls if any were accumulated during processing

--- a/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
@@ -206,3 +206,160 @@ func TestConvertClaudeResponseToOpenAINonStream_RefusalStopReason(t *testing.T) 
 		})
 	}
 }
+
+
+func TestConvertClaudeResponseToOpenAINonStream_ReasoningContent(t *testing.T) {
+	rawJSON := []byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_123\",\"model\":\"claude-opus-4-6\"}}\n" +
+		"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Let me analyze the problem.\"}}\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\" Step 2 is clear.\"}}\n" +
+		"data: {\"type\":\"content_block_stop\",\"index\":0}\n" +
+		"data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"Here is the solution.\"}}\n" +
+		"data: {\"type\":\"content_block_stop\",\"index\":1}\n" +
+		"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":10,\"output_tokens\":20}}\n")
+
+	out := ConvertClaudeResponseToOpenAINonStream(context.Background(), "", nil, nil, rawJSON, nil)
+
+	gotRC := gjson.GetBytes(out, "choices.0.message.reasoning_content")
+	if !gotRC.Exists() {
+		t.Fatalf("expected choices.0.message.reasoning_content to exist, payload=%s", string(out))
+	}
+	wantRC := "Let me analyze the problem. Step 2 is clear."
+	if gotRC.String() != wantRC {
+		t.Fatalf("reasoning_content = %q, want %q", gotRC.String(), wantRC)
+	}
+
+	if gotOldReasoning := gjson.GetBytes(out, "choices.0.message.reasoning"); gotOldReasoning.Exists() {
+		t.Fatalf("choices.0.message.reasoning should not exist, got %q", gotOldReasoning.String())
+	}
+
+	gotContent := gjson.GetBytes(out, "choices.0.message.content").String()
+	wantContent := "Here is the solution."
+	if gotContent != wantContent {
+		t.Fatalf("content = %q, want %q", gotContent, wantContent)
+	}
+}
+
+func TestConvertClaudeResponseToOpenAINonStream_OmitsReasoningContentWhenAbsent(t *testing.T) {
+	rawJSON := []byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_123\",\"model\":\"claude-opus-4-6\"}}\n" +
+		"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Just plain text.\"}}\n" +
+		"data: {\"type\":\"content_block_stop\",\"index\":0}\n" +
+		"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":10,\"output_tokens\":20}}\n")
+
+	out := ConvertClaudeResponseToOpenAINonStream(context.Background(), "", nil, nil, rawJSON, nil)
+
+	if gotRC := gjson.GetBytes(out, "choices.0.message.reasoning_content"); gotRC.Exists() {
+		t.Fatalf("choices.0.message.reasoning_content should be omitted when absent, got %q", gotRC.String())
+	}
+	if gotReasoning := gjson.GetBytes(out, "choices.0.message.reasoning"); gotReasoning.Exists() {
+		t.Fatalf("choices.0.message.reasoning should not exist, got %q", gotReasoning.String())
+	}
+	if gotContent := gjson.GetBytes(out, "choices.0.message.content").String(); gotContent != "Just plain text." {
+		t.Fatalf("content = %q, want %q", gotContent, "Just plain text.")
+	}
+}
+
+func TestConvertClaudeResponseToOpenAI_StreamAndNonStreamParity(t *testing.T) {
+	events := [][]byte{
+		[]byte(`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-opus-4-6","usage":{"input_tokens":15,"output_tokens":1}}}`),
+		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`),
+		[]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"First thought. "}}`),
+		[]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Second thought."}}`),
+		[]byte(`data: {"type":"content_block_stop","index":0}`),
+		[]byte(`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`),
+		[]byte(`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Final "}}`),
+		[]byte(`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"answer."}}`),
+		[]byte(`data: {"type":"content_block_stop","index":1}`),
+		[]byte(`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":25}}`),
+		[]byte(`data: {"type":"message_stop"}`),
+	}
+
+	// 1. Process via streaming
+	ctx := context.Background()
+	var param any
+	var streamReasoning string
+	var streamContent string
+	var streamFinishReason string
+
+	for _, ev := range events {
+		chunks := ConvertClaudeResponseToOpenAI(ctx, "claude-opus-4-6", nil, nil, ev, &param)
+		for _, chunk := range chunks {
+			if rc := gjson.GetBytes(chunk, "choices.0.delta.reasoning_content"); rc.Exists() {
+				streamReasoning += rc.String()
+			}
+			if c := gjson.GetBytes(chunk, "choices.0.delta.content"); c.Exists() {
+				streamContent += c.String()
+			}
+			if fr := gjson.GetBytes(chunk, "choices.0.finish_reason"); fr.Exists() && fr.String() != "" {
+				streamFinishReason = fr.String()
+			}
+		}
+	}
+
+	// 2. Process via non-stream
+	var rawBuffer []byte
+	for _, ev := range events {
+		rawBuffer = append(rawBuffer, ev...)
+		rawBuffer = append(rawBuffer, '\n')
+	}
+
+	nonStreamOut := ConvertClaudeResponseToOpenAINonStream(ctx, "", nil, nil, rawBuffer, nil)
+	nonStreamRC := gjson.GetBytes(nonStreamOut, "choices.0.message.reasoning_content").String()
+	nonStreamContent := gjson.GetBytes(nonStreamOut, "choices.0.message.content").String()
+	nonStreamFinishReason := gjson.GetBytes(nonStreamOut, "choices.0.finish_reason").String()
+
+	if streamReasoning != "First thought. Second thought." {
+		t.Fatalf("streamReasoning = %q, want %q", streamReasoning, "First thought. Second thought.")
+	}
+	if nonStreamRC != streamReasoning {
+		t.Fatalf("parity mismatch for reasoning_content: nonStream=%q, stream=%q", nonStreamRC, streamReasoning)
+	}
+	if nonStreamContent != streamContent {
+		t.Fatalf("parity mismatch for content: nonStream=%q, stream=%q", nonStreamContent, streamContent)
+	}
+	if nonStreamFinishReason != streamFinishReason {
+		t.Fatalf("parity mismatch for finish_reason: nonStream=%q, stream=%q", nonStreamFinishReason, streamFinishReason)
+	}
+}
+
+func TestConvertClaudeResponseToOpenAI_RedactedThinkingIgnored(t *testing.T) {
+	rawJSON := []byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_123\",\"model\":\"claude-opus-4-6\"}}\n" +
+		"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"redacted_thinking\",\"data\":\"encrypted_blob\"}}\n" +
+		"data: {\"type\":\"content_block_stop\",\"index\":0}\n" +
+		"data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"Visible reply.\"}}\n" +
+		"data: {\"type\":\"content_block_stop\",\"index\":1}\n" +
+		"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":10,\"output_tokens\":20}}\n")
+
+	// Non-stream check
+	outNonStream := ConvertClaudeResponseToOpenAINonStream(context.Background(), "", nil, nil, rawJSON, nil)
+	if gotRC := gjson.GetBytes(outNonStream, "choices.0.message.reasoning_content"); gotRC.Exists() {
+		t.Fatalf("redacted_thinking must never map to reasoning_content in non-stream, got %q", gotRC.String())
+	}
+	if gotReasoning := gjson.GetBytes(outNonStream, "choices.0.message.reasoning"); gotReasoning.Exists() {
+		t.Fatalf("redacted_thinking must not produce reasoning field in non-stream, got %q", gotReasoning.String())
+	}
+
+	// Stream check
+	ctx := context.Background()
+	var param any
+	lines := [][]byte{
+		[]byte(`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-opus-4-6"}}`),
+		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"redacted_thinking","data":"encrypted_blob"}}`),
+		[]byte(`data: {"type":"content_block_stop","index":0}`),
+		[]byte(`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`),
+		[]byte(`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Visible reply."}}`),
+		[]byte(`data: {"type":"content_block_stop","index":1}`),
+		[]byte(`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":10,"output_tokens":20}}`),
+	}
+	for _, line := range lines {
+		chunks := ConvertClaudeResponseToOpenAI(ctx, "claude-opus-4-6", nil, nil, line, &param)
+		for _, chunk := range chunks {
+			if gotRC := gjson.GetBytes(chunk, "choices.0.delta.reasoning_content"); gotRC.Exists() {
+				t.Fatalf("redacted_thinking must never map to reasoning_content in stream, got %q", gotRC.String())
+			}
+		}
+	}
+}

--- a/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
@@ -207,7 +207,6 @@ func TestConvertClaudeResponseToOpenAINonStream_RefusalStopReason(t *testing.T) 
 	}
 }
 
-
 func TestConvertClaudeResponseToOpenAINonStream_ReasoningContent(t *testing.T) {
 	rawJSON := []byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_123\",\"model\":\"claude-opus-4-6\"}}\n" +
 		"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n" +


### PR DESCRIPTION
## Problem

When translating non-streaming Claude responses to OpenAI Chat Completions (`ConvertClaudeResponseToOpenAINonStream`), thinking blocks were written to the non-canonical field `choices.0.message.reasoning`. In contrast, the streaming converter in the same file (`ConvertClaudeResponseToOpenAI`) outputs reasoning deltas using the canonical `choices.0.delta.reasoning_content`.

Because downstream OpenAI clients and multi-turn request adapters expect `choices.0.message.reasoning_content`, non-streaming responses failed to preserve thinking tokens across subsequent turns.

## Fix

- `internal/translator/claude/openai/chat-completions/claude_openai_response.go:437`: Updated `ConvertClaudeResponseToOpenAINonStream` to serialize reasoning content to `choices.0.message.reasoning_content`.

## Tests

- `TestConvertClaudeResponseToOpenAINonStream_ReasoningContent`: Verifies `reasoning_content` is properly populated and legacy `reasoning` field is omitted.
- `TestConvertClaudeResponseToOpenAINonStream_OmitsReasoningContentWhenAbsent`: Verifies reasoning fields are omitted when responses lack thinking blocks.
- `TestConvertClaudeResponseToOpenAI_StreamAndNonStreamParity`: Verifies stream and non-stream parity for thinking content, visible text, and finish reason.
- `TestConvertClaudeResponseToOpenAI_RedactedThinkingIgnored`: Verifies `redacted_thinking` blocks are never leaked into `reasoning_content` in streaming or non-streaming mode.

## Reverse bite-check

Reverting `internal/translator/claude/openai/chat-completions/claude_openai_response.go` to the pre-fix state reproduces the failure where `reasoning_content` is missing:

```
=== RUN   TestConvertClaudeResponseToOpenAINonStream_ReasoningContent
    claude_openai_response_test.go:226: expected choices.0.message.reasoning_content to exist, payload={"id":"msg_123","object":"chat.completion","created":1787286777,"model":"claude-opus-4-6","choices":[{"index":0,"message":{"role":"assistant","content":"Here is the solution.","reasoning":"Let me analyze the problem. Step 2 is clear."},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30,"prompt_tokens_details":{"cached_tokens":0,"cached_creation_tokens":0}}}
--- FAIL: TestConvertClaudeResponseToOpenAINonStream_ReasoningContent (0.00s)
=== RUN   TestConvertClaudeResponseToOpenAI_StreamAndNonStreamParity
    claude_openai_response_test.go:317: parity mismatch for reasoning_content: nonStream="", stream="First thought. Second thought."
--- FAIL: TestConvertClaudeResponseToOpenAI_StreamAndNonStreamParity (0.00s)
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/internal/translator/claude/openai/chat-completions	0.385s
FAIL
```

## Verification

```bash
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go build ./...
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go vet ./internal/translator/claude/openai/chat-completions/...
gofmt -l internal/translator/claude/openai/chat-completions/claude_openai_response.go internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go test -v -run "TestConvertClaudeResponseToOpenAINonStream_ReasoningContent|TestConvertClaudeResponseToOpenAI_StreamAndNonStreamParity|TestConvertClaudeResponseToOpenAI_RedactedThinkingIgnored" ./internal/translator/claude/openai/chat-completions/...
```

Output:
```
=== RUN   TestConvertClaudeResponseToOpenAINonStream_ReasoningContent
--- PASS: TestConvertClaudeResponseToOpenAINonStream_ReasoningContent (0.00s)
=== RUN   TestConvertClaudeResponseToOpenAI_StreamAndNonStreamParity
--- PASS: TestConvertClaudeResponseToOpenAI_StreamAndNonStreamParity (0.00s)
=== RUN   TestConvertClaudeResponseToOpenAI_RedactedThinkingIgnored
--- PASS: TestConvertClaudeResponseToOpenAI_RedactedThinkingIgnored (0.00s)
PASS
ok  	github.com/router-for-me/CLIProxyAPI/v7/internal/translator/claude/openai/chat-completions	0.388s
```

### Tooling note

The `jbcontext` semantic-search CLI is installed but non-functional in this environment
(`jbcontext search` fails with `the OS keychain is not accessible`). The equivalent
review passes were performed with the repository's own tooling and manual inspection
instead; this is disclosed for transparency about how the change was reviewed.
