### PR TITLE
fix(openai): sanitize websocket errors before request logging

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -1024,8 +1024,12 @@ func truncateResponsesStreamErrorText(text string, limit int) string {
 }
 
 func redactResponsesStreamErrorText(text string) string {
-	text = responsesStreamSensitiveValuePattern.ReplaceAllString(text, `${1}[REDACTED]`)
-	return responsesStreamBearerPattern.ReplaceAllString(text, "Bearer [REDACTED]")
+	// The bearer pattern must run first: it consumes the whole credential
+	// ("Bearer <token>"), while the key/value pattern would otherwise match
+	// "Bearer" itself as the value of an Authorization header and leave the
+	// token behind in the clear.
+	text = responsesStreamBearerPattern.ReplaceAllString(text, "Bearer [REDACTED]")
+	return responsesStreamSensitiveValuePattern.ReplaceAllString(text, `${1}[REDACTED]`)
 }
 
 func sanitizeResponsesStreamEventName(eventName string) string {

--- a/sdk/api/handlers/openai/openai_responses_websocket_forward.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_forward.go
@@ -66,7 +66,7 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 				return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), nil, nil
 			}
 
-			h.LoggingAPIResponseError(context.WithValue(context.Background(), "gin", c), errMsg)
+			h.LoggingAPIResponseError(context.WithValue(context.Background(), "gin", c), sanitizeResponsesStreamErrorMessage(errMsg))
 			if opts.suppressError != nil && opts.suppressError(errMsg) {
 				cancel(errMsg.Error)
 				return completedOutput, completedResponseID, sortedStringSet(pendingToolCallIDs), errMsg, nil
@@ -129,7 +129,7 @@ func (h *OpenAIResponsesAPIHandler) forwardResponsesWebsocket(
 				if eventType == wsEventTypeError {
 					payloadErrMsg = responsesWebsocketErrorMessageFromPayload(payloads[i])
 					if h != nil {
-						h.LoggingAPIResponseError(context.WithValue(context.Background(), "gin", c), payloadErrMsg)
+						h.LoggingAPIResponseError(context.WithValue(context.Background(), "gin", c), sanitizeResponsesStreamErrorMessage(payloadErrMsg))
 					}
 					if opts.suppressError != nil && opts.suppressError(payloadErrMsg) {
 						cancel(payloadErrMsg.Error)

--- a/sdk/api/handlers/openai/openai_responses_websocket_forward_sanitization_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_forward_sanitization_test.go
@@ -1,0 +1,121 @@
+package openai
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+// runResponsesWebsocketForward drives forwardResponsesWebsocket over a real
+// websocket pair with the given payloads / executor error and reports the
+// ErrorMessage the request logger stored in API_RESPONSE_ERROR.
+func runResponsesWebsocketForward(t *testing.T, payloads []string, upstreamErr *interfaces.ErrorMessage) (string, bool) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	type forwardResult struct {
+		logged string
+		exists bool
+	}
+	resultCh := make(chan forwardResult, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := responsesWebsocketUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = r
+
+		data := make(chan []byte, len(payloads))
+		for _, payload := range payloads {
+			data <- []byte(payload)
+		}
+		close(data)
+		errCh := make(chan *interfaces.ErrorMessage, 1)
+		if upstreamErr != nil {
+			errCh <- upstreamErr
+		}
+		close(errCh)
+
+		h := NewOpenAIResponsesAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, nil))
+		_, _, _, _, _ = h.forwardResponsesWebsocket(
+			ctx,
+			newResponsesWebsocketWriter(conn),
+			func(...interface{}) {},
+			data,
+			errCh,
+			newInMemoryWebsocketTimelineLog(),
+			"session-1",
+		)
+		res := forwardResult{}
+		if value, exists := ctx.Get("API_RESPONSE_ERROR"); exists {
+			if errs, ok := value.([]*interfaces.ErrorMessage); ok && len(errs) > 0 && errs[0] != nil && errs[0].Error != nil {
+				res.exists = true
+				res.logged = errs[0].Error.Error()
+			}
+		}
+		resultCh <- res
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	select {
+	case res := <-resultCh:
+		return res.logged, res.exists
+	case <-time.After(5 * time.Second):
+		t.Fatal("forwarder did not finish")
+		return "", false
+	}
+}
+
+// An executor error delivered over the errs channel can carry the raw
+// upstream body, which may echo the credential we sent upstream. The request
+// logger records whatever reaches LoggingAPIResponseError verbatim, so the
+// websocket forwarder must sanitize before logging.
+func TestForwardResponsesWebsocketSanitizesLoggedUpstreamError(t *testing.T) {
+	const secret = "sk-forward-errs-secret"
+	logged, exists := runResponsesWebsocketForward(t,
+		[]string{`{"type":"response.output_text.delta","delta":"hi"}`},
+		&interfaces.ErrorMessage{StatusCode: http.StatusUnauthorized, Error: errors.New("upstream rejected request: Authorization: Bearer " + secret)},
+	)
+	if !exists {
+		t.Fatal("expected the forwarder to record the upstream error in API_RESPONSE_ERROR")
+	}
+	if strings.Contains(logged, secret) {
+		t.Fatalf("request log stored the credential verbatim: %q", logged)
+	}
+}
+
+// Same boundary for the upstream "error" event payload: the terminal payload
+// error is logged before the sanitized rebuild happens, so the log copy must
+// be sanitized on its own.
+func TestForwardResponsesWebsocketSanitizesLoggedErrorPayload(t *testing.T) {
+	const secret = "sk-forward-payload-secret"
+	logged, exists := runResponsesWebsocketForward(t,
+		[]string{`{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"bad request: Authorization: Bearer ` + secret + `"}}`},
+		nil,
+	)
+	if !exists {
+		t.Fatal("expected the forwarder to record the upstream error payload in API_RESPONSE_ERROR")
+	}
+	if strings.Contains(logged, secret) {
+		t.Fatalf("request log stored the credential verbatim: %q", logged)
+	}
+}


### PR DESCRIPTION
## Problem

`forwardResponsesWebsocket` passed two upstream-derived errors to `LoggingAPIResponseError` verbatim, before the redaction that `writeResponsesWebsocketTerminalError` applies to the client-facing frame:

- the executor error delivered on the errs channel (`sdk/api/handlers/openai/openai_responses_websocket_forward.go:69`), and
- the terminal `error` event payload (`:132`).

With `RequestLog` enabled the request logger stores whatever it receives (`sdk/api/handlers/handlers_errors.go:164-170`), so a raw upstream body could land in the log — including a credential the upstream echoed back.

Surfaced by the upstream review at router-for-me/CLIProxyAPI#4881 (discussion_r3827803235); the same code already lives on `main` here, so this is the Plus-side hardening for it.

## Fix

- Both call sites now pass the message through `sanitizeResponsesStreamErrorMessage`, the same trust-boundary sanitizer used elsewhere in this package.
- `redactResponsesStreamErrorText` now applies the bearer pattern BEFORE the key/value pattern (`sdk/api/handlers/openai/openai_responses_handlers.go`). Previously the key/value pattern matched `Bearer` itself as the value of an `Authorization:` header and redacted only that word, leaving the token behind in the clear.

The locally constructed `stream closed before response.completed` message is intentionally left unsanitized — it contains no upstream content.

## Tests

`TestForwardResponsesWebsocketSanitizesLoggedUpstreamError` and `TestForwardResponsesWebsocketSanitizesLoggedErrorPayload` (new file `openai_responses_websocket_forward_sanitization_test.go`) drive the forwarder over a real websocket pair with a credential-bearing upstream error and assert the recorded `API_RESPONSE_ERROR` is redacted.

Reverse bite-checks:

1. Restoring both verbatim call sites (redaction swap kept):

```
--- FAIL: TestForwardResponsesWebsocketSanitizesLoggedErrorPayload (0.00s)
    openai_responses_websocket_forward_sanitization_test.go:119: request log stored the credential verbatim: "{\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"bad request: Authorization: Bearer sk-forward-payload-secret\"}}"
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/openai	0.821s
FAIL
```

2. Restoring the old redaction order only (call-site wraps kept):

```
--- FAIL: TestForwardResponsesWebsocketSanitizesLoggedUpstreamError (0.00s)
    openai_responses_websocket_forward_sanitization_test.go:102: request log stored the credential verbatim: "upstream rejected request: Authorization: [REDACTED] sk-forward-errs-secret"
--- FAIL: TestForwardResponsesWebsocketSanitizesLoggedErrorPayload (0.00s)
    openai_responses_websocket_forward_sanitization_test.go:119: request log stored the credential verbatim: "{\"error\":{\"type\":\"invalid_request_error\",\"message\":\"bad request: Authorization: [REDACTED] sk-forward-payload-secret\"}}"
FAIL
FAIL	github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/openai	0.715s
```

With the fix, `go build ./...`, `go vet ./sdk/api/handlers/openai/...` and `go test -count=1 ./sdk/api/handlers/openai/...` are green.
