### PR TITLE
fix(auth): lower transient error cooldown default to 10s

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -167,7 +167,7 @@ disable-cooling: false
 save-cooldown-status: false
 
 # Cooldown duration in seconds for transient upstream errors (408/500/502/503/504).
-# Set to 0 to keep the legacy 60-second cooldown; set to -1 to disable transient error cooldowns.
+# Set to 0 to keep the legacy 10-second cooldown; set to -1 to disable transient error cooldowns.
 transient-error-cooldown-seconds: 0
 
 # When true, globally disable Claude request cloaking (the Claude Code CLI disguise and

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -946,8 +946,8 @@ func TestManager_MarkResult_TransientErrorCooldownDefault(t *testing.T) {
 		t.Fatal("expected transient error cooldown to keep the legacy default")
 	}
 	diff := time.Until(state.NextRetryAfter)
-	if diff < 55*time.Second || diff > 65*time.Second {
-		t.Fatalf("expected transient error cooldown to be ~60 seconds, got %v", diff)
+	if diff < 5*time.Second || diff > 15*time.Second {
+		t.Fatalf("expected transient error cooldown to be ~10 seconds, got %v", diff)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -32,7 +32,7 @@ const (
 	refreshIneffectiveBackoff = 30 * time.Second
 	quotaBackoffBase          = time.Second
 	quotaBackoffMax           = 30 * time.Minute
-	transientErrorCooldown    = time.Minute
+	transientErrorCooldown    = 10 * time.Second
 )
 
 // StartAutoRefresh launches a background loop that evaluates auth freshness

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -32,7 +32,12 @@ const (
 	refreshIneffectiveBackoff = 30 * time.Second
 	quotaBackoffBase          = time.Second
 	quotaBackoffMax           = 30 * time.Minute
-	transientErrorCooldown    = 10 * time.Second
+	// transientErrorCooldown is the default for 408/500/502/503/504 transient
+	// errors and the fallback enforced cooldown for request-scoped
+	// stop-and-cooldown / continue-and-cooldown rules. The latter use this
+	// constant directly and do not consult the transient-error-cooldown-seconds
+	// knob.
+	transientErrorCooldown = 10 * time.Second
 )
 
 // StartAutoRefresh launches a background loop that evaluates auth freshness


### PR DESCRIPTION
## Summary

Lowers the effective default transient-error cooldown from 60 seconds to 10 seconds.

A single transient 5xx/408 blip was sidelining a genuinely-live account or model for a full minute. With several auths sharing the same upstream model, one gateway hiccup could cause a service blackout. The legacy `transientErrorCooldown` constant is now `10s`, and the example config documents the new default. The `transient-error-cooldown-seconds` knob remains fully configurable for the normal transient-error path.

## Note on `ErrorCodeForceCooldown`

`transientErrorCooldown` also backs the two `ErrorCodeForceCooldown` fallbacks in `conductor_cooldown.go` (model state at line ~928 and auth state at line ~2029: `now.Add(transientErrorCooldown)`). These enforce request-scoped `stop-and-cooldown` / `continue-and-cooldown` rules. That path uses the same constant directly and is intentionally not gated by `transient-error-cooldown-seconds`, so those forced cooldowns also drop from 60s to 10s. This is consistent with the blackout-avoidance rationale: a force-cooldown rule should not sideline a live account for a full minute either. A code comment has been added to `conductor_refresh.go` to make this explicit.

## Cross-link

Mirror PR in upstream `CLIProxyAPI`: #5140

## Related work

- Quota-429 ladder hardening is handled in #198 (this repo) and #5130 (upstream). Those PRs are related but not in conflict with this change.

## Test plan

- `sdk/cliproxy/auth/conductor_overrides_test.go` pins the new default at ~10s.
- `go test ./sdk/cliproxy/auth/...` and `go build ./...` pass.
