### PR TITLE
fix(auth): rotate on in-stream provider errors during bootstrap

### DIFF
--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -281,6 +281,9 @@ func readStreamBootstrap(ctx context.Context, ch <-chan cliproxyexecutor.StreamC
 			chunk, ok = <-ch
 		}
 		if !ok {
+			if err := bootstrap.streamError(); err != nil && !bootstrap.hasMeaningfulOutput() {
+				return nil, false, err
+			}
 			return buffered, true, nil
 		}
 		if chunk.Err != nil {
@@ -298,6 +301,12 @@ func readStreamBootstrap(ctx context.Context, ch <-chan cliproxyexecutor.StreamC
 		buffered = append(buffered, chunk)
 		if bootstrap.observe(chunk.Payload) {
 			return buffered, false, nil
+		}
+		if err := bootstrap.streamError(); err != nil {
+			if bootstrap.hasMeaningfulOutput() {
+				return buffered, false, nil
+			}
+			return nil, false, err
 		}
 		if bootstrap.isTerminalEmpty() {
 			return buffered, true, nil
@@ -328,6 +337,16 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr, Options: opts}
 				applyRequestScopedActionToResult(action, okAction, &result)
 				m.recordExecutionResult(ctx, result, auth, ephemeralResult)
+			}
+			if !failed && len(chunk.Payload) > 0 {
+				if streamErr := detectStreamPayloadError(chunk.Payload); streamErr != nil {
+					failed = true
+					rerr := resultErrorFromError(streamErr)
+					action, okAction := matchRequestScopedErrorAction(auth, streamErr, m.runtimeConfigSnapshot())
+					result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr, Options: opts}
+					applyRequestScopedActionToResult(action, okAction, &result)
+					m.recordExecutionResult(ctx, result, auth, ephemeralResult)
+				}
 			}
 			if !forward {
 				return false

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -281,6 +281,10 @@ func readStreamBootstrap(ctx context.Context, ch <-chan cliproxyexecutor.StreamC
 			chunk, ok = <-ch
 		}
 		if !ok {
+			// A final frame without its blank-line delimiter is only parsed by
+			// finish(): without it a provider error carried by that last frame stays
+			// pending and the stream looks like a clean close.
+			bootstrap.finish()
 			if err := bootstrap.streamError(); err != nil && !bootstrap.hasMeaningfulOutput() {
 				return nil, false, err
 			}

--- a/sdk/cliproxy/auth/conductor_stream_eof_test.go
+++ b/sdk/cliproxy/auth/conductor_stream_eof_test.go
@@ -1,0 +1,36 @@
+package auth
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// TestReadStreamBootstrapFinalizesDetectorAtEOF covers an upstream that closes the
+// channel right after an SSE error event whose data line is newline-terminated but
+// never followed by the blank separator line. flushData() only runs on that blank
+// line or from finish(), so without finalizing the bootstrap state the provider
+// error stays buffered, the bootstrap reports a clean close, and the caller gets an
+// empty stream instead of a routable failure it can fail over on.
+func TestReadStreamBootstrapFinalizesDetectorAtEOF(t *testing.T) {
+	ch := make(chan cliproxyexecutor.StreamChunk, 2)
+	ch <- cliproxyexecutor.StreamChunk{Payload: []byte("data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n\n")}
+	ch <- cliproxyexecutor.StreamChunk{Payload: []byte("event: error\ndata: {\"error\":{\"code\":\"invalid_api_key\",\"message\":\"invalid api key\"}}\n")}
+	close(ch)
+
+	buffered, closed, err := readStreamBootstrap(context.Background(), ch)
+	if err == nil {
+		t.Fatalf("readStreamBootstrap() error = nil, want the in-band provider error (closed=%v, buffered=%d)", closed, len(buffered))
+	}
+	if !strings.Contains(err.Error(), "invalid api key") {
+		t.Fatalf("readStreamBootstrap() error = %v, want the invalid api key provider error", err)
+	}
+	if closed {
+		t.Fatal("closed = true, want false so the caller can fail over")
+	}
+	if len(buffered) != 0 {
+		t.Fatalf("len(buffered) = %d, want 0 when the provider error propagates", len(buffered))
+	}
+}

--- a/sdk/cliproxy/auth/empty_completion.go
+++ b/sdk/cliproxy/auth/empty_completion.go
@@ -8,8 +8,10 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"strconv"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
@@ -1025,21 +1027,33 @@ func isEmptyCompletionError(err error) bool {
 // streamBootstrapState incrementally evaluates chunks so a metadata-heavy
 // prefix is processed once instead of reparsing the entire prefix per chunk.
 type streamBootstrapState struct {
-	acc       emptyCompletionAccum
-	bytes     int
-	pending   []byte
-	dataLines [][]byte
-	forward   bool
-	sawSSE    bool
-	sawDone   bool
+	acc          emptyCompletionAccum
+	bytes        int
+	pending      []byte
+	dataLines    [][]byte
+	forward      bool
+	sawSSE       bool
+	sawDone      bool
+	currentEvent string
+	streamErr    *Error
+}
+
+func (s *streamBootstrapState) streamError() error {
+	if s == nil || s.streamErr == nil {
+		return nil
+	}
+	return s.streamErr
 }
 
 func (s *streamBootstrapState) flushData() {
 	if len(s.dataLines) == 0 {
+		s.currentEvent = ""
 		return
 	}
 	data := bytes.Join(s.dataLines, []byte("\n"))
 	s.dataLines = s.dataLines[:0]
+	currentEvent := s.currentEvent
+	s.currentEvent = ""
 	if bytes.Equal(data, []byte("[DONE]")) {
 		s.acc.recognized = true
 		s.acc.terminal = true
@@ -1048,7 +1062,13 @@ func (s *streamBootstrapState) flushData() {
 		return
 	}
 	if len(data) == 0 {
-		s.acc.sawMetadataOnly = true
+		if currentEvent != "error" {
+			s.acc.sawMetadataOnly = true
+		}
+		return
+	}
+	if err := evalProviderError(data, currentEvent); err != nil {
+		s.streamErr = err
 		return
 	}
 	if !s.acc.evalJSON(data) {
@@ -1091,12 +1111,15 @@ func (s *streamBootstrapState) processSingleLine(line []byte) {
 	switch {
 	case bytes.HasPrefix(line, []byte("event:")):
 		s.sawSSE = true
-		event := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("event:")))
-		if bytes.Equal(event, []byte("message_stop")) {
+		event := strings.TrimSpace(string(bytes.TrimPrefix(line, []byte("event:"))))
+		s.currentEvent = event
+		if event == "message_stop" {
 			s.acc.recognized = true
 			s.acc.terminal = true
 			s.acc.sawMessageData = true
 			s.sawDone = true
+		} else if event == "error" {
+			// Do not mark metadata only as success signal on error event
 		} else {
 			s.acc.sawMetadataOnly = true
 		}
@@ -1120,7 +1143,9 @@ func (s *streamBootstrapState) processSingleLine(line []byte) {
 		s.dataLines = append(s.dataLines, line)
 	default:
 		if classify := classifyJSONBuffer(line); classify == jsonBufComplete || classify == jsonBufIncomplete {
-			if !s.acc.evalJSON(line) {
+			if err := evalProviderError(line, ""); err != nil {
+				s.streamErr = err
+			} else if !s.acc.evalJSON(line) {
 				s.acc.sawUnknownData = true
 			}
 		} else {
@@ -1176,7 +1201,9 @@ func (s *streamBootstrapState) observe(fragment []byte) bool {
 	}
 	switch classifyJSONBuffer(trimmed) {
 	case jsonBufComplete:
-		if !s.acc.evalJSON(trimmed) {
+		if err := evalProviderError(trimmed, ""); err != nil {
+			s.streamErr = err
+		} else if !s.acc.evalJSON(trimmed) {
 			s.acc.sawUnknownData = true
 		}
 		s.pending = s.pending[:0]
@@ -1215,6 +1242,9 @@ func (s *streamBootstrapState) hasMeaningfulOutput() bool {
 	if s.acc.hasContent || s.acc.hasToolCalls || s.acc.blocked || (s.acc.sawUsage && s.acc.completionTokens > 0) || s.acc.sawUnknownData {
 		return true
 	}
+	if s.streamErr != nil {
+		return false
+	}
 	if !s.acc.recognized && !s.sawSSE && s.bytes > 0 {
 		return true
 	}
@@ -1222,7 +1252,238 @@ func (s *streamBootstrapState) hasMeaningfulOutput() bool {
 }
 
 func (s *streamBootstrapState) shouldForward() bool {
+	if s.streamErr != nil {
+		return false
+	}
 	return s.acc.hasContent || s.acc.hasToolCalls || s.acc.blocked || (s.acc.sawUsage && s.acc.completionTokens > 0) || s.acc.sawUnknownData || (!s.acc.recognized && !s.sawSSE)
+}
+
+type streamErrorEnvelope struct {
+	Type    string          `json:"type"`
+	Error   json.RawMessage `json:"error"`
+	Message string          `json:"message"`
+	Code    json.RawMessage `json:"code"`
+	Status  string          `json:"status"`
+}
+
+func inferHTTPStatus(typeStr, codeStr, statusStr string) int {
+	if statusStr != "" {
+		switch strings.ToUpper(strings.TrimSpace(statusStr)) {
+		case "RESOURCE_EXHAUSTED":
+			return http.StatusTooManyRequests
+		case "UNAUTHENTICATED":
+			return http.StatusUnauthorized
+		case "PERMISSION_DENIED":
+			return http.StatusForbidden
+		case "UNAVAILABLE":
+			return http.StatusServiceUnavailable
+		case "DEADLINE_EXCEEDED":
+			return http.StatusGatewayTimeout
+		case "INTERNAL":
+			return http.StatusInternalServerError
+		case "INVALID_ARGUMENT", "FAILED_PRECONDITION":
+			return http.StatusBadRequest
+		case "NOT_FOUND":
+			return http.StatusNotFound
+		case "ALREADY_EXISTS":
+			return http.StatusConflict
+		}
+	}
+	for _, s := range []string{typeStr, codeStr} {
+		switch strings.ToLower(strings.TrimSpace(s)) {
+		case "overloaded_error", "overloaded":
+			return http.StatusServiceUnavailable
+		case "rate_limit_error", "rate_limit_exceeded", "insufficient_quota", "quota_exceeded", "requests":
+			return http.StatusTooManyRequests
+		case "authentication_error", "invalid_api_key", "unauthorized":
+			return http.StatusUnauthorized
+		case "permission_error", "forbidden":
+			return http.StatusForbidden
+		case "not_found_error":
+			return http.StatusNotFound
+		case "invalid_request_error", "bad_request_error", "invalid_prompt", "cyber_policy", "context_length_exceeded":
+			return http.StatusBadRequest
+		case "api_error", "internal_server_error":
+			return http.StatusInternalServerError
+		}
+	}
+	return 0
+}
+
+func parseStreamErrorFromEnvelope(data []byte, envelope streamErrorEnvelope) *Error {
+	var detail struct {
+		Message string          `json:"message"`
+		Type    string          `json:"type"`
+		Code    json.RawMessage `json:"code"`
+		Status  string          `json:"status"`
+	}
+
+	var rawErrorString string
+	if len(envelope.Error) > 0 {
+		trimmedErr := bytes.TrimSpace(envelope.Error)
+		if bytes.HasPrefix(trimmedErr, []byte("{")) {
+			_ = json.Unmarshal(trimmedErr, &detail)
+		} else if bytes.HasPrefix(trimmedErr, []byte("\"")) {
+			_ = json.Unmarshal(trimmedErr, &rawErrorString)
+		}
+	}
+
+	message := detail.Message
+	if message == "" {
+		message = envelope.Message
+	}
+	if message == "" {
+		message = rawErrorString
+	}
+	if message == "" && detail.Type != "" {
+		message = detail.Type
+	}
+	if message == "" && detail.Status != "" {
+		message = detail.Status
+	}
+	if message == "" && len(data) > 0 && !bytes.HasPrefix(data, []byte("{")) {
+		message = string(data)
+	}
+	if message == "" {
+		message = "upstream stream error"
+	}
+
+	code := ""
+	var rawCodeInt int
+
+	extractCode := func(raw json.RawMessage) {
+		if len(raw) == 0 {
+			return
+		}
+		var strCode string
+		if json.Unmarshal(raw, &strCode) == nil && strings.TrimSpace(strCode) != "" {
+			code = strings.TrimSpace(strCode)
+			if num, err := strconv.Atoi(code); err == nil && num > 0 {
+				rawCodeInt = num
+			}
+			return
+		}
+		var num json.Number
+		if json.Unmarshal(raw, &num) == nil {
+			if n, err := num.Int64(); err == nil && n > 0 {
+				rawCodeInt = int(n)
+				code = strconv.Itoa(rawCodeInt)
+			}
+		}
+	}
+
+	extractCode(detail.Code)
+	if code == "" {
+		extractCode(envelope.Code)
+	}
+	if code == "" && detail.Type != "" {
+		code = detail.Type
+	}
+	if code == "" && detail.Status != "" {
+		code = detail.Status
+	}
+	if code == "" && envelope.Type != "" && !strings.EqualFold(envelope.Type, "error") {
+		code = envelope.Type
+	}
+
+	status := rawCodeInt
+	statusStr := strings.TrimSpace(detail.Status)
+	if statusStr == "" {
+		statusStr = strings.TrimSpace(envelope.Status)
+	}
+	typeStr := strings.TrimSpace(detail.Type)
+	if typeStr == "" {
+		typeStr = strings.TrimSpace(envelope.Type)
+	}
+
+	if status == 0 {
+		status = inferHTTPStatus(typeStr, code, statusStr)
+	}
+
+	if status == 0 {
+		lowerMsg := strings.ToLower(message)
+		switch {
+		case strings.Contains(lowerMsg, "rate limit") || strings.Contains(lowerMsg, "resource exhausted") || strings.Contains(lowerMsg, "too many requests") || strings.Contains(lowerMsg, "quota"):
+			status = http.StatusTooManyRequests
+		case strings.Contains(lowerMsg, "overloaded"):
+			status = http.StatusServiceUnavailable
+		case strings.Contains(lowerMsg, "unauthorized") || strings.Contains(lowerMsg, "invalid api key") || strings.Contains(lowerMsg, "invalid x-api-key") || strings.Contains(lowerMsg, "unauthenticated"):
+			status = http.StatusUnauthorized
+		case strings.Contains(lowerMsg, "permission denied") || strings.Contains(lowerMsg, "forbidden"):
+			status = http.StatusForbidden
+		default:
+			status = http.StatusBadGateway
+		}
+	}
+
+	err := &Error{
+		Code:       code,
+		Message:    message,
+		HTTPStatus: status,
+	}
+
+	if isRequestInvalidError(err) || clienterror.IsRequestFault(status, errors.New(string(data))) {
+		err.Retryable = false
+	} else {
+		err.Retryable = true
+	}
+
+	return err
+}
+
+func evalProviderError(data []byte, sseEvent string) *Error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil
+	}
+
+	var envelope streamErrorEnvelope
+	isError := strings.EqualFold(sseEvent, "error")
+
+	if bytes.HasPrefix(trimmed, []byte("{")) {
+		if err := json.Unmarshal(trimmed, &envelope); err == nil {
+			if len(envelope.Error) > 0 && !bytes.Equal(envelope.Error, []byte("null")) {
+				isError = true
+			} else if strings.EqualFold(envelope.Type, "error") {
+				isError = true
+			}
+		}
+	}
+
+	if !isError {
+		return nil
+	}
+
+	return parseStreamErrorFromEnvelope(trimmed, envelope)
+}
+
+func detectStreamPayloadError(payload []byte) *Error {
+	trimmed := bytes.TrimSpace(payload)
+	if len(trimmed) == 0 {
+		return nil
+	}
+	if isSSEPayload(trimmed) {
+		var currentEvent string
+		for _, line := range bytes.Split(trimmed, []byte("\n")) {
+			line = bytes.TrimSpace(line)
+			if len(line) == 0 {
+				currentEvent = ""
+				continue
+			}
+			if bytes.HasPrefix(line, []byte("event:")) {
+				currentEvent = strings.TrimSpace(string(bytes.TrimPrefix(line, []byte("event:"))))
+				continue
+			}
+			if bytes.HasPrefix(line, []byte("data:")) {
+				data := parseSSEDataLine(line)
+				if err := evalProviderError(data, currentEvent); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	return evalProviderError(trimmed, "")
 }
 
 type jsonBufferStatus int

--- a/sdk/cliproxy/auth/empty_completion_test.go
+++ b/sdk/cliproxy/auth/empty_completion_test.go
@@ -3112,3 +3112,179 @@ func TestEmptyCompletionResponsesImageGenerationCallResult(t *testing.T) {
 		t.Fatalf("StreamBootstrapDetector.Observe(whitespace result) = %v, want false", got)
 	}
 }
+
+func TestExecuteStreamInStreamGemini429ErrorRotatesAuth(t *testing.T) {
+	executor := &emptyCompletionTestExecutor{
+		streamPayloads: map[string][][]byte{},
+		streamCalls:    map[string]int{},
+		emptyStreamPayload: [][]byte{
+			[]byte("data: {\"error\":{\"code\":429,\"message\":\"Resource exhausted\",\"status\":\"RESOURCE_EXHAUSTED\"}}\n\n"),
+		},
+		contentStreamPayload: [][]byte{
+			[]byte("data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"gemini response\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"candidatesTokenCount\":5}}\n\n"),
+		},
+	}
+	manager, ids, model, capture := newEmptyCompletionTestManager(t, executor)
+
+	stream, err := manager.ExecuteStream(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	if stream == nil {
+		t.Fatal("ExecuteStream() returned nil stream")
+	}
+	var got strings.Builder
+	for chunk := range stream.Chunks {
+		got.Write(chunk.Payload)
+	}
+	assertRotatesToContent(t, ids, executor.firstStream, got.String(), "gemini response", capture)
+
+	if auth, ok := manager.GetByID(executor.firstStream); ok && auth != nil {
+		if !auth.Unavailable && auth.NextRetryAfter.IsZero() && !auth.Quota.Exceeded {
+			t.Fatalf("auth %q was not marked unavailable or quota exceeded after in-stream 429 error", executor.firstStream)
+		}
+	}
+}
+
+func TestExecuteStreamInStreamClaudeOverloadedErrorRotatesAuth(t *testing.T) {
+	executor := &emptyCompletionTestExecutor{
+		streamPayloads: map[string][][]byte{},
+		streamCalls:    map[string]int{},
+		emptyStreamPayload: [][]byte{
+			[]byte("event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"Overloaded\"}}\n\n"),
+		},
+		contentStreamPayload: [][]byte{
+			[]byte("data: {\"choices\":[{\"delta\":{\"content\":\"claude response\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
+		},
+	}
+	manager, ids, model, capture := newEmptyCompletionTestManager(t, executor)
+
+	stream, err := manager.ExecuteStream(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	if stream == nil {
+		t.Fatal("ExecuteStream() returned nil stream")
+	}
+	var got strings.Builder
+	for chunk := range stream.Chunks {
+		got.Write(chunk.Payload)
+	}
+	assertRotatesToContent(t, ids, executor.firstStream, got.String(), "claude response", capture)
+}
+
+func TestExecuteStreamInStream400InvalidRequestNotRotated(t *testing.T) {
+	executor := &emptyCompletionTestExecutor{
+		streamPayloads: map[string][][]byte{},
+		streamCalls:    map[string]int{},
+		emptyStreamPayload: [][]byte{
+			[]byte("data: {\"error\":{\"code\":400,\"message\":\"Invalid request prompt\",\"type\":\"invalid_request_error\"}}\n\n"),
+		},
+		contentStreamPayload: [][]byte{
+			[]byte("data: {\"choices\":[{\"delta\":{\"content\":\"should not reach\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
+		},
+	}
+	manager, ids, model, capture := newEmptyCompletionTestManager(t, executor)
+
+	_, err := manager.ExecuteStream(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{Stream: true})
+	if err == nil {
+		t.Fatal("ExecuteStream() want error for 400 invalid request, got nil")
+	}
+
+	other := ids[0]
+	if executor.firstStream == ids[0] {
+		other = ids[1]
+	}
+	if executor.streamCalls[other] > 0 {
+		t.Fatalf("second auth %q was called (%d times), want 0 calls (400 must not rotate)", other, executor.streamCalls[other])
+	}
+	_ = capture
+}
+
+func TestExecuteStreamInStreamUnknownJSONForwardedNotRotated(t *testing.T) {
+	executor := &emptyCompletionTestExecutor{
+		streamPayloads: map[string][][]byte{},
+		streamCalls:    map[string]int{},
+		emptyStreamPayload: [][]byte{
+			[]byte("data: {\"custom_future_protocol_field\":\"forward_me\"}\n\n"),
+			[]byte("data: [DONE]\n\n"),
+		},
+		contentStreamPayload: [][]byte{
+			[]byte("data: {\"choices\":[{\"delta\":{\"content\":\"should not reach\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"),
+		},
+	}
+	manager, ids, model, _ := newEmptyCompletionTestManager(t, executor)
+
+	stream, err := manager.ExecuteStream(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	var got strings.Builder
+	for chunk := range stream.Chunks {
+		got.Write(chunk.Payload)
+	}
+	if !strings.Contains(got.String(), "custom_future_protocol_field") {
+		t.Fatalf("payload = %q, want unknown JSON forwarded directly", got.String())
+	}
+	other := ids[0]
+	if executor.firstStream == ids[0] {
+		other = ids[1]
+	}
+	if executor.streamCalls[other] > 0 {
+		t.Fatalf("second auth %q was called (%d times), want 0 calls for unknown valid JSON", other, executor.streamCalls[other])
+	}
+}
+
+func TestExecuteStreamMidStreamInStreamErrorMarksAuthFailed(t *testing.T) {
+	midStreamPayload := [][]byte{
+		[]byte("data: {\"choices\":[{\"delta\":{\"content\":\"valid prefix content\"}}]}\n\n"),
+		[]byte("data: {\"error\":{\"code\":429,\"message\":\"Resource exhausted mid-stream\",\"status\":\"RESOURCE_EXHAUSTED\"}}\n\n"),
+	}
+	executor := &emptyCompletionTestExecutor{
+		streamPayloads:       map[string][][]byte{},
+		streamCalls:          map[string]int{},
+		contentStreamPayload: midStreamPayload,
+	}
+	manager, ids, model, capture := newEmptyCompletionTestManager(t, executor)
+
+	stream, err := manager.ExecuteStream(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream() unexpected error = %v", err)
+	}
+	if stream == nil {
+		t.Fatal("ExecuteStream() returned nil stream")
+	}
+
+	var got strings.Builder
+	for chunk := range stream.Chunks {
+		got.Write(chunk.Payload)
+	}
+
+	payloadStr := got.String()
+	if !strings.Contains(payloadStr, "valid prefix content") {
+		t.Fatalf("stream payload missing prefix content, got: %q", payloadStr)
+	}
+	if !strings.Contains(payloadStr, "Resource exhausted mid-stream") {
+		t.Fatalf("stream payload missing mid-stream error, got: %q", payloadStr)
+	}
+
+	results := capture.Results()
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 execution result recorded, got 0")
+	}
+
+	hasFailed := false
+	for _, res := range results {
+		if res.Success {
+			t.Fatalf("recorded execution result with Success = true for mid-stream error: %+v", res)
+		}
+		if !res.Success {
+			hasFailed = true
+		}
+	}
+	if !hasFailed {
+		t.Fatal("expected execution result with Success = false, none found")
+	}
+
+	_ = ids
+}


### PR DESCRIPTION
## Summary

Detect in-stream provider error envelopes during stream bootstrap and fail over to rotate credentials, preventing dead auth keys from being recorded as successful completions.

## Problem

1. **In-stream provider errors masquerading as HTTP 200**:
   Upstream providers (e.g. Gemini, Claude, Antigravity) may return HTTP status 200 OK while embedding provider error envelopes directly inside the SSE stream body (e.g. Gemini `data: {"error":{"code":429,"message":"Resource exhausted","status":"RESOURCE_EXHAUSTED"}}` or Claude `event: error\ndata: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`).
2. **False positive bootstrap and broken auth rotation**:
   Because network transport succeeded (`chunk.Err == nil`), `streamBootstrapState` previously marked `sawUnknownData = true`. Consequently, `hasMeaningfulOutput()` returned `true`, the bootstrap phase completed without error, and upon stream termination `wrapStreamResult` recorded `Success: true`.
   - Exhausted credentials (429 / 503 / 401) were never marked unavailable or put into cooldown.
   - Downstream clients received provider error payloads without triggering proxy failover or account rotation.

## Fix

1. **Stream bootstrap error detection (`sdk/cliproxy/auth/empty_completion.go`)**:
   - Added `streamErr *Error` and `currentEvent string` tracking to `streamBootstrapState`.
   - Introduced `streamErrorEnvelope`, `inferHTTPStatus`, `parseStreamErrorFromEnvelope`, and `evalProviderError` to identify provider error structures across Gemini, Claude, and OpenAI-compatible SSE streams.
   - Updated `processSingleLine`, `flushData`, and `observe` to capture error frames, suppress `sawMetadataOnly` / `sawUnknownData`, and set `hasMeaningfulOutput() = false`.
2. **Conductor failover and metrics recording (`sdk/cliproxy/auth/conductor_stream.go`)**:
   - `readStreamBootstrap`: checks `bootstrap.streamError()` on chunk observation or stream EOF; aborts bootstrap if an in-stream error occurs before meaningful output, initiating credential failover.
   - `wrapStreamResult`: inspects late stream chunks via `detectStreamPayloadError` to record `Success: false` and trigger account cooldown if a provider error arrives mid-stream.
3. **Preserved invariants**:
   - Non-error unknown JSON payloads continue to be forwarded directly without triggering rotation (`TestExecuteStreamInStreamUnknownJSONForwardedNotRotated`).
   - 400-class client request faults remain terminal and are returned directly to the client without rotating accounts (`TestExecuteStreamInStream400InvalidRequestNotRotated`).
4. **Unit tests (`sdk/cliproxy/auth/empty_completion_test.go`)**:
   - `TestExecuteStreamInStreamGemini429ErrorRotatesAuth`: in-stream Gemini 429 rotates auth and marks quota exceeded.
   - `TestExecuteStreamInStreamClaudeOverloadedErrorRotatesAuth`: in-stream Claude `overloaded_error` rotates to fallback auth.
   - `TestExecuteStreamInStream400InvalidRequestNotRotated`: in-stream 400 invalid request returns error directly without auth rotation.
   - `TestExecuteStreamInStreamUnknownJSONForwardedNotRotated`: unrecognized non-error JSON forwarded without rotation.
   - `TestExecuteStreamMidStreamInStreamErrorMarksAuthFailed`: mid-stream error after initial tokens records `Success: false`.

## Testing

- `TMPDIR=/Users/warelik/.cache/gotmp go build ./...` — exit code 0
- `TMPDIR=/Users/warelik/.cache/gotmp go vet ./sdk/cliproxy/auth/...` — exit code 0
- `TMPDIR=/Users/warelik/.cache/gotmp go test -count=1 ./sdk/cliproxy/auth/...` — exit code 0
- Comprehensive test suite covering SSE events, JSON classification, error envelope mapping, and rotation invariants.

## Upstream Reference

- This change is located entirely within `sdk/cliproxy/auth/` and does not touch `internal/translator/` (`src/AGENTS.md` translator policy does not apply).
- Ported companion of upstream pull request [router-for-me/CLIProxyAPI#4881](https://github.com/router-for-me/CLIProxyAPI/pull/4881).
