### PR TITLE
fix(translator): use deterministic tool call IDs in Gemini request translators

### DIFF
--- a/internal/translator/claude/gemini/claude_gemini_request.go
+++ b/internal/translator/claude/gemini/claude_gemini_request.go
@@ -86,12 +86,41 @@ func ConvertGeminiRequestToClaude(modelName string, inputRawJSON []byte, stream 
 		return ids
 	}
 
+	usedToolIDs := make(map[string]bool)
+	if contents := root.Get("contents"); contents.Exists() && contents.IsArray() {
+		contents.ForEach(func(_, content gjson.Result) bool {
+			if parts := content.Get("parts"); parts.Exists() && parts.IsArray() {
+				parts.ForEach(func(_, part gjson.Result) bool {
+					if id := getGeminiToolID(part.Get("functionCall")); id != "" {
+						usedToolIDs[id] = true
+					}
+					if id := getGeminiToolID(part.Get("functionResponse")); id != "" {
+						usedToolIDs[id] = true
+					}
+					return true
+				})
+			}
+			return true
+		})
+	}
+
 	// FIFO queue to store tool call IDs for matching with tool results
 	// Gemini uses sequential pairing across possibly multiple in-flight
 	// functionCalls, so we keep a FIFO queue of generated tool IDs and
 	// consume them in order when functionResponses arrive.
 	var pendingToolIDs []string
 	toolIDCounter := 0
+
+	generateToolID := func() string {
+		for {
+			toolIDCounter++
+			id := fmt.Sprintf("toolu_%d", toolIDCounter)
+			if !usedToolIDs[id] {
+				usedToolIDs[id] = true
+				return id
+			}
+		}
+	}
 
 	// Model mapping to specify which Claude Code model to use
 	out, _ = sjson.SetBytes(out, "model", modelName)
@@ -273,8 +302,7 @@ func ConvertGeminiRequestToClaude(modelName string, inputRawJSON []byte, stream 
 						// Reuse gateway-provided IDs when present, otherwise generate one for pairing.
 						toolID := getGeminiToolID(fc)
 						if toolID == "" {
-							toolIDCounter++
-							toolID = fmt.Sprintf("toolu_%d", toolIDCounter)
+							toolID = generateToolID()
 						}
 						pendingToolIDs = append(pendingToolIDs, toolID)
 						toolUse, _ = sjson.SetBytes(toolUse, "id", toolID)
@@ -305,8 +333,7 @@ func ConvertGeminiRequestToClaude(modelName string, inputRawJSON []byte, stream 
 							pendingToolIDs = pendingToolIDs[1:]
 						} else {
 							// Fallback: generate new ID if no pending tool_use found
-							toolIDCounter++
-							toolID = fmt.Sprintf("toolu_%d", toolIDCounter)
+							toolID = generateToolID()
 						}
 						toolResult, _ = sjson.SetBytes(toolResult, "tool_use_id", toolID)
 

--- a/internal/translator/claude/gemini/claude_gemini_request.go
+++ b/internal/translator/claude/gemini/claude_gemini_request.go
@@ -91,6 +91,7 @@ func ConvertGeminiRequestToClaude(modelName string, inputRawJSON []byte, stream 
 	// functionCalls, so we keep a FIFO queue of generated tool IDs and
 	// consume them in order when functionResponses arrive.
 	var pendingToolIDs []string
+	toolIDCounter := 0
 
 	// Model mapping to specify which Claude Code model to use
 	out, _ = sjson.SetBytes(out, "model", modelName)
@@ -272,7 +273,8 @@ func ConvertGeminiRequestToClaude(modelName string, inputRawJSON []byte, stream 
 						// Reuse gateway-provided IDs when present, otherwise generate one for pairing.
 						toolID := getGeminiToolID(fc)
 						if toolID == "" {
-							toolID = translatorcommon.GenerateClaudeToolCallID()
+							toolIDCounter++
+							toolID = fmt.Sprintf("toolu_%d", toolIDCounter)
 						}
 						pendingToolIDs = append(pendingToolIDs, toolID)
 						toolUse, _ = sjson.SetBytes(toolUse, "id", toolID)
@@ -303,7 +305,8 @@ func ConvertGeminiRequestToClaude(modelName string, inputRawJSON []byte, stream 
 							pendingToolIDs = pendingToolIDs[1:]
 						} else {
 							// Fallback: generate new ID if no pending tool_use found
-							toolID = translatorcommon.GenerateClaudeToolCallID()
+							toolIDCounter++
+							toolID = fmt.Sprintf("toolu_%d", toolIDCounter)
 						}
 						toolResult, _ = sjson.SetBytes(toolResult, "tool_use_id", toolID)
 

--- a/internal/translator/claude/gemini/claude_gemini_request_test.go
+++ b/internal/translator/claude/gemini/claude_gemini_request_test.go
@@ -200,3 +200,133 @@ func TestConvertGeminiRequestToClaude_DropsHiddenThoughtParts(t *testing.T) {
 		}
 	})
 }
+
+func TestConvertGeminiRequestToClaude_DeterministicToolIDsAcrossRepeatedTranslations(t *testing.T) {
+	raw := []byte(`{
+		"contents": [
+			{
+				"role": "user",
+				"parts": [{"text": "check weather in Paris and Tokyo"}]
+			},
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "get_weather", "args": {"city": "Paris"}}},
+					{"functionCall": {"name": "get_weather", "args": {"city": "Tokyo"}}}
+				]
+			},
+			{
+				"role": "user",
+				"parts": [
+					{"functionResponse": {"name": "get_weather", "response": {"result": "Paris: 15C"}}},
+					{"functionResponse": {"name": "get_weather", "response": {"result": "Tokyo: 20C"}}}
+				]
+			},
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "get_forecast", "args": {"city": "Paris"}}}
+				]
+			}
+		]
+	}`)
+
+	out1 := ConvertGeminiRequestToClaude("claude-sonnet-4", raw, false)
+	out2 := ConvertGeminiRequestToClaude("claude-sonnet-4", raw, false)
+
+	id1_call0 := gjson.GetBytes(out1, "messages.1.content.0.id").String()
+	id1_call1 := gjson.GetBytes(out1, "messages.1.content.1.id").String()
+	id1_resp0 := gjson.GetBytes(out1, "messages.2.content.0.tool_use_id").String()
+	id1_resp1 := gjson.GetBytes(out1, "messages.2.content.1.tool_use_id").String()
+	id1_call2 := gjson.GetBytes(out1, "messages.3.content.0.id").String()
+
+	id2_call0 := gjson.GetBytes(out2, "messages.1.content.0.id").String()
+	id2_call1 := gjson.GetBytes(out2, "messages.1.content.1.id").String()
+	id2_resp0 := gjson.GetBytes(out2, "messages.2.content.0.tool_use_id").String()
+	id2_resp1 := gjson.GetBytes(out2, "messages.2.content.1.tool_use_id").String()
+	id2_call2 := gjson.GetBytes(out2, "messages.3.content.0.id").String()
+
+	if id1_call0 != id2_call0 || id1_call1 != id2_call1 || id1_call2 != id2_call2 {
+		t.Fatalf("tool_use IDs are not deterministic across calls:\nout1 calls: [%s, %s, %s]\nout2 calls: [%s, %s, %s]",
+			id1_call0, id1_call1, id1_call2, id2_call0, id2_call1, id2_call2)
+	}
+
+	if id1_resp0 != id2_resp0 || id1_resp1 != id2_resp1 {
+		t.Fatalf("tool_result IDs are not deterministic across calls:\nout1 resps: [%s, %s]\nout2 resps: [%s, %s]",
+			id1_resp0, id1_resp1, id2_resp0, id2_resp1)
+	}
+
+	if id1_call0 != id1_resp0 {
+		t.Fatalf("first call ID %q does not match first response ID %q", id1_call0, id1_resp0)
+	}
+	if id1_call1 != id1_resp1 {
+		t.Fatalf("second call ID %q does not match second response ID %q", id1_call1, id1_resp1)
+	}
+}
+
+func TestConvertGeminiRequestToClaude_ToolIDsUniqueWithinRequest(t *testing.T) {
+	raw := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "func1", "args": {}}},
+					{"functionCall": {"name": "func2", "args": {}}},
+					{"functionCall": {"name": "func3", "args": {}}}
+				]
+			}
+		]
+	}`)
+
+	out := ConvertGeminiRequestToClaude("claude-sonnet-4", raw, false)
+	id1 := gjson.GetBytes(out, "messages.0.content.0.id").String()
+	id2 := gjson.GetBytes(out, "messages.0.content.1.id").String()
+	id3 := gjson.GetBytes(out, "messages.0.content.2.id").String()
+
+	if id1 == "" || id2 == "" || id3 == "" {
+		t.Fatalf("expected non-empty IDs, got id1=%q, id2=%q, id3=%q", id1, id2, id3)
+	}
+	if id1 == id2 || id1 == id3 || id2 == id3 {
+		t.Fatalf("tool IDs must be unique within request: id1=%q, id2=%q, id3=%q", id1, id2, id3)
+	}
+}
+
+func TestConvertGeminiRequestToClaude_ExplicitIDWinsOverGenerated(t *testing.T) {
+	raw := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "func1", "id": "explicit_id_123", "args": {}}},
+					{"functionCall": {"name": "func2", "args": {}}}
+				]
+			},
+			{
+				"role": "user",
+				"parts": [
+					{"functionResponse": {"name": "func1", "id": "explicit_id_123", "response": {"result": "ok"}}},
+					{"functionResponse": {"name": "func2", "response": {"result": "ok"}}}
+				]
+			}
+		]
+	}`)
+
+	out := ConvertGeminiRequestToClaude("claude-sonnet-4", raw, false)
+	call0ID := gjson.GetBytes(out, "messages.0.content.0.id").String()
+	call1ID := gjson.GetBytes(out, "messages.0.content.1.id").String()
+	resp0ID := gjson.GetBytes(out, "messages.1.content.0.tool_use_id").String()
+	resp1ID := gjson.GetBytes(out, "messages.1.content.1.tool_use_id").String()
+
+	if call0ID != "explicit_id_123" {
+		t.Fatalf("expected explicit ID %q, got %q", "explicit_id_123", call0ID)
+	}
+	if resp0ID != "explicit_id_123" {
+		t.Fatalf("expected explicit response ID %q, got %q", "explicit_id_123", resp0ID)
+	}
+	if call1ID == "explicit_id_123" {
+		t.Fatalf("generated ID must not collide with explicit ID, got %q", call1ID)
+	}
+	if resp1ID != call1ID {
+		t.Fatalf("generated response ID %q must match generated call ID %q", resp1ID, call1ID)
+	}
+}

--- a/internal/translator/claude/gemini/claude_gemini_request_test.go
+++ b/internal/translator/claude/gemini/claude_gemini_request_test.go
@@ -330,3 +330,76 @@ func TestConvertGeminiRequestToClaude_ExplicitIDWinsOverGenerated(t *testing.T) 
 		t.Fatalf("generated response ID %q must match generated call ID %q", resp1ID, call1ID)
 	}
 }
+
+func TestConvertGeminiRequestToClaude_ExplicitIDCollisionAvoided(t *testing.T) {
+	raw := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "func1", "id": "toolu_1", "args": {}}},
+					{"functionCall": {"name": "func2", "args": {}}}
+				]
+			},
+			{
+				"role": "user",
+				"parts": [
+					{"functionResponse": {"name": "func1", "id": "toolu_1", "response": {"result": "ok1"}}},
+					{"functionResponse": {"name": "func2", "response": {"result": "ok2"}}}
+				]
+			}
+		]
+	}`)
+
+	out := ConvertGeminiRequestToClaude("claude-sonnet-4", raw, false)
+	call0ID := gjson.GetBytes(out, "messages.0.content.0.id").String()
+	call1ID := gjson.GetBytes(out, "messages.0.content.1.id").String()
+	resp0ID := gjson.GetBytes(out, "messages.1.content.0.tool_use_id").String()
+	resp1ID := gjson.GetBytes(out, "messages.1.content.1.tool_use_id").String()
+
+	if call0ID == call1ID {
+		t.Fatalf("duplicate tool_use ID detected: call0=%q, call1=%q", call0ID, call1ID)
+	}
+	if call0ID != "toolu_1" {
+		t.Fatalf("expected call0 ID %q, got %q", "toolu_1", call0ID)
+	}
+	if resp0ID != call0ID {
+		t.Fatalf("response 0 ID %q does not match call 0 ID %q", resp0ID, call0ID)
+	}
+	if resp1ID != call1ID {
+		t.Fatalf("response 1 ID %q does not match call 1 ID %q", resp1ID, call1ID)
+	}
+	if call1ID != "toolu_2" {
+		t.Fatalf("expected call1 ID %q, got %q", "toolu_2", call1ID)
+	}
+}
+
+func TestConvertGeminiRequestToClaude_ExplicitIDAfterGeneratedCollisionAvoided(t *testing.T) {
+	raw := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "func1", "args": {}}},
+					{"functionCall": {"name": "func2", "id": "toolu_1", "args": {}}},
+					{"functionCall": {"name": "func3", "args": {}}}
+				]
+			}
+		]
+	}`)
+
+	out := ConvertGeminiRequestToClaude("claude-sonnet-4", raw, false)
+	call0ID := gjson.GetBytes(out, "messages.0.content.0.id").String()
+	call1ID := gjson.GetBytes(out, "messages.0.content.1.id").String()
+	call2ID := gjson.GetBytes(out, "messages.0.content.2.id").String()
+
+	if call0ID != "toolu_2" {
+		t.Fatalf("expected call0 ID %q (skipping explicit toolu_1), got %q", "toolu_2", call0ID)
+	}
+	if call1ID != "toolu_1" {
+		t.Fatalf("expected call1 ID %q (explicit), got %q", "toolu_1", call1ID)
+	}
+	if call2ID != "toolu_3" {
+		t.Fatalf("expected call2 ID %q, got %q", "toolu_3", call2ID)
+	}
+}

--- a/internal/translator/codex/gemini/codex_gemini_request.go
+++ b/internal/translator/codex/gemini/codex_gemini_request.go
@@ -89,6 +89,35 @@ func ConvertGeminiRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 		return ids
 	}
 
+	usedCallIDs := make(map[string]bool)
+	if contents := root.Get("contents"); contents.Exists() && contents.IsArray() {
+		contents.ForEach(func(_, content gjson.Result) bool {
+			if parts := content.Get("parts"); parts.Exists() && parts.IsArray() {
+				parts.ForEach(func(_, part gjson.Result) bool {
+					if id := getGeminiCallID(part.Get("functionCall")); id != "" {
+						usedCallIDs[id] = true
+					}
+					if id := getGeminiCallID(part.Get("functionResponse")); id != "" {
+						usedCallIDs[id] = true
+					}
+					return true
+				})
+			}
+			return true
+		})
+	}
+
+	generateCallID := func() string {
+		for {
+			callIDCounter++
+			id := fmt.Sprintf("call_%d", callIDCounter)
+			if !usedCallIDs[id] {
+				usedCallIDs[id] = true
+				return id
+			}
+		}
+	}
+
 	// Model
 	out, _ = sjson.SetBytes(out, "model", modelName)
 	if serviceTier := normalizeGeminiCodexServiceTier(root.Get("service_tier")); serviceTier != "" {
@@ -185,8 +214,7 @@ func ConvertGeminiRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 					// Reuse gateway-provided IDs when present, otherwise generate one for pairing.
 					id := getGeminiCallID(fc)
 					if id == "" {
-						callIDCounter++
-						id = fmt.Sprintf("call_%d", callIDCounter)
+						id = generateCallID()
 					}
 					fn, _ = sjson.SetBytes(fn, "call_id", id)
 					pendingCallIDs = append(pendingCallIDs, id)
@@ -215,8 +243,7 @@ func ConvertGeminiRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 						// pop the first element
 						pendingCallIDs = pendingCallIDs[1:]
 					} else {
-						callIDCounter++
-						id = fmt.Sprintf("call_%d", callIDCounter)
+						id = generateCallID()
 					}
 					fno, _ = sjson.SetBytes(fno, "call_id", id)
 					inputItems = append(inputItems, fno)

--- a/internal/translator/codex/gemini/codex_gemini_request.go
+++ b/internal/translator/codex/gemini/codex_gemini_request.go
@@ -6,9 +6,7 @@
 package gemini
 
 import (
-	"crypto/rand"
 	"fmt"
-	"math/big"
 	"strconv"
 	"strings"
 
@@ -65,23 +63,12 @@ func ConvertGeminiRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 		}
 	}
 
-	// helper for generating paired call IDs in the form: call_<alphanum>
+	// helper for generating paired call IDs in the form: call_<number>
 	// Gemini uses sequential pairing across possibly multiple in-flight
 	// functionCalls, so we keep a FIFO queue of generated call IDs and
 	// consume them in order when functionResponses arrive.
 	var pendingCallIDs []string
-
-	// genCallID creates a random call id like: call_<8chars>
-	genCallID := func() string {
-		const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-		var b strings.Builder
-		// 8 chars random suffix
-		for i := 0; i < 24; i++ {
-			n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
-			b.WriteByte(letters[n.Int64()])
-		}
-		return "call_" + b.String()
-	}
+	callIDCounter := 0
 
 	getGeminiCallID := func(value gjson.Result) string {
 		if callID := strings.TrimSpace(value.Get("id").String()); callID != "" {
@@ -198,7 +185,8 @@ func ConvertGeminiRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 					// Reuse gateway-provided IDs when present, otherwise generate one for pairing.
 					id := getGeminiCallID(fc)
 					if id == "" {
-						id = genCallID()
+						callIDCounter++
+						id = fmt.Sprintf("call_%d", callIDCounter)
 					}
 					fn, _ = sjson.SetBytes(fn, "call_id", id)
 					pendingCallIDs = append(pendingCallIDs, id)
@@ -227,7 +215,8 @@ func ConvertGeminiRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 						// pop the first element
 						pendingCallIDs = pendingCallIDs[1:]
 					} else {
-						id = genCallID()
+						callIDCounter++
+						id = fmt.Sprintf("call_%d", callIDCounter)
 					}
 					fno, _ = sjson.SetBytes(fno, "call_id", id)
 					inputItems = append(inputItems, fno)

--- a/internal/translator/codex/gemini/codex_gemini_request_test.go
+++ b/internal/translator/codex/gemini/codex_gemini_request_test.go
@@ -115,3 +115,133 @@ func TestConvertGeminiRequestToCodex_DropsHiddenThoughtParts(t *testing.T) {
 		}
 	})
 }
+
+func TestConvertGeminiRequestToCodex_DeterministicCallIDsAcrossRepeatedTranslations(t *testing.T) {
+	raw := []byte(`{
+		"contents": [
+			{
+				"role": "user",
+				"parts": [{"text": "check weather in Paris and Tokyo"}]
+			},
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "get_weather", "args": {"city": "Paris"}}},
+					{"functionCall": {"name": "get_weather", "args": {"city": "Tokyo"}}}
+				]
+			},
+			{
+				"role": "user",
+				"parts": [
+					{"functionResponse": {"name": "get_weather", "response": {"result": "Paris: 15C"}}},
+					{"functionResponse": {"name": "get_weather", "response": {"result": "Tokyo: 20C"}}}
+				]
+			},
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "get_forecast", "args": {"city": "Paris"}}}
+				]
+			}
+		]
+	}`)
+
+	out1 := ConvertGeminiRequestToCodex("gpt-5.1-codex", raw, false)
+	out2 := ConvertGeminiRequestToCodex("gpt-5.1-codex", raw, false)
+
+	call1_id1 := gjson.GetBytes(out1, "input.1.call_id").String()
+	call2_id1 := gjson.GetBytes(out1, "input.2.call_id").String()
+	resp1_id1 := gjson.GetBytes(out1, "input.3.call_id").String()
+	resp2_id1 := gjson.GetBytes(out1, "input.4.call_id").String()
+	call3_id1 := gjson.GetBytes(out1, "input.5.call_id").String()
+
+	call1_id2 := gjson.GetBytes(out2, "input.1.call_id").String()
+	call2_id2 := gjson.GetBytes(out2, "input.2.call_id").String()
+	resp1_id2 := gjson.GetBytes(out2, "input.3.call_id").String()
+	resp2_id2 := gjson.GetBytes(out2, "input.4.call_id").String()
+	call3_id2 := gjson.GetBytes(out2, "input.5.call_id").String()
+
+	if call1_id1 != call1_id2 || call2_id1 != call2_id2 || call3_id1 != call3_id2 {
+		t.Fatalf("call_ids are not deterministic across calls:\nout1 calls: [%s, %s, %s]\nout2 calls: [%s, %s, %s]",
+			call1_id1, call2_id1, call3_id1, call1_id2, call2_id2, call3_id2)
+	}
+
+	if resp1_id1 != resp1_id2 || resp2_id1 != resp2_id2 {
+		t.Fatalf("function_call_output call_ids are not deterministic across calls:\nout1 resps: [%s, %s]\nout2 resps: [%s, %s]",
+			resp1_id1, resp2_id1, resp1_id2, resp2_id2)
+	}
+
+	if call1_id1 != resp1_id1 {
+		t.Fatalf("first call ID %q does not match first response ID %q", call1_id1, resp1_id1)
+	}
+	if call2_id1 != resp2_id1 {
+		t.Fatalf("second call ID %q does not match second response ID %q", call2_id1, resp2_id1)
+	}
+}
+
+func TestConvertGeminiRequestToCodex_CallIDsUniqueWithinRequest(t *testing.T) {
+	raw := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "func1", "args": {}}},
+					{"functionCall": {"name": "func2", "args": {}}},
+					{"functionCall": {"name": "func3", "args": {}}}
+				]
+			}
+		]
+	}`)
+
+	out := ConvertGeminiRequestToCodex("gpt-5.1-codex", raw, false)
+	id1 := gjson.GetBytes(out, "input.0.call_id").String()
+	id2 := gjson.GetBytes(out, "input.1.call_id").String()
+	id3 := gjson.GetBytes(out, "input.2.call_id").String()
+
+	if id1 == "" || id2 == "" || id3 == "" {
+		t.Fatalf("expected non-empty IDs, got id1=%q, id2=%q, id3=%q", id1, id2, id3)
+	}
+	if id1 == id2 || id1 == id3 || id2 == id3 {
+		t.Fatalf("call IDs must be unique within request: id1=%q, id2=%q, id3=%q", id1, id2, id3)
+	}
+}
+
+func TestConvertGeminiRequestToCodex_ExplicitIDWinsOverGenerated(t *testing.T) {
+	raw := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "func1", "id": "explicit_call_123", "args": {}}},
+					{"functionCall": {"name": "func2", "args": {}}}
+				]
+			},
+			{
+				"role": "user",
+				"parts": [
+					{"functionResponse": {"name": "func1", "id": "explicit_call_123", "response": {"result": "ok"}}},
+					{"functionResponse": {"name": "func2", "response": {"result": "ok"}}}
+				]
+			}
+		]
+	}`)
+
+	out := ConvertGeminiRequestToCodex("gpt-5.1-codex", raw, false)
+	call0ID := gjson.GetBytes(out, "input.0.call_id").String()
+	call1ID := gjson.GetBytes(out, "input.1.call_id").String()
+	resp0ID := gjson.GetBytes(out, "input.2.call_id").String()
+	resp1ID := gjson.GetBytes(out, "input.3.call_id").String()
+
+	if call0ID != "explicit_call_123" {
+		t.Fatalf("expected explicit ID %q, got %q", "explicit_call_123", call0ID)
+	}
+	if resp0ID != "explicit_call_123" {
+		t.Fatalf("expected explicit response ID %q, got %q", "explicit_call_123", resp0ID)
+	}
+	if call1ID == "explicit_call_123" {
+		t.Fatalf("generated ID must not collide with explicit ID, got %q", call1ID)
+	}
+	if resp1ID != call1ID {
+		t.Fatalf("generated response ID %q must match generated call ID %q", resp1ID, call1ID)
+	}
+}

--- a/internal/translator/codex/gemini/codex_gemini_request_test.go
+++ b/internal/translator/codex/gemini/codex_gemini_request_test.go
@@ -245,3 +245,76 @@ func TestConvertGeminiRequestToCodex_ExplicitIDWinsOverGenerated(t *testing.T) {
 		t.Fatalf("generated response ID %q must match generated call ID %q", resp1ID, call1ID)
 	}
 }
+
+func TestConvertGeminiRequestToCodex_ExplicitIDCollisionAvoided(t *testing.T) {
+	raw := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "func1", "id": "call_1", "args": {}}},
+					{"functionCall": {"name": "func2", "args": {}}}
+				]
+			},
+			{
+				"role": "user",
+				"parts": [
+					{"functionResponse": {"name": "func1", "id": "call_1", "response": {"result": "ok1"}}},
+					{"functionResponse": {"name": "func2", "response": {"result": "ok2"}}}
+				]
+			}
+		]
+	}`)
+
+	out := ConvertGeminiRequestToCodex("gpt-5.1-codex", raw, false)
+	call0ID := gjson.GetBytes(out, "input.0.call_id").String()
+	call1ID := gjson.GetBytes(out, "input.1.call_id").String()
+	resp0ID := gjson.GetBytes(out, "input.2.call_id").String()
+	resp1ID := gjson.GetBytes(out, "input.3.call_id").String()
+
+	if call0ID == call1ID {
+		t.Fatalf("duplicate call_id detected: call0=%q, call1=%q", call0ID, call1ID)
+	}
+	if call0ID != "call_1" {
+		t.Fatalf("expected call0 ID %q, got %q", "call_1", call0ID)
+	}
+	if resp0ID != call0ID {
+		t.Fatalf("response 0 ID %q does not match call 0 ID %q", resp0ID, call0ID)
+	}
+	if resp1ID != call1ID {
+		t.Fatalf("response 1 ID %q does not match call 1 ID %q", resp1ID, call1ID)
+	}
+	if call1ID != "call_2" {
+		t.Fatalf("expected call1 ID %q, got %q", "call_2", call1ID)
+	}
+}
+
+func TestConvertGeminiRequestToCodex_ExplicitIDAfterGeneratedCollisionAvoided(t *testing.T) {
+	raw := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "func1", "args": {}}},
+					{"functionCall": {"name": "func2", "id": "call_1", "args": {}}},
+					{"functionCall": {"name": "func3", "args": {}}}
+				]
+			}
+		]
+	}`)
+
+	out := ConvertGeminiRequestToCodex("gpt-5.1-codex", raw, false)
+	call0ID := gjson.GetBytes(out, "input.0.call_id").String()
+	call1ID := gjson.GetBytes(out, "input.1.call_id").String()
+	call2ID := gjson.GetBytes(out, "input.2.call_id").String()
+
+	if call0ID != "call_2" {
+		t.Fatalf("expected call0 ID %q (skipping explicit call_1), got %q", "call_2", call0ID)
+	}
+	if call1ID != "call_1" {
+		t.Fatalf("expected call1 ID %q (explicit), got %q", "call_1", call1ID)
+	}
+	if call2ID != "call_3" {
+		t.Fatalf("expected call2 ID %q, got %q", "call_3", call2ID)
+	}
+}


### PR DESCRIPTION
## Problem

In Gemini API multi-turn conversations, the client re-sends the entire conversation history in `contents` on each turn. Gemini `functionCall` and `functionResponse` objects do not carry mandatory ID fields.

When translating Gemini requests to Claude (`ConvertGeminiRequestToClaude`) and Codex (`ConvertGeminiRequestToCodex`), missing tool/call IDs were generated using random number generators (`crypto/rand`). Consequently, historical tool calls were assigned different random IDs on every subsequent turn, completely invalidating upstream LLM prompt caches (Anthropic Prompt Caching and OpenAI Prefix Caching) and resulting in a 100% cache miss rate, higher latencies, and increased token costs.

## Fix

- `internal/translator/claude/gemini/claude_gemini_request.go:89`: Pre-scans payload `contents` for existing explicit tool IDs and generates deterministic sequential IDs (`toolu_1`, `toolu_2`, ...) while avoiding collisions with explicit IDs.
- `internal/translator/codex/gemini/codex_gemini_request.go:92`: Pre-scans payload `contents` for existing explicit call IDs and generates deterministic sequential IDs (`call_1`, `call_2`, ...) while avoiding collisions with explicit IDs.

## Tests

- `internal/translator/claude/gemini/claude_gemini_request_test.go`:
  - `TestConvertGeminiRequestToClaude_DeterministicToolIDsAcrossRepeatedTranslations`: Verifies identical multi-turn history produces byte-for-byte identical tool IDs across multiple translations.
  - `TestConvertGeminiRequestToClaude_ToolIDsUniqueWithinRequest`: Verifies tool IDs within a single request are distinct.
  - `TestConvertGeminiRequestToClaude_ExplicitIDWinsOverGenerated`: Verifies explicit tool IDs in Gemini payload are preserved.
  - `TestConvertGeminiRequestToClaude_ExplicitIDCollisionAvoided`: Verifies generated IDs skip existing explicit IDs.
  - `TestConvertGeminiRequestToClaude_ExplicitIDAfterGeneratedCollisionAvoided`: Verifies collision avoidance regardless of payload ordering.
- `internal/translator/codex/gemini/codex_gemini_request_test.go`:
  - `TestConvertGeminiRequestToCodex_DeterministicCallIDsAcrossRepeatedTranslations`: Verifies repeated translation produces identical call IDs.
  - `TestConvertGeminiRequestToCodex_CallIDsUniqueWithinRequest`: Verifies unique call IDs per request.
  - `TestConvertGeminiRequestToCodex_ExplicitIDWinsOverGenerated`: Verifies explicit call IDs are preserved.
  - `TestConvertGeminiRequestToCodex_ExplicitIDCollisionAvoided`: Verifies generated IDs avoid collisions with explicit call IDs.
  - `TestConvertGeminiRequestToCodex_ExplicitIDAfterGeneratedCollisionAvoided`: Verifies collision avoidance across mixed ordering.

## Reverse bite-check

Reverting `internal/translator/claude/gemini/claude_gemini_request.go` and `internal/translator/codex/gemini/codex_gemini_request.go` to random ID generation produces immediate test failures across both test suites:

Claude Request Translator:
```
=== RUN   TestConvertGeminiRequestToClaude_DeterministicToolIDsAcrossRepeatedTranslations
    claude_gemini_request_test.go:250: tool_use IDs are not deterministic across calls:
        out1 calls: [toolu_GBXaebiBnT2nWvOPEvJeYpVD, toolu_UqDNQQjDLrdtAErZSyJsUytF, toolu_DyF6gGM0PQZqX6bwugXOfjXp]
        out2 calls: [toolu_b9hCGM05swi08thosO2D8IvQ, toolu_PHERlbkrnw43EcT5UrylPjqO, toolu_TVPx9Yn9YE2KAp41vQcL58BF]
--- FAIL: TestConvertGeminiRequestToClaude_DeterministicToolIDsAcrossRepeatedTranslations (0.00s)
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/internal/translator/claude/gemini	0.387s
FAIL
```

Codex Request Translator:
```
=== RUN   TestConvertGeminiRequestToCodex_DeterministicCallIDsAcrossRepeatedTranslations
    codex_gemini_request_test.go:165: call_ids are not deterministic across calls:
        out1 calls: [call_pFVszrqhUIaFkXfjRutkkjav, call_YcHreuho35BMa0ITEYB2mmfU, call_at1qfq2g9gP51I0frhMwA4qW]
        out2 calls: [call_dlzqOPHpsgGLMAnibWEn8UHr, call_lbJ2dL232dlm7CNv7y14qUpf, call_i0HJeoEYHsfO2Og7l1aoRdSY]
--- FAIL: TestConvertGeminiRequestToCodex_DeterministicCallIDsAcrossRepeatedTranslations (0.00s)
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/internal/translator/codex/gemini	0.388s
FAIL
```

## Verification

```bash
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go build ./...
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go vet ./internal/translator/claude/gemini/... ./internal/translator/codex/gemini/...
gofmt -l internal/translator/claude/gemini/claude_gemini_request.go internal/translator/claude/gemini/claude_gemini_request_test.go internal/translator/codex/gemini/codex_gemini_request.go internal/translator/codex/gemini/codex_gemini_request_test.go
TMPDIR=/Users/warelik/.cache/gotmp GOCACHE=/Users/warelik/.cache/gocache go test -v -run "TestConvertGeminiRequestToClaude_DeterministicToolIDsAcrossRepeatedTranslations|TestConvertGeminiRequestToCodex_DeterministicCallIDsAcrossRepeatedTranslations" ./internal/translator/claude/gemini/... ./internal/translator/codex/gemini/...
```

Output:
```
=== RUN   TestConvertGeminiRequestToClaude_DeterministicToolIDsAcrossRepeatedTranslations
--- PASS: TestConvertGeminiRequestToClaude_DeterministicToolIDsAcrossRepeatedTranslations (0.00s)
PASS
ok  	github.com/router-for-me/CLIProxyAPI/v7/internal/translator/claude/gemini	0.748s
=== RUN   TestConvertGeminiRequestToCodex_DeterministicCallIDsAcrossRepeatedTranslations
--- PASS: TestConvertGeminiRequestToCodex_DeterministicCallIDsAcrossRepeatedTranslations (0.00s)
PASS
ok  	github.com/router-for-me/CLIProxyAPI/v7/internal/translator/codex/gemini	0.407s
```

### Tooling note

The `jbcontext` semantic-search CLI is installed but non-functional in this environment
(`jbcontext search` fails with `the OS keychain is not accessible`). The equivalent
review passes were performed with the repository's own tooling and manual inspection
instead; this is disclosed for transparency about how the change was reviewed.
