### PR TITLE
fix(auth): floor quota cooldown at the escalating ladder

### DIFF
--- a/internal/runtime/executor/antigravity_executor_cooldown_transient_test.go
+++ b/internal/runtime/executor/antigravity_executor_cooldown_transient_test.go
@@ -1,0 +1,90 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+// TestAntigravityShortCooldownErrorIsTransient pins the classification of the
+// synthetic 429 the executor raises while an auth sits in a short cooldown.
+// The cooldown is a local, self-imposed pause of at most a few minutes, so the
+// conductor has to read it as a transient rate limit and rotate to the next
+// auth. Unclassified, the same error looks like an exhausted quota carrying a
+// retry hint, and the conductor escalates BackoffLevel toward the 30 minute
+// ceiling — parking an account that was never actually throttled upstream.
+func TestAntigravityShortCooldownErrorIsTransient(t *testing.T) {
+	resetAntigravityCreditsRetryState()
+	t.Cleanup(resetAntigravityCreditsRetryState)
+	client := newFakeAntigravityKVClient()
+	useFakeAntigravityKVClient(t, client, true, nil)
+
+	exec := NewAntigravityExecutor(&config.Config{})
+	opts := cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatGemini,
+		ResponseFormat: sdktranslator.FormatGemini,
+	}
+	payload := []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`)
+
+	for _, tc := range []struct {
+		name  string
+		model string
+		call  func(auth *cliproxyauth.Auth, model string) error
+	}{
+		{
+			name:  "execute",
+			model: "gemini-3.6-flash",
+			call: func(auth *cliproxyauth.Auth, model string) error {
+				_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{Model: model, Payload: payload}, opts)
+				return err
+			},
+		},
+		{
+			name:  "execute-claude",
+			model: "claude-sonnet-4-5",
+			call: func(auth *cliproxyauth.Auth, model string) error {
+				_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{Model: model, Payload: payload}, opts)
+				return err
+			},
+		},
+		{
+			name:  "execute-stream",
+			model: "gemini-3.6-flash",
+			call: func(auth *cliproxyauth.Auth, model string) error {
+				_, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{Model: model, Payload: payload}, opts)
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			auth := &cliproxyauth.Auth{ID: "cooldown-transient-" + tc.name}
+			if errMark := markAntigravityShortCooldownRequired(context.Background(), auth, tc.model, time.Now(), 30*time.Second); errMark != nil {
+				t.Fatalf("markAntigravityShortCooldownRequired() error = %v", errMark)
+			}
+
+			err := tc.call(auth, tc.model)
+			if err == nil {
+				t.Fatal("expected the short cooldown to surface a 429")
+			}
+
+			var classified interface{ TransientRateLimit() bool }
+			if !errors.As(err, &classified) {
+				t.Fatalf("short-cooldown error carries no 429 classification: %T", err)
+			}
+			if !classified.TransientRateLimit() {
+				t.Fatal("expected the synthetic short-cooldown 429 to be transient so the conductor rotates instead of escalating backoff")
+			}
+
+			var hinted interface{ RetryAfter() *time.Duration }
+			if !errors.As(err, &hinted) || hinted.RetryAfter() == nil || *hinted.RetryAfter() <= 0 {
+				t.Fatalf("expected a positive retry hint on the short-cooldown 429, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/antigravity_executor_credits.go
+++ b/internal/runtime/executor/antigravity_executor_credits.go
@@ -341,7 +341,13 @@ func newAntigravityStatusErr(statusCode int, body []byte) statusErr {
 		}
 		// Only a decisively rate-limited 429 may keep its raw retry hint downstream;
 		// exhausted quota and unclassified bodies stay on the escalating cooldown ladder.
-		err.transientRateLimit = classifyAntigravity429(body) == antigravity429RateLimited
+		// A RATE_LIMIT_EXCEEDED reason without a RetryInfo hint is still a short-lived
+		// throttle, not an exhausted quota, so it is transient too — but only when the
+		// classification comes from the ErrorInfo reason, not from the bare
+		// "too many requests" message heuristic.
+		category := classifyAntigravity429(body)
+		err.transientRateLimit = category == antigravity429RateLimited ||
+			(category == antigravity429SoftRateLimit && strings.EqualFold(decideAntigravity429(body).reason, "RATE_LIMIT_EXCEEDED"))
 	}
 	return err
 }

--- a/internal/runtime/executor/antigravity_executor_credits.go
+++ b/internal/runtime/executor/antigravity_executor_credits.go
@@ -339,6 +339,9 @@ func newAntigravityStatusErr(statusCode int, body []byte) statusErr {
 		if retryAfter, parseErr := helps.ParseRetryDelay(body); parseErr == nil && retryAfter != nil {
 			err.retryAfter = retryAfter
 		}
+		// Only a decisively rate-limited 429 may keep its raw retry hint downstream;
+		// exhausted quota and unclassified bodies stay on the escalating cooldown ladder.
+		err.transientRateLimit = classifyAntigravity429(body) == antigravity429RateLimited
 	}
 	return err
 }

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -819,3 +819,47 @@ func TestParseMetaFloat(t *testing.T) {
 		})
 	}
 }
+
+func TestAntigravityCountTokensClassifiesTransient429(t *testing.T) {
+	body := `{
+		"error": {
+			"code": 429,
+			"status": "RESOURCE_EXHAUSTED",
+			"details": [
+				{"@type": "type.googleapis.com/google.rpc.ErrorInfo", "reason": "RATE_LIMIT_EXCEEDED"},
+				{"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "0.479417207s"}
+			]
+		}
+	}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	exec := NewAntigravityExecutor(&config.Config{RequestRetry: 1})
+	_, errCount := exec.CountTokens(context.Background(), testAntigravityAuth(server.URL), cliproxyexecutor.Request{
+		Model:   "gemini-3.6-flash-high",
+		Payload: []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatGemini,
+		ResponseFormat: sdktranslator.FormatGemini,
+	})
+	if errCount == nil {
+		t.Fatal("expected CountTokens to fail on an upstream 429")
+	}
+
+	var classified interface{ TransientRateLimit() bool }
+	if !errors.As(errCount, &classified) {
+		t.Fatalf("CountTokens error carries no 429 classification: %T", errCount)
+	}
+	if !classified.TransientRateLimit() {
+		t.Fatal("expected a RATE_LIMIT_EXCEEDED token-count 429 to be marked transient")
+	}
+
+	var hinted interface{ RetryAfter() *time.Duration }
+	if !errors.As(errCount, &hinted) || hinted.RetryAfter() == nil {
+		t.Fatal("expected the provider retry hint to survive the token-count path")
+	}
+}

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -225,6 +225,60 @@ func TestClassifyAntigravity429(t *testing.T) {
 	})
 }
 
+func TestNewAntigravityStatusErrMarksTransientRateLimit(t *testing.T) {
+	rateLimited := []byte(`{
+		"error": {
+			"code": 429,
+			"message": "You have exhausted your capacity on this model. Your quota will reset after 0s.",
+			"status": "RESOURCE_EXHAUSTED",
+			"details": [
+				{
+					"@type": "type.googleapis.com/google.rpc.ErrorInfo",
+					"reason": "RATE_LIMIT_EXCEEDED",
+					"domain": "cloudcode-pa.googleapis.com"
+				},
+				{
+					"@type": "type.googleapis.com/google.rpc.RetryInfo",
+					"retryDelay": "0.479417207s"
+				}
+			]
+		}
+	}`)
+	transient := newAntigravityStatusErr(http.StatusTooManyRequests, rateLimited)
+	if !transient.TransientRateLimit() {
+		t.Fatal("expected a RATE_LIMIT_EXCEEDED 429 with a sub-second hint to be marked transient")
+	}
+	if transient.RetryAfter() == nil {
+		t.Fatal("expected the provider retry hint to be preserved on a transient rate limit")
+	}
+
+	exhausted := []byte(`{
+		"error": {
+			"code": 429,
+			"status": "RESOURCE_EXHAUSTED",
+			"details": [
+				{"@type": "type.googleapis.com/google.rpc.ErrorInfo", "reason": "QUOTA_EXHAUSTED"},
+				{"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "0.479417207s"}
+			]
+		}
+	}`)
+	quotaErr := newAntigravityStatusErr(http.StatusTooManyRequests, exhausted)
+	if quotaErr.TransientRateLimit() {
+		t.Fatal("expected a QUOTA_EXHAUSTED 429 not to be marked transient")
+	}
+	if quotaErr.RetryAfter() == nil {
+		t.Fatal("expected the provider retry hint to be preserved on an exhausted quota")
+	}
+
+	if soft := newAntigravityStatusErr(http.StatusTooManyRequests, []byte(`{"error":{"message":"too many requests"}}`)); soft.TransientRateLimit() {
+		t.Fatal("expected an unclassified 429 to stay on the escalating cooldown ladder")
+	}
+
+	if nonRateLimit := newAntigravityStatusErr(http.StatusServiceUnavailable, rateLimited); nonRateLimit.TransientRateLimit() {
+		t.Fatal("expected a non-429 status not to be marked transient")
+	}
+}
+
 func TestAntigravityShouldRetryNoCapacity_Standard503(t *testing.T) {
 	body := []byte(`{
 		"error": {

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -274,6 +274,25 @@ func TestNewAntigravityStatusErrMarksTransientRateLimit(t *testing.T) {
 		t.Fatal("expected an unclassified 429 to stay on the escalating cooldown ladder")
 	}
 
+	// A reasoned RATE_LIMIT_EXCEEDED without a RetryInfo hint is still a
+	// short-lived throttle, not an exhausted quota.
+	noHint := []byte(`{
+		"error": {
+			"code": 429,
+			"status": "RESOURCE_EXHAUSTED",
+			"details": [
+				{"@type": "type.googleapis.com/google.rpc.ErrorInfo", "reason": "RATE_LIMIT_EXCEEDED", "domain": "cloudcode-pa.googleapis.com"}
+			]
+		}
+	}`)
+	noHintErr := newAntigravityStatusErr(http.StatusTooManyRequests, noHint)
+	if !noHintErr.TransientRateLimit() {
+		t.Fatal("expected a RATE_LIMIT_EXCEEDED 429 without RetryInfo to be marked transient")
+	}
+	if noHintErr.RetryAfter() != nil {
+		t.Fatal("expected no retry hint when Google omits RetryInfo")
+	}
+
 	if nonRateLimit := newAntigravityStatusErr(http.StatusServiceUnavailable, rateLimited); nonRateLimit.TransientRateLimit() {
 		t.Fatal("expected a non-429 status not to be marked transient")
 	}

--- a/internal/runtime/executor/antigravity_executor_execute.go
+++ b/internal/runtime/executor/antigravity_executor_execute.go
@@ -33,7 +33,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	} else if inCooldown && !antigravityShouldBypassShortCooldown(ctx, e.cfg) {
 		log.Debugf("antigravity executor: auth %s in short cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
 		d := remaining
-		return resp, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d}
+		return resp, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d, transientRateLimit: true}
 	}
 
 	isClaude := strings.Contains(strings.ToLower(baseModel), "claude")
@@ -264,7 +264,7 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 	} else if inCooldown && !antigravityShouldBypassShortCooldown(ctx, e.cfg) {
 		log.Debugf("antigravity executor: auth %s in short cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
 		d := remaining
-		return resp, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d}
+		return resp, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d, transientRateLimit: true}
 	}
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)

--- a/internal/runtime/executor/antigravity_executor_stream.go
+++ b/internal/runtime/executor/antigravity_executor_stream.go
@@ -32,7 +32,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 	} else if inCooldown && !antigravityShouldBypassShortCooldown(ctx, e.cfg) {
 		log.Debugf("antigravity executor: auth %s in short cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
 		d := remaining
-		return nil, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d}
+		return nil, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d, transientRateLimit: true}
 	}
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)

--- a/internal/runtime/executor/antigravity_executor_tokens.go
+++ b/internal/runtime/executor/antigravity_executor_tokens.go
@@ -164,24 +164,12 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 			log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
 			continue
 		}
-		sErr := statusErr{code: httpResp.StatusCode, msg: string(bodyBytes)}
-		if httpResp.StatusCode == http.StatusTooManyRequests {
-			if retryAfter, parseErr := helps.ParseRetryDelay(bodyBytes); parseErr == nil && retryAfter != nil {
-				sErr.retryAfter = retryAfter
-			}
-		}
-		return cliproxyexecutor.Response{}, sErr
+		return cliproxyexecutor.Response{}, newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
 	}
 
 	switch {
 	case lastStatus != 0:
-		sErr := statusErr{code: lastStatus, msg: string(lastBody)}
-		if lastStatus == http.StatusTooManyRequests {
-			if retryAfter, parseErr := helps.ParseRetryDelay(lastBody); parseErr == nil && retryAfter != nil {
-				sErr.retryAfter = retryAfter
-			}
-		}
-		return cliproxyexecutor.Response{}, sErr
+		return cliproxyexecutor.Response{}, newAntigravityStatusErr(lastStatus, lastBody)
 	case lastErr != nil:
 		return cliproxyexecutor.Response{}, lastErr
 	default:

--- a/internal/runtime/executor/antigravity_executor_transport_test.go
+++ b/internal/runtime/executor/antigravity_executor_transport_test.go
@@ -224,10 +224,15 @@ func TestAntigravityConcurrentRequestsReusePooledConnections(t *testing.T) {
 	mu.Unlock()
 	// The first wave legitimately opens perWave connections. Later waves must reuse
 	// them; with MaxIdleConnsPerHost=2 only two survive each wave and distinct grows
-	// towards totalConns instead.
-	if distinct > perWave {
+	// towards totalConns instead. A wave boundary can cost one extra dial when a
+	// connection is retired between waves (the server closes an idle connection at
+	// exactly the wrong moment), so allow one stray dial per later wave: that still
+	// cleanly separates the pooled case from the MaxIdleConnsPerHost=2 regression
+	// (which would open roughly totalConns - 2*(waves-1) distinct connections).
+	maxAllowed := perWave + (waves - 1)
+	if distinct > maxAllowed {
 		t.Fatalf("%d waves of %d concurrent requests opened %d connections, want at most %d (unpooled worst case is %d)",
-			waves, perWave, distinct, perWave, totalConns)
+			waves, perWave, distinct, maxAllowed, totalConns)
 	}
 }
 

--- a/internal/runtime/executor/claude_executor_beta_policy_test.go
+++ b/internal/runtime/executor/claude_executor_beta_policy_test.go
@@ -293,3 +293,31 @@ func TestClassifyClaudeUpstreamError_OtherStatusesUnaffected(t *testing.T) {
 		t.Fatal("non-429 status was misclassified as request-scoped")
 	}
 }
+
+// An ordinary model-level Claude 429 (no unified 5h/7d rejection headers) is
+// a transient throttle: the conductor must rotate to the next credential
+// instead of escalating BackoffLevel as if quota were exhausted.
+func TestClassifyClaudeUpstreamError_OrdinaryRateLimitIsTransient(t *testing.T) {
+	body := []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Number of requests has exceeded your rate limit."}}`)
+	err := classifyClaudeUpstreamError(http.StatusTooManyRequests, nil, body)
+
+	var transient interface{ TransientRateLimit() bool }
+	if !errors.As(err, &transient) || !transient.TransientRateLimit() {
+		t.Fatalf("ordinary Claude 429 = %v, want a transient rate limit", err)
+	}
+}
+
+// The unified 5h/7d rejection stays on the quota ladder: it must NOT be
+// reported as a transient rate limit.
+func TestClassifyClaudeUpstreamError_UnifiedRejectionNotTransient(t *testing.T) {
+	headers := http.Header{
+		"Anthropic-Ratelimit-Unified-5h-Status": []string{"rejected"},
+		"Anthropic-Ratelimit-Unified-7d-Status": []string{"allowed"},
+	}
+	err := classifyClaudeUpstreamError(http.StatusTooManyRequests, headers, []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Shared usage window rejected."}}`))
+
+	var transient interface{ TransientRateLimit() bool }
+	if errors.As(err, &transient) && transient.TransientRateLimit() {
+		t.Fatal("unified 5h/7d rejection must stay on the quota ladder, not be marked transient")
+	}
+}

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -304,7 +304,10 @@ func classifyClaudeUpstreamError(statusCode int, headers http.Header, body []byt
 		if claudeBodyIndicatesFastModeCredits(body) {
 			return claudeEntitlementError{err}
 		}
-		// Ordinary model-level Claude 429 (not a unified 5h/7d rejection)
+		// Ordinary model-level Claude 429 (not a unified 5h/7d rejection): a
+		// transient throttle, so the conductor rotates instead of escalating
+		// BackoffLevel as if quota were exhausted.
+		err.transientRateLimit = true
 		return claudeRateLimitError{statusErr: err, credentialScoped: false}
 	}
 	return err

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -1011,9 +1011,10 @@ func openAICompatStreamDataError(payload []byte, eventName string) (statusErr, b
 }
 
 type statusErr struct {
-	code       int
-	msg        string
-	retryAfter *time.Duration
+	code               int
+	msg                string
+	retryAfter         *time.Duration
+	transientRateLimit bool
 }
 
 func (e statusErr) Error() string {
@@ -1024,3 +1025,7 @@ func (e statusErr) Error() string {
 }
 func (e statusErr) StatusCode() int            { return e.code }
 func (e statusErr) RetryAfter() *time.Duration { return e.retryAfter }
+
+// TransientRateLimit reports whether the upstream 429 was classified as a
+// short-lived rate limit rather than an exhausted quota window.
+func (e statusErr) TransientRateLimit() bool { return e.transientRateLimit }

--- a/internal/runtime/executor/qoder_executor_test.go
+++ b/internal/runtime/executor/qoder_executor_test.go
@@ -474,7 +474,7 @@ func (p *captureQoderUsagePlugin) HandleUsage(_ context.Context, record usage.Re
 
 func waitForQoderUsageRecord(t *testing.T, records <-chan usage.Record, authID, model string) usage.Record {
 	t.Helper()
-	timeout := time.After(5 * time.Second) // generous for CI scheduling jitter; correctness comes from matching the record, not the deadline
+	timeout := time.After(30 * time.Second) // generous for CI scheduling jitter; correctness comes from matching the record, not the deadline
 	for {
 		select {
 		case record := <-records:

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -54,6 +54,10 @@ type Result struct {
 	Success bool
 	// RetryAfter carries a provider supplied retry hint (e.g. 429 retryDelay).
 	RetryAfter *time.Duration
+	// TransientRateLimit marks a 429 the provider classified as a short-lived rate
+	// limit rather than an exhausted quota window. Such failures keep RetryAfter
+	// verbatim instead of being floored at the escalating quota cooldown ladder.
+	TransientRateLimit bool
 	// CredentialScope indicates that the failure affects the whole credential across models (e.g. Anthropic 5h/7d unified limits).
 	CredentialScope bool
 	// Error describes the failure when Success is false.

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -862,12 +862,23 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							var next time.Time
 							backoffLevel := state.Quota.BackoffLevel
 							if !disableCooling {
-								if result.RetryAfter != nil && (*result.RetryAfter <= 0 || result.TransientRateLimit) {
-									// Zero-delay retries and 429s the provider classified as a short-lived
-									// rate limit keep their hint verbatim: flooring them at the quota ladder
-									// would park a still-usable credential for up to the full ladder step.
+								switch {
+								case result.TransientRateLimit:
+									// A 429 the provider classified as a short-lived rate limit bypasses
+									// the quota ladder entirely: flooring a transient throttle at the
+									// escalating ladder would park a still-usable credential. With no
+									// parseable hint, fall back to the standard transient-error cooldown.
+									if result.RetryAfter != nil {
+										next = now.Add(*result.RetryAfter)
+									} else {
+										next = nextTransientErrorRetryAfter(now)
+									}
+								case result.RetryAfter != nil && *result.RetryAfter <= 0:
+									// Zero-delay retries keep their hint verbatim: flooring them at the
+									// quota ladder would park a still-usable credential for up to the
+									// full ladder step.
 									next = now.Add(*result.RetryAfter)
-								} else {
+								default:
 									next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
 									if result.RetryAfter != nil {
 										// An exhausted-quota hint can be sub-second even when the quota is gone
@@ -2026,12 +2037,22 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.Quota.Reason = "quota"
 		var next time.Time
 		if !disableCooling {
-			if retryAfter != nil && (*retryAfter <= 0 || transientRateLimit) {
-				// Zero-delay retries and 429s the provider classified as a short-lived rate
-				// limit keep their hint verbatim: flooring them at the quota ladder would park
-				// a still-usable credential for up to the full ladder step.
+			switch {
+			case transientRateLimit:
+				// A 429 the provider classified as a short-lived rate limit bypasses the
+				// quota ladder entirely: flooring a transient throttle at the escalating
+				// ladder would park a still-usable credential. With no parseable hint,
+				// fall back to the standard transient-error cooldown.
+				if retryAfter != nil {
+					next = now.Add(*retryAfter)
+				} else {
+					next = nextTransientErrorRetryAfter(now)
+				}
+			case retryAfter != nil && *retryAfter <= 0:
+				// Zero-delay retries keep their hint verbatim: flooring them at the quota
+				// ladder would park a still-usable credential for up to the full ladder step.
 				next = now.Add(*retryAfter)
-			} else {
+			default:
 				next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now)
 				if retryAfter != nil {
 					// An exhausted-quota hint can be sub-second even when the quota is gone for

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1954,6 +1954,8 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	if shouldSkipCredentialCooldown(resultErr) {
 		return
 	}
+	prevUnavailable := auth.Unavailable
+	prevNextRetry := auth.NextRetryAfter
 	defer func() {
 		if disableCooling && auth.NextRetryAfter.IsZero() && auth.Quota.NextRecoverAt.IsZero() {
 			auth.Unavailable = false
@@ -2087,6 +2089,8 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			auth.StatusMessage = prevStatusMessage
 			auth.Quota.Exceeded = prevExceeded
 			auth.Quota.Reason = prevReason
+			auth.Unavailable = prevUnavailable
+			auth.NextRetryAfter = prevNextRetry
 			break
 		}
 		auth.Quota.NextRecoverAt = next

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -862,13 +862,16 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							var next time.Time
 							backoffLevel := state.Quota.BackoffLevel
 							if !disableCooling {
-								if result.RetryAfter != nil && *result.RetryAfter <= 0 {
+								if result.RetryAfter != nil && (*result.RetryAfter <= 0 || result.TransientRateLimit) {
+									// Zero-delay retries and 429s the provider classified as a short-lived
+									// rate limit keep their hint verbatim: flooring them at the quota ladder
+									// would park a still-usable credential for up to the full ladder step.
 									next = now.Add(*result.RetryAfter)
 								} else {
 									next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
 									if result.RetryAfter != nil {
-										// A provider hint can be sub-second even when the quota is exhausted for
-										// the whole day, so never let it undercut the escalating quota ladder.
+										// An exhausted-quota hint can be sub-second even when the quota is gone
+										// for the whole day, so never let it undercut the escalating ladder.
 										if hinted := now.Add(*result.RetryAfter); hinted.After(next) {
 											next = hinted
 										}
@@ -944,7 +947,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				if result.Error != nil && result.Error.Code == ErrorCodeForceCooldown {
 					disableCooling = false
 				}
-				applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling)
+				applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling, result.TransientRateLimit)
 			}
 		}
 
@@ -1503,6 +1506,19 @@ func retryAfterFromError(err error) *time.Duration {
 	return &value
 }
 
+// isTransientRateLimitError reports whether the executor classified the failure
+// as a short-lived provider rate limit rather than an exhausted quota window.
+func isTransientRateLimitError(err error) bool {
+	if err == nil {
+		return false
+	}
+	type transientRateLimitProvider interface {
+		TransientRateLimit() bool
+	}
+	var trp transientRateLimitProvider
+	return errors.As(err, &trp) && trp != nil && trp.TransientRateLimit()
+}
+
 func isCredentialScopedError(err error) bool {
 	if err == nil {
 		return false
@@ -1910,7 +1926,7 @@ func isRequestInvalidError(err error) bool {
 	return false
 }
 
-func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time, disableCooling bool) {
+func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time, disableCooling bool, transientRateLimit bool) {
 	if auth == nil {
 		return
 	}
@@ -2010,13 +2026,16 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.Quota.Reason = "quota"
 		var next time.Time
 		if !disableCooling {
-			if retryAfter != nil && *retryAfter <= 0 {
+			if retryAfter != nil && (*retryAfter <= 0 || transientRateLimit) {
+				// Zero-delay retries and 429s the provider classified as a short-lived rate
+				// limit keep their hint verbatim: flooring them at the quota ladder would park
+				// a still-usable credential for up to the full ladder step.
 				next = now.Add(*retryAfter)
 			} else {
 				next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now)
 				if retryAfter != nil {
-					// A provider hint can be sub-second even when the quota is exhausted for the
-					// whole day, so never let it undercut the escalating quota ladder.
+					// An exhausted-quota hint can be sub-second even when the quota is gone for
+					// the whole day, so never let it undercut the escalating quota ladder.
 					if hinted := now.Add(*retryAfter); hinted.After(next) {
 						next = hinted
 					}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -861,6 +861,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						case 429:
 							var next time.Time
 							backoffLevel := state.Quota.BackoffLevel
+							transientCooldownOff := false
 							if !disableCooling {
 								switch {
 								case result.TransientRateLimit:
@@ -873,6 +874,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 									} else {
 										next = nextTransientErrorRetryAfter(now)
 									}
+									transientCooldownOff = next.IsZero()
 								case result.RetryAfter != nil && *result.RetryAfter <= 0:
 									// Zero-delay retries keep their hint verbatim: flooring them at the
 									// quota ladder would park a still-usable credential for up to the
@@ -891,6 +893,14 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								if state.Quota.Exceeded && state.Quota.NextRecoverAt.After(next) {
 									next = state.Quota.NextRecoverAt
 								}
+							}
+							if transientCooldownOff && !state.Quota.Exceeded {
+								// Transient cooldowns are disabled for this auth: keep the model
+								// available instead of recording a zero-time quota block. A
+								// pre-existing quota block is left untouched.
+								state.Unavailable = false
+								state.NextRetryAfter = time.Time{}
+								break
 							}
 							state.NextRetryAfter = next
 							state.Quota = QuotaState{
@@ -2032,10 +2042,13 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			auth.NextRetryAfter = now.Add(12 * time.Hour)
 		}
 	case 429:
+		prevStatusMessage := auth.StatusMessage
+		prevExceeded, prevReason := auth.Quota.Exceeded, auth.Quota.Reason
 		auth.StatusMessage = "quota exhausted"
 		auth.Quota.Exceeded = true
 		auth.Quota.Reason = "quota"
 		var next time.Time
+		transientCooldownOff := false
 		if !disableCooling {
 			switch {
 			case transientRateLimit:
@@ -2048,6 +2061,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 				} else {
 					next = nextTransientErrorRetryAfter(now)
 				}
+				transientCooldownOff = next.IsZero()
 			case retryAfter != nil && *retryAfter <= 0:
 				// Zero-delay retries keep their hint verbatim: flooring them at the quota
 				// ladder would park a still-usable credential for up to the full ladder step.
@@ -2065,6 +2079,15 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			if auth.Quota.Exceeded && auth.Quota.NextRecoverAt.After(next) {
 				next = auth.Quota.NextRecoverAt
 			}
+		}
+		if transientCooldownOff && !prevExceeded {
+			// Transient cooldowns are disabled: keep the credential available
+			// instead of recording a zero-time quota block. A pre-existing quota
+			// block is left untouched.
+			auth.StatusMessage = prevStatusMessage
+			auth.Quota.Exceeded = prevExceeded
+			auth.Quota.Reason = prevReason
+			break
 		}
 		auth.Quota.NextRecoverAt = next
 		auth.NextRetryAfter = next

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -862,12 +862,16 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							var next time.Time
 							backoffLevel := state.Quota.BackoffLevel
 							if !disableCooling {
-								next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
-								if result.RetryAfter != nil {
-									// A provider hint can be sub-second even when the quota is exhausted for
-									// the whole day, so never let it undercut the escalating quota ladder.
-									if hinted := now.Add(*result.RetryAfter); hinted.After(next) {
-										next = hinted
+								if result.RetryAfter != nil && *result.RetryAfter <= 0 {
+									next = now.Add(*result.RetryAfter)
+								} else {
+									next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
+									if result.RetryAfter != nil {
+										// A provider hint can be sub-second even when the quota is exhausted for
+										// the whole day, so never let it undercut the escalating quota ladder.
+										if hinted := now.Add(*result.RetryAfter); hinted.After(next) {
+											next = hinted
+										}
 									}
 								}
 								if state.Quota.Exceeded && state.Quota.NextRecoverAt.After(next) {
@@ -2006,12 +2010,16 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.Quota.Reason = "quota"
 		var next time.Time
 		if !disableCooling {
-			next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now)
-			if retryAfter != nil {
-				// A provider hint can be sub-second even when the quota is exhausted for the
-				// whole day, so never let it undercut the escalating quota ladder.
-				if hinted := now.Add(*retryAfter); hinted.After(next) {
-					next = hinted
+			if retryAfter != nil && *retryAfter <= 0 {
+				next = now.Add(*retryAfter)
+			} else {
+				next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now)
+				if retryAfter != nil {
+					// A provider hint can be sub-second even when the quota is exhausted for the
+					// whole day, so never let it undercut the escalating quota ladder.
+					if hinted := now.Add(*retryAfter); hinted.After(next) {
+						next = hinted
+					}
 				}
 			}
 			if auth.Quota.Exceeded && auth.Quota.NextRecoverAt.After(next) {

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -862,10 +862,13 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							var next time.Time
 							backoffLevel := state.Quota.BackoffLevel
 							if !disableCooling {
+								next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
 								if result.RetryAfter != nil {
-									next = now.Add(*result.RetryAfter)
-								} else {
-									next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
+									// A provider hint can be sub-second even when the quota is exhausted for
+									// the whole day, so never let it undercut the escalating quota ladder.
+									if hinted := now.Add(*result.RetryAfter); hinted.After(next) {
+										next = hinted
+									}
 								}
 								if state.Quota.Exceeded && state.Quota.NextRecoverAt.After(next) {
 									next = state.Quota.NextRecoverAt
@@ -2003,10 +2006,13 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.Quota.Reason = "quota"
 		var next time.Time
 		if !disableCooling {
+			next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now)
 			if retryAfter != nil {
-				next = now.Add(*retryAfter)
-			} else {
-				next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now)
+				// A provider hint can be sub-second even when the quota is exhausted for the
+				// whole day, so never let it undercut the escalating quota ladder.
+				if hinted := now.Add(*retryAfter); hinted.After(next) {
+					next = hinted
+				}
 			}
 			if auth.Quota.Exceeded && auth.Quota.NextRecoverAt.After(next) {
 				next = auth.Quota.NextRecoverAt

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -433,6 +433,9 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
 				}
+				if isTransientRateLimitError(errExec) {
+					result.TransientRateLimit = true
+				}
 				if isCredentialScopedError(errExec) {
 					result.CredentialScope = true
 				}
@@ -600,6 +603,9 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
+				}
+				if isTransientRateLimitError(errExec) {
+					result.TransientRateLimit = true
 				}
 				action, okAction := matchRequestScopedErrorAction(auth, errExec, m.runtimeConfigSnapshot())
 				applyRequestScopedActionToResult(action, okAction, &result)

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -1121,6 +1121,9 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
 				}
+				if isTransientRateLimitError(errExec) {
+					result.TransientRateLimit = true
+				}
 				if isCredentialScopedError(errExec) {
 					result.CredentialScope = true
 				}

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -192,6 +192,7 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			}
 			result.Error = resultErrorFromError(errExecute)
 			result.RetryAfter = retryAfterFromError(errExecute)
+			result.TransientRateLimit = isTransientRateLimitError(errExecute)
 			if isCredentialScopedError(errExecute) {
 				result.CredentialScope = true
 			}

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -951,6 +951,65 @@ func TestManager_MarkResult_TransientErrorCooldownDefault(t *testing.T) {
 	}
 }
 
+// A transient 429 without any parseable retry hint must bypass the quota
+// ladder on both the per-model and the credential level: it falls back to the
+// standard transient-error cooldown instead of parking a still-usable
+// credential on the escalating quota backoff.
+func TestManager_MarkResult_Transient429WithoutHintBypassesQuotaLadder(t *testing.T) {
+	prevQuota := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(0)
+	t.Cleanup(func() {
+		quotaCooldownDisabled.Store(prevQuota)
+		transientErrorCooldownSeconds.Store(prevTransient)
+	})
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-transient-429-nohint", Provider: "claude"}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	model := "test-model-transient-429-nohint"
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    model,
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: http.StatusTooManyRequests,
+			Message:    "rate limited",
+		},
+		TransientRateLimit: true,
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("auth %s missing after MarkResult", auth.ID)
+	}
+
+	if updated.Quota.BackoffLevel != 0 {
+		t.Fatalf("expected credential quota ladder to stay at level 0 for a transient 429 without hint, got %d", updated.Quota.BackoffLevel)
+	}
+	diff := time.Until(updated.NextRetryAfter)
+	if diff < 55*time.Second || diff > 65*time.Second {
+		t.Fatalf("expected credential NextRetryAfter ~60s transient cooldown, got %v", diff)
+	}
+
+	state := updated.ModelStates[model]
+	if state == nil || state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected per-model cooldown state for %s, got %+v", model, state)
+	}
+	if state.Quota.BackoffLevel != 0 {
+		t.Fatalf("expected per-model quota ladder to stay at level 0, got %d", state.Quota.BackoffLevel)
+	}
+	modelDiff := time.Until(state.NextRetryAfter)
+	if modelDiff < 55*time.Second || modelDiff > 65*time.Second {
+		t.Fatalf("expected per-model NextRetryAfter ~60s transient cooldown, got %v", modelDiff)
+	}
+}
+
 func TestManager_MarkResult_TransientErrorCooldownDisabled(t *testing.T) {
 	prevQuota := quotaCooldownDisabled.Load()
 	quotaCooldownDisabled.Store(false)

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -1071,6 +1071,51 @@ func TestManager_MarkResult_Transient429WithoutHintRespectsDisabledCooldown(t *t
 	}
 }
 
+// Same as TestManager_MarkResult_Transient429WithoutHintRespectsDisabledCooldown
+// but for an auth-level Result (empty Model), which drives applyAuthFailureState
+// instead of the per-model branch: the credential must stay available.
+func TestManager_MarkResult_Transient429WithoutHintRespectsDisabledCooldownAuthLevel(t *testing.T) {
+	prevQuota := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(-1)
+	t.Cleanup(func() {
+		quotaCooldownDisabled.Store(prevQuota)
+		transientErrorCooldownSeconds.Store(prevTransient)
+	})
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-transient-429-disabled-authlevel", Provider: "claude"}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: http.StatusTooManyRequests,
+			Message:    "rate limited",
+		},
+		TransientRateLimit: true,
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("auth %s missing after MarkResult", auth.ID)
+	}
+	if updated.Unavailable {
+		t.Fatal("expected the credential to stay available with transient cooldowns disabled")
+	}
+	if !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected credential NextRetryAfter to stay zero with transient cooldowns disabled, got %v", updated.NextRetryAfter)
+	}
+	if updated.Quota.Exceeded {
+		t.Fatal("expected the credential quota state to stay clear with transient cooldowns disabled")
+	}
+}
+
 func TestManager_MarkResult_TransientErrorCooldownDisabled(t *testing.T) {
 	prevQuota := quotaCooldownDisabled.Load()
 	quotaCooldownDisabled.Store(false)

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -1010,6 +1010,67 @@ func TestManager_MarkResult_Transient429WithoutHintBypassesQuotaLadder(t *testin
 	}
 }
 
+// With transient cooldowns disabled (transientErrorCooldownSeconds < 0) the
+// transient-429 fallback yields a zero retry time. That zero must not be
+// stored as state: an unavailable/quota-exceeded flag with an empty
+// NextRetryAfter would read as an indefinite block and hide the credential
+// forever.
+func TestManager_MarkResult_Transient429WithoutHintRespectsDisabledCooldown(t *testing.T) {
+	prevQuota := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(-1)
+	t.Cleanup(func() {
+		quotaCooldownDisabled.Store(prevQuota)
+		transientErrorCooldownSeconds.Store(prevTransient)
+	})
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-transient-429-disabled", Provider: "claude"}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	model := "test-model-transient-429-disabled"
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    model,
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: http.StatusTooManyRequests,
+			Message:    "rate limited",
+		},
+		TransientRateLimit: true,
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("auth %s missing after MarkResult", auth.ID)
+	}
+
+	if !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected credential NextRetryAfter to stay zero with transient cooldowns disabled, got %v", updated.NextRetryAfter)
+	}
+	if updated.Quota.Exceeded {
+		t.Fatal("expected the credential quota state to stay clear with transient cooldowns disabled")
+	}
+
+	state := updated.ModelStates[model]
+	if state == nil {
+		t.Fatalf("expected per-model state for %s", model)
+	}
+	if state.Unavailable {
+		t.Fatal("expected the model to stay available with transient cooldowns disabled")
+	}
+	if !state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected per-model NextRetryAfter to stay zero, got %v", state.NextRetryAfter)
+	}
+	if state.Quota.Exceeded {
+		t.Fatal("expected the per-model quota state to stay clear with transient cooldowns disabled")
+	}
+}
+
 func TestManager_MarkResult_TransientErrorCooldownDisabled(t *testing.T) {
 	prevQuota := quotaCooldownDisabled.Load()
 	quotaCooldownDisabled.Store(false)

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -507,6 +507,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			action, okAction := matchRequestScopedErrorAction(auth, errStream, m.runtimeConfigSnapshot())
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr, Options: execOpts}
 			result.RetryAfter = retryAfterFromError(errStream)
+			result.TransientRateLimit = isTransientRateLimitError(errStream)
 			if isCredentialScopedError(errStream) {
 				result.CredentialScope = true
 			}
@@ -609,6 +610,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				rerr := resultErrorFromError(bootstrapErr)
 				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
+				result.TransientRateLimit = isTransientRateLimitError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
 				}
@@ -628,6 +630,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				rerr := resultErrorFromError(bootstrapErr)
 				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
+				result.TransientRateLimit = isTransientRateLimitError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
 				}
@@ -639,6 +642,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				rerr := resultErrorFromError(bootstrapErr)
 				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
+				result.TransientRateLimit = isTransientRateLimitError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
 				}
@@ -653,6 +657,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			rerr := resultErrorFromError(bootstrapErr)
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr, Options: execOpts}
 			result.RetryAfter = retryAfterFromError(bootstrapErr)
+			result.TransientRateLimit = isTransientRateLimitError(bootstrapErr)
 			if isCredentialScopedError(bootstrapErr) {
 				result.CredentialScope = true
 			}

--- a/sdk/cliproxy/auth/conductor_stream_classification_test.go
+++ b/sdk/cliproxy/auth/conductor_stream_classification_test.go
@@ -1,0 +1,59 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type streamTransientRateLimitError struct {
+	retryAfter time.Duration
+}
+
+func (e streamTransientRateLimitError) Error() string            { return "429 rate limited" }
+func (e streamTransientRateLimitError) StatusCode() int          { return http.StatusTooManyRequests }
+func (e streamTransientRateLimitError) TransientRateLimit() bool { return true }
+
+func (e streamTransientRateLimitError) RetryAfter() *time.Duration {
+	hint := e.retryAfter
+	return &hint
+}
+
+// TestExecuteStreamKeepsProviderHintForTransientRateLimit covers the streaming
+// failure path: the provider classification must reach MarkResult, otherwise a
+// still-usable credential is parked at the quota ladder step.
+func TestExecuteStreamKeepsProviderHintForTransientRateLimit(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+
+	hint := time.Duration(observedExhaustedQuotaHint)
+	executor := &claudeCancellationTestExecutor{
+		streamFn: func(context.Context, *Auth) (*cliproxyexecutor.StreamResult, error) {
+			return nil, streamTransientRateLimitError{retryAfter: hint}
+		},
+	}
+	manager, auth, model := newClaudeCancellationTestManager(t, executor, nil)
+
+	before := time.Now()
+	_, errStream := manager.ExecuteStream(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{Stream: true})
+	if errStream == nil {
+		t.Fatal("expected the stream request to fail with the upstream 429")
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("GetByID(%q) did not return auth", auth.ID)
+	}
+	state := updated.ModelStates[model]
+	if state == nil {
+		t.Fatalf("expected model state for %q after the failure", model)
+	}
+	if state.Quota.BackoffLevel != 0 {
+		t.Fatalf("expected BackoffLevel to stay 0 for a transient rate limit, got %d", state.Quota.BackoffLevel)
+	}
+	if ceiling := before.Add(hint + time.Second); state.Quota.NextRecoverAt.After(ceiling) {
+		t.Fatalf("transient stream rate limit was floored at the quota ladder: NextRecoverAt=%v, want <= %v", state.Quota.NextRecoverAt, ceiling)
+	}
+}

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -117,7 +119,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	quotaErr := &Error{Code: "rate_limit", Message: "quota", HTTPStatus: http.StatusTooManyRequests}
 	auth := &Auth{ID: "auth-level-quota"}
 
-	applyAuthFailureState(auth, quotaErr, nil, now, false)
+	applyAuthFailureState(auth, quotaErr, nil, now, false, false)
 	if auth.Quota.BackoffLevel != 1 {
 		t.Fatalf("expected BackoffLevel 1 after first failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -127,7 +129,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	}
 
 	// In-window failure keeps the current window and level.
-	applyAuthFailureState(auth, quotaErr, nil, now.Add(100*time.Millisecond), false)
+	applyAuthFailureState(auth, quotaErr, nil, now.Add(100*time.Millisecond), false, false)
 	if auth.Quota.BackoffLevel != 1 {
 		t.Fatalf("expected BackoffLevel to stay 1 for in-window failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -136,7 +138,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	}
 
 	// A failure after the window expired escalates to the next level.
-	applyAuthFailureState(auth, quotaErr, nil, now.Add(2*time.Second), false)
+	applyAuthFailureState(auth, quotaErr, nil, now.Add(2*time.Second), false, false)
 	if auth.Quota.BackoffLevel != 2 {
 		t.Fatalf("expected BackoffLevel 2 after post-window failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -146,7 +148,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 
 	// A provider supplied retry hint always takes effect, even in-window.
 	retryAfter := 10 * time.Second
-	applyAuthFailureState(auth, quotaErr, &retryAfter, now.Add(3*time.Second), false)
+	applyAuthFailureState(auth, quotaErr, &retryAfter, now.Add(3*time.Second), false, false)
 	if auth.Quota.BackoffLevel != 2 {
 		t.Fatalf("expected BackoffLevel to stay 2 with retry hint, got %d", auth.Quota.BackoffLevel)
 	}
@@ -367,7 +369,7 @@ func TestApplyAuthFailureStateSubSecondQuotaHintStillEscalates(t *testing.T) {
 	hint := observedExhaustedQuotaHint
 	auth := &Auth{ID: "auth-subsecond-hint"}
 
-	applyAuthFailureState(auth, quotaErr, &hint, now, false)
+	applyAuthFailureState(auth, quotaErr, &hint, now, false, false)
 	if auth.Quota.BackoffLevel != 1 {
 		t.Fatalf("expected BackoffLevel 1 after the first hinted failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -378,7 +380,7 @@ func TestApplyAuthFailureStateSubSecondQuotaHintStillEscalates(t *testing.T) {
 	// A later failure, once the first window has closed, must climb the ladder even
 	// though the provider keeps repeating the same sub-second hint.
 	after := now.Add(20 * time.Second)
-	applyAuthFailureState(auth, quotaErr, &hint, after, false)
+	applyAuthFailureState(auth, quotaErr, &hint, after, false, false)
 	if auth.Quota.BackoffLevel != 2 {
 		t.Fatalf("expected BackoffLevel 2 after the repeated hinted failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -432,7 +434,7 @@ func TestApplyAuthFailureStateZeroRetryAfterDoesNotApplyLadderFloor(t *testing.T
 	zeroHint := time.Duration(0)
 	auth := &Auth{ID: "auth-zero-hint"}
 
-	applyAuthFailureState(auth, err, &zeroHint, now, false)
+	applyAuthFailureState(auth, err, &zeroHint, now, false, false)
 	if auth.Quota.BackoffLevel != 0 {
 		t.Fatalf("expected BackoffLevel 0 for zero RetryAfter, got %d", auth.Quota.BackoffLevel)
 	}
@@ -441,5 +443,96 @@ func TestApplyAuthFailureStateZeroRetryAfterDoesNotApplyLadderFloor(t *testing.T
 	}
 	if auth.NextRetryAfter.After(now) {
 		t.Fatalf("expected NextRetryAfter not to receive ladder floor, NextRetryAfter=%v, want %v", auth.NextRetryAfter, now)
+	}
+}
+
+func TestMarkResultTransientRateLimitKeepsProviderHint(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "auth-transient-rate-limit",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex"},
+		ModelStates: map[string]*ModelState{
+			"gpt-5": {
+				Status: StatusActive,
+				Quota:  QuotaState{BackoffLevel: 0},
+			},
+		},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("Register returned error: %v", errRegister)
+	}
+
+	hint := observedExhaustedQuotaHint
+	result := quotaResult(auth.ID, "gpt-5")
+	result.RetryAfter = &hint
+	result.TransientRateLimit = true
+
+	before := time.Now()
+	manager.MarkResult(context.Background(), result)
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil || updated.ModelStates["gpt-5"] == nil {
+		t.Fatalf("expected model state after failure")
+	}
+	state := updated.ModelStates["gpt-5"]
+	if state.Quota.BackoffLevel != 0 {
+		t.Fatalf("expected BackoffLevel to stay 0 for a transient rate limit, got %d", state.Quota.BackoffLevel)
+	}
+	if ceiling := before.Add(hint + time.Second); state.Quota.NextRecoverAt.After(ceiling) {
+		t.Fatalf("transient rate limit was floored at the quota ladder: NextRecoverAt=%v, want <= %v", state.Quota.NextRecoverAt, ceiling)
+	}
+}
+
+func TestApplyAuthFailureStateTransientRateLimitKeepsProviderHint(t *testing.T) {
+	now := time.Now()
+	rateLimitErr := &Error{Code: "rate_limit", Message: "RATE_LIMIT_EXCEEDED", HTTPStatus: http.StatusTooManyRequests}
+	hint := observedExhaustedQuotaHint
+
+	transient := &Auth{ID: "auth-transient-hint"}
+	applyAuthFailureState(transient, rateLimitErr, &hint, now, false, true)
+	if transient.Quota.BackoffLevel != 0 {
+		t.Fatalf("expected BackoffLevel to stay 0 for a transient rate limit, got %d", transient.Quota.BackoffLevel)
+	}
+	if !transient.Quota.NextRecoverAt.Equal(now.Add(hint)) {
+		t.Fatalf("expected the transient hint to be honored verbatim at %v, got %v", now.Add(hint), transient.Quota.NextRecoverAt)
+	}
+	if !transient.NextRetryAfter.Equal(now.Add(hint)) {
+		t.Fatalf("expected NextRetryAfter to honor the transient hint at %v, got %v", now.Add(hint), transient.NextRetryAfter)
+	}
+
+	// The same sub-second hint on an exhausted quota must still be floored at the ladder.
+	exhausted := &Auth{ID: "auth-exhausted-hint"}
+	applyAuthFailureState(exhausted, rateLimitErr, &hint, now, false, false)
+	if exhausted.Quota.BackoffLevel != 1 {
+		t.Fatalf("expected BackoffLevel 1 for an exhausted-quota failure, got %d", exhausted.Quota.BackoffLevel)
+	}
+	if !exhausted.Quota.NextRecoverAt.Equal(now.Add(quotaBackoffBase)) {
+		t.Fatalf("expected the exhausted-quota hint to stay floored at %v, got %v", now.Add(quotaBackoffBase), exhausted.Quota.NextRecoverAt)
+	}
+}
+
+type classifiedRateLimitError struct {
+	transient bool
+}
+
+func (e classifiedRateLimitError) Error() string            { return "429 rate limited" }
+func (e classifiedRateLimitError) StatusCode() int          { return http.StatusTooManyRequests }
+func (e classifiedRateLimitError) TransientRateLimit() bool { return e.transient }
+
+func TestIsTransientRateLimitErrorDetectsWrappedProviderClassification(t *testing.T) {
+	if isTransientRateLimitError(nil) {
+		t.Fatal("expected a nil error not to be transient")
+	}
+	if isTransientRateLimitError(errors.New("boom")) {
+		t.Fatal("expected an unclassified error not to be transient")
+	}
+	if isTransientRateLimitError(classifiedRateLimitError{}) {
+		t.Fatal("expected an exhausted-quota classification not to be transient")
+	}
+	if !isTransientRateLimitError(fmt.Errorf("upstream: %w", classifiedRateLimitError{transient: true})) {
+		t.Fatal("expected a wrapped transient rate limit classification to be detected")
 	}
 }

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -308,3 +308,81 @@ func TestJitteredCooldownWaitBounds(t *testing.T) {
 		t.Fatalf("expected sub-4ns wait to stay unchanged, got %v", got)
 	}
 }
+
+// Gemini and Antigravity answer an exhausted daily quota with a RetryInfo hint of
+// well under a second (see internal/runtime/executor/helps/json_retry_helpers.go).
+// Honouring such a hint verbatim returned dead credentials to the pool a few hundred
+// milliseconds later and pinned the backoff ladder at its current level forever, so
+// every request kept walking the whole exhausted pool before failing.
+const observedExhaustedQuotaHint = 479417207 * time.Nanosecond
+
+func TestMarkResultSubSecondQuotaHintStillEscalates(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+
+	expired := time.Now().Add(-time.Second)
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "auth-quota-subsecond-hint",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex"},
+		ModelStates: map[string]*ModelState{
+			"gpt-5": {
+				Status:         StatusError,
+				Unavailable:    true,
+				NextRetryAfter: expired,
+				Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: expired, BackoffLevel: 3},
+			},
+		},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("Register returned error: %v", errRegister)
+	}
+
+	hint := observedExhaustedQuotaHint
+	result := quotaResult(auth.ID, "gpt-5")
+	result.RetryAfter = &hint
+
+	before := time.Now()
+	manager.MarkResult(context.Background(), result)
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil || updated.ModelStates["gpt-5"] == nil {
+		t.Fatalf("expected model state after failure")
+	}
+	state := updated.ModelStates["gpt-5"]
+	if state.Quota.BackoffLevel != 4 {
+		t.Fatalf("expected BackoffLevel 4 after hinted post-window failure, got %d", state.Quota.BackoffLevel)
+	}
+	if !state.Quota.NextRecoverAt.After(before.Add(hint)) {
+		t.Fatalf("sub-second hint was not floored: window closes at %v, the hint alone would close it at %v", state.Quota.NextRecoverAt, before.Add(hint))
+	}
+	if got := state.Quota.NextRecoverAt.Sub(before); got < 8*quotaBackoffBase {
+		t.Fatalf("expected at least the level-3 ladder step (%v), got %v", 8*quotaBackoffBase, got)
+	}
+}
+
+func TestApplyAuthFailureStateSubSecondQuotaHintStillEscalates(t *testing.T) {
+	now := time.Now()
+	quotaErr := &Error{Code: "rate_limit", Message: "quota", HTTPStatus: http.StatusTooManyRequests}
+	hint := observedExhaustedQuotaHint
+	auth := &Auth{ID: "auth-subsecond-hint"}
+
+	applyAuthFailureState(auth, quotaErr, &hint, now, false)
+	if auth.Quota.BackoffLevel != 1 {
+		t.Fatalf("expected BackoffLevel 1 after the first hinted failure, got %d", auth.Quota.BackoffLevel)
+	}
+	if !auth.Quota.NextRecoverAt.Equal(now.Add(quotaBackoffBase)) {
+		t.Fatalf("expected the sub-second hint to be floored at %v, got %v", now.Add(quotaBackoffBase), auth.Quota.NextRecoverAt)
+	}
+
+	// A later failure, once the first window has closed, must climb the ladder even
+	// though the provider keeps repeating the same sub-second hint.
+	after := now.Add(20 * time.Second)
+	applyAuthFailureState(auth, quotaErr, &hint, after, false)
+	if auth.Quota.BackoffLevel != 2 {
+		t.Fatalf("expected BackoffLevel 2 after the repeated hinted failure, got %d", auth.Quota.BackoffLevel)
+	}
+	if !auth.Quota.NextRecoverAt.Equal(after.Add(2 * quotaBackoffBase)) {
+		t.Fatalf("expected the escalated window to close at %v, got %v", after.Add(2*quotaBackoffBase), auth.Quota.NextRecoverAt)
+	}
+}

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -386,3 +386,60 @@ func TestApplyAuthFailureStateSubSecondQuotaHintStillEscalates(t *testing.T) {
 		t.Fatalf("expected the escalated window to close at %v, got %v", after.Add(2*quotaBackoffBase), auth.Quota.NextRecoverAt)
 	}
 }
+
+func TestMarkResultZeroRetryAfterDoesNotApplyLadderFloor(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "auth-zero-retry-after",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex"},
+		ModelStates: map[string]*ModelState{
+			"gpt-5": {
+				Status: StatusActive,
+				Quota:  QuotaState{BackoffLevel: 0},
+			},
+		},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("Register returned error: %v", errRegister)
+	}
+
+	zeroHint := time.Duration(0)
+	result := quotaResult(auth.ID, "gpt-5")
+	result.RetryAfter = &zeroHint
+
+	now := time.Now()
+	manager.MarkResult(context.Background(), result)
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil || updated.ModelStates["gpt-5"] == nil {
+		t.Fatalf("expected model state after failure")
+	}
+	state := updated.ModelStates["gpt-5"]
+	if state.Quota.BackoffLevel != 0 {
+		t.Fatalf("expected BackoffLevel to remain 0 for zero RetryAfter, got %d", state.Quota.BackoffLevel)
+	}
+	if state.Quota.NextRecoverAt.After(now.Add(500 * time.Millisecond)) {
+		t.Fatalf("zero RetryAfter was given ladder floor: NextRecoverAt=%v, want <= %v", state.Quota.NextRecoverAt, now)
+	}
+}
+
+func TestApplyAuthFailureStateZeroRetryAfterDoesNotApplyLadderFloor(t *testing.T) {
+	now := time.Now()
+	err := &Error{Code: "rate_limit", Message: "websocket_connection_limit_reached", HTTPStatus: http.StatusTooManyRequests}
+	zeroHint := time.Duration(0)
+	auth := &Auth{ID: "auth-zero-hint"}
+
+	applyAuthFailureState(auth, err, &zeroHint, now, false)
+	if auth.Quota.BackoffLevel != 0 {
+		t.Fatalf("expected BackoffLevel 0 for zero RetryAfter, got %d", auth.Quota.BackoffLevel)
+	}
+	if auth.Quota.NextRecoverAt.After(now) {
+		t.Fatalf("expected zero RetryAfter not to receive ladder floor, NextRecoverAt=%v, want %v", auth.Quota.NextRecoverAt, now)
+	}
+	if auth.NextRetryAfter.After(now) {
+		t.Fatalf("expected NextRetryAfter not to receive ladder floor, NextRetryAfter=%v, want %v", auth.NextRetryAfter, now)
+	}
+}


### PR DESCRIPTION
## Summary

Gemini and Antigravity can answer HTTP 429 for a fully exhausted daily quota with a `RetryInfo` hint of only ~479ms (observed: `479417207ns`). Taking that hint verbatim returned the dead credential to the pool ~500ms later AND pinned `BackoffLevel` forever because every retry recomputed the ladder and then discarded it in favor of the sub-second hint.

This change floors the quota cooldown deadline at the escalating ladder calculation. A provider hint may still push the recovery deadline further out, but can never pull it in below the ladder step — except for the two cases the provider itself marks as non-exhaustion (see the follow-up rounds below).

## Code changes

### Before

```go
next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
if result.RetryAfter != nil {
    next = now.Add(*result.RetryAfter)
}
```

### After

```go
next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
if result.RetryAfter != nil {
    // A provider hint can be sub-second even when the quota is exhausted for
    // the whole day, so never let it undercut the escalating quota ladder.
    if hinted := now.Add(*result.RetryAfter); hinted.After(next) {
        next = hinted
    }
}
```

## Blast radius

`quotaCooldownAfterFailure` is package-private with exactly two call sites:
- `MarkResult` in `sdk/cliproxy/auth/conductor_cooldown.go`
- `applyAuthFailureState` in `sdk/cliproxy/auth/conductor_cooldown.go`

Both call sites are updated identically to respect the ladder floor.

## Tests & Verification

Added two unit tests in `sdk/cliproxy/auth/cooldown_backoff_test.go`:
- `TestMarkResultSubSecondQuotaHintStillEscalates`
- `TestApplyAuthFailureStateSubSecondQuotaHintStillEscalates`

### Mandatory reverse bite-check failure

Reverting the fix produced the expected test failure:
```
=== RUN   TestMarkResultSubSecondQuotaHintStillEscalates
    cooldown_backoff_test.go:354: expected BackoffLevel 4 after hinted post-window failure, got 3
--- FAIL: TestMarkResultSubSecondQuotaHintStillEscalates (0.00s)
=== RUN   TestApplyAuthFailureStateSubSecondQuotaHintStillEscalates
    cooldown_backoff_test.go:372: expected BackoffLevel 1 after the first hinted failure, got 0
--- FAIL: TestApplyAuthFailureStateSubSecondQuotaHintStillEscalates (0.00s)
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth	0.430s
FAIL
```

### Passing tests with fix applied

```
=== RUN   TestMarkResultSubSecondQuotaHintStillEscalates
--- PASS: TestMarkResultSubSecondQuotaHintStillEscalates (0.00s)
=== RUN   TestApplyAuthFailureStateSubSecondQuotaHintStillEscalates
--- PASS: TestApplyAuthFailureStateSubSecondQuotaHintStillEscalates (0.00s)
PASS
ok  	github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth	0.348s
```

## Follow-up review round 1 — zero-delay retries (`165e9326`)

Review pointed out that an unconditional floor also swallowed `RetryAfter: 0`, which upstream
uses to mean "retry immediately on the same credential". The gate now exempts a non-positive
hint (`conductor_cooldown.go:829` in `MarkResult`, `:1966` in `applyAuthFailureState`).

Tests: `TestMarkResultZeroRetryAfterDoesNotApplyLadderFloor`,
`TestApplyAuthFailureStateZeroRetryAfterDoesNotApplyLadderFloor`.

Reverse bite-check — dropping the `*retryAfter <= 0` clause from both gates:

```
--- FAIL: TestMarkResultZeroRetryAfterDoesNotApplyLadderFloor (0.00s)
    cooldown_backoff_test.go:424: expected BackoffLevel to remain 0 for zero RetryAfter, got 1
--- FAIL: TestApplyAuthFailureStateZeroRetryAfterDoesNotApplyLadderFloor (0.00s)
    cooldown_backoff_test.go:439: expected BackoffLevel 0 for zero RetryAfter, got 1
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth	0.319s
FAIL
```

## Follow-up review round 2 — transient rate limits (`c6ec29ef`)

Review then pointed out that the floor still applied to 429s the executor had already
classified as a short-lived rate limit rather than an exhausted quota, parking a usable
credential for a whole ladder step.

`classifyAntigravity429` (`internal/runtime/executor/antigravity_executor_credits.go:203`) already
distinguishes `RATE_LIMIT_EXCEEDED` from `QUOTA_EXHAUSTED`, but the classification never reached
the conductor: `newAntigravityStatusErr` built a bare `statusErr{code, msg, retryAfter}` and only
status, text and hint were carried across.

- `statusErr` gains `transientRateLimit bool` and `func (e statusErr) TransientRateLimit() bool`
  (`internal/runtime/executor/openai_compat_executor.go:1031`). Every other executor leaves it
  `false`, so their behaviour is unchanged.
- `newAntigravityStatusErr` sets it for 429s only:
  `err.transientRateLimit = classifyAntigravity429(body) == antigravity429RateLimited`
  (`antigravity_executor_credits.go:344`). Deliberately narrow: `QUOTA_EXHAUSTED`, soft bodies
  and anything unclassified keep the floor and keep escalating.
- `isTransientRateLimitError` (`sdk/cliproxy/auth/conductor_cooldown.go:1459`) recovers the flag
  with `errors.As` over an `interface{ TransientRateLimit() bool }`, mirroring how
  `retryAfterFromError` already recovers the hint. The execution paths set
  `result.TransientRateLimit` next to the existing `result.RetryAfter` assignment.

The flag lives on `Result`, not on `auth.Error`, and is threaded as the sixth parameter of
`applyAuthFailureState`: `sdk/cliproxy/auth/errors_compat_test.go`
`TestErrorLegacyUnkeyedLiteralCompatibility` constructs `Error` with an unkeyed literal, so any
new field on that struct breaks `go vet`. The seven pre-existing `applyAuthFailureState` call
sites in `cooldown_backoff_test.go` were updated mechanically with a trailing `, false`; no
assertion was changed.

Tests: `TestMarkResultTransientRateLimitKeepsProviderHint`,
`TestApplyAuthFailureStateTransientRateLimitKeepsProviderHint` (its second half feeds the same
sub-second hint through an exhausted-quota error and asserts the floor and `BackoffLevel == 1`
still apply), `TestIsTransientRateLimitErrorDetectsWrappedProviderClassification`,
`TestNewAntigravityStatusErrMarksTransientRateLimit`.

Reverse bite-check — reverting both gates to `*retryAfter <= 0`:

```
=== RUN   TestMarkResultTransientRateLimitKeepsProviderHint
    cooldown_backoff_test.go:482: expected BackoffLevel to stay 0 for a transient rate limit, got 1
--- FAIL: TestMarkResultTransientRateLimitKeepsProviderHint (0.00s)
=== RUN   TestApplyAuthFailureStateTransientRateLimitKeepsProviderHint
    cooldown_backoff_test.go:497: expected BackoffLevel to stay 0 for a transient rate limit, got 1
--- FAIL: TestApplyAuthFailureStateTransientRateLimitKeepsProviderHint (0.00s)
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth	0.422s
FAIL
```

Reverse bite-check — discarding the executor classification:

```
=== RUN   TestNewAntigravityStatusErrMarksTransientRateLimit
    antigravity_executor_credits_test.go:249: expected a RATE_LIMIT_EXCEEDED 429 with a sub-second hint to be marked transient
--- FAIL: TestNewAntigravityStatusErrMarksTransientRateLimit (0.00s)
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor	0.666s
FAIL
```

`go build ./...`, `go vet ./sdk/cliproxy/... ./internal/runtime/executor/...`, `gofmt -l` and
`go test ./sdk/cliproxy/auth/... ./internal/runtime/executor/...` are clean.

## Follow-up review round 3 — streaming and token-count paths (`8c07697e`)

Review found the classification was still only wired into the non-stream execution path.

- `executeStreamWithModelPool` built every failure result from `retryAfterFromError` alone. All
  five results now set the flag next to the hint: `sdk/cliproxy/auth/conductor_stream.go:275`,
  `:354`, `:374`, `:386`, `:401`. The mid-stream result in `wrapStreamResult` (`:131`) is left
  alone on purpose — it sets no hint today, so the ladder still applies there and adding one
  would be a behavioural change beyond this review.
- Antigravity `CountTokens` hand-rolled `statusErr` twice. Both now go through
  `newAntigravityStatusErr` (`internal/runtime/executor/antigravity_executor_tokens.go:167` and
  `:172`), which does the same `helps.ParseRetryDelay` work and additionally applies
  `classifyAntigravity429`.

Tests: `TestExecuteStreamKeepsProviderHintForTransientRateLimit` (new file
`sdk/cliproxy/auth/conductor_stream_classification_test.go`, drives a real `Manager.ExecuteStream`
against a stub executor whose error reports 429 + `479417207ns` + transient) and
`TestAntigravityCountTokensClassifiesTransient429` (real `CountTokens` against an `httptest`
server serving a structured `RATE_LIMIT_EXCEEDED` 429).

Reverse bite-check — dropping the new line from the executor-error stream branch:

```
--- FAIL: TestExecuteStreamKeepsProviderHintForTransientRateLimit (0.00s)
    conductor_stream_classification_test.go:54: expected BackoffLevel to stay 0 for a transient rate limit, got 1
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth	0.433s
FAIL
```

Reverse bite-check — restoring the hand-rolled token-count `statusErr`:

```
--- FAIL: TestAntigravityCountTokensClassifiesTransient429 (0.00s)
    antigravity_executor_credits_test.go:858: expected a RATE_LIMIT_EXCEEDED token-count 429 to be marked transient
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor	0.666s
FAIL
```

Upstream counterpart: https://github.com/router-for-me/CLIProxyAPI/pull/5130

## Review follow-up: short-cooldown 429s are transient

The Antigravity executor raises a synthetic 429 while an auth sits in a short cooldown. That cooldown is a local, self-imposed pause of at most a few minutes, but the error carried only a positive `retryAfter` hint and no classification, so `isTransientRateLimitError()` (`sdk/cliproxy/auth/conductor_cooldown.go:1459`) returned false and `applyAuthFailureState()` (`sdk/cliproxy/auth/conductor_cooldown.go:914`) treated it as an exhausted upstream quota, escalating `BackoffLevel` toward the 30 minute ceiling.

All three cooldown short-circuits now set `transientRateLimit: true` — `internal/runtime/executor/antigravity_executor_execute.go:36` (`Execute`), `:268` (`executeClaudeNonStream`) and `internal/runtime/executor/antigravity_executor_stream.go:35` (`ExecuteStream`) — because the classification is consumed independently on each path (`conductor_execution.go:381`, `conductor_stream.go:275/354/374/386/401`, `conductor_home_execution.go:181`).

Test: `TestAntigravityShortCooldownErrorIsTransient` in `internal/runtime/executor/antigravity_executor_cooldown_transient_test.go`.

Reverse bite-check — dropping `transientRateLimit: true` from the three literals:

```
--- FAIL: TestAntigravityShortCooldownErrorIsTransient (0.00s)
    --- FAIL: TestAntigravityShortCooldownErrorIsTransient/execute (0.00s)
        antigravity_executor_cooldown_transient_test.go:81: expected the synthetic short-cooldown 429 to be transient so the conductor rotates instead of escalating backoff
    --- FAIL: TestAntigravityShortCooldownErrorIsTransient/execute-claude (0.00s)
        antigravity_executor_cooldown_transient_test.go:81: expected the synthetic short-cooldown 429 to be transient so the conductor rotates instead of escalating backoff
    --- FAIL: TestAntigravityShortCooldownErrorIsTransient/execute-stream (0.00s)
        antigravity_executor_cooldown_transient_test.go:81: expected the synthetic short-cooldown 429 to be transient so the conductor rotates instead of escalating backoff
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor	0.671s
FAIL
```


## Review follow-up: ordinary Claude 429s are transient

Ordinary (non-unified) Claude 429s reached `claudeRateLimitError` wrapping a `statusErr` with no `transientRateLimit` flag (`internal/runtime/executor/claude_executor_request.go:295-308`), so `isTransientRateLimitError()` returned false and `applyAuthFailureState()` treated an ordinary model-level throttle as exhausted quota, escalating `BackoffLevel` toward the 30 minute ceiling. The ordinary path in `classifyClaudeUpstreamError` now sets `transientRateLimit = true`; the unified 5h/7d rejection path is untouched and stays on the quota ladder.

Tests: `TestClassifyClaudeUpstreamError_OrdinaryRateLimitIsTransient` and `TestClassifyClaudeUpstreamError_UnifiedRejectionNotTransient` (the negative pin for the unified path).

Reverse bite-check — dropping `err.transientRateLimit = true`:

```
--- FAIL: TestClassifyClaudeUpstreamError_OrdinaryRateLimitIsTransient (0.00s)
    claude_executor_beta_policy_test.go:306: ordinary Claude 429 = {"type":"error","error":{"type":"rate_limit_error","message":"Number of requests has exceeded your rate limit."}}, want a transient rate limit
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor	0.695s
FAIL
```


## Review follow-up: transient 429s without a hint bypass the quota ladder

The ladder bypass previously required a parseable `retryAfter` hint, so a transient 429 with no hint (e.g. an ordinary Claude throttle without reset headers) fell into `quotaCooldownAfterFailure` and advanced `BackoffLevel` anyway. Both copies of the logic — `MarkResult`'s per-model state (`sdk/cliproxy/auth/conductor_cooldown.go:829`) and `applyAuthFailureState`'s credential state (`:1917`) — now bypass the ladder for any transient 429, keeping the hint verbatim when present and falling back to `nextTransientErrorRetryAfter` (~60s) otherwise.

Test: `TestManager_MarkResult_Transient429WithoutHintBypassesQuotaLadder`.

Reverse bite-check — reverting `conductor_cooldown.go`:

```
--- FAIL: TestManager_MarkResult_Transient429WithoutHintBypassesQuotaLadder (0.00s)
    conductor_overrides_test.go:836: expected credential quota ladder to stay at level 0 for a transient 429 without hint, got 1
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth	0.610s
FAIL
```


## Review follow-up: transient fallback respects disabled cooldowns

With `transientErrorCooldownSeconds < 0` the transient fallback returns a zero time, but both 429 branches still recorded `Unavailable=true` / `Quota.Exceeded=true` with an empty `NextRecoverAt`, which `availabilityBlock` reads as an indefinite park. The transient-429 handling in `MarkResult` (`sdk/cliproxy/auth/conductor_cooldown.go:861`) and `applyAuthFailureState` (`:1952`) now skips the marking when the transient fallback yields a zero time, preserving any pre-existing quota block.

Test: `TestManager_MarkResult_Transient429WithoutHintRespectsDisabledCooldown`.

Reverse bite-check — reverting `conductor_cooldown.go`:

```
--- FAIL: TestManager_MarkResult_Transient429WithoutHintRespectsDisabledCooldown (0.00s)
    conductor_overrides_test.go:899: expected the credential quota state to stay clear with transient cooldowns disabled
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth	0.435s
FAIL
```


## Review follow-up: disabled-cooldown skip restores availability fields

The transient-cooldown-off skip restored the status/quota fields but left `auth.Unavailable=true` (set at the top of `applyAuthFailureState`) and `auth.NextRetryAfter` untouched, so the credential stayed blocked anyway. The prior availability fields are now captured and restored (`sdk/cliproxy/auth/conductor_cooldown.go:2027`).

Test: `TestManager_MarkResult_Transient429WithoutHintRespectsDisabledCooldownAuthLevel` (auth-level Result drives `applyAuthFailureState`).

Reverse bite-check — reverting `conductor_cooldown.go`:

```
--- FAIL: TestManager_MarkResult_Transient429WithoutHintRespectsDisabledCooldownAuthLevel (0.00s)
    conductor_overrides_test.go:952: expected the credential to stay available with transient cooldowns disabled
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth	0.426s
FAIL
```

## Review follow-up: reasoned RATE_LIMIT_EXCEEDED without RetryInfo is transient

`RATE_LIMIT_EXCEEDED` without a `RetryInfo` detail downgrades to `SoftRetry`, and only the `RateLimited` category was marked transient, so a plain per-minute throttle was read as exhausted quota. `newAntigravityStatusErr` now marks the soft rate limit transient when the classification comes from the ErrorInfo reason (`antigravity_executor_credits.go:350`); the bare "too many requests" message heuristic still stays on the quota ladder.

Test: new case in `TestNewAntigravityStatusErrMarksTransientRateLimit`.

Reverse bite-check — reverting `antigravity_executor_credits.go`:

```
--- FAIL: TestNewAntigravityStatusErrMarksTransientRateLimit (0.00s)
    antigravity_executor_credits_test.go:290: expected a RATE_LIMIT_EXCEEDED 429 without RetryInfo to be marked transient
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor	0.788s
FAIL
```

## Tooling note

The `jbcontext` CLI is installed on this machine but its stored session cannot be decrypted (`the OS keychain is not accessible`), so `jbcontext search` could not run. The equivalent semantic search, review and blast-radius passes were performed with local code-intelligence tooling instead.
