### PR TITLE
fix(antigravity): restore inline image attachment and add GeminiCLI tests

### DIFF
--- a/internal/translator/antigravity/gemini/antigravity_gemini_request.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request.go
@@ -633,6 +633,74 @@ func logAntigravityClaudeGeminiSignatureSanitize(modelName, action, reason strin
 	log.WithFields(fields).Debug("antigravity gemini translator: sanitized Claude target thoughtSignature before upstream")
 }
 
+func normalizeAntigravityInlineDataPart(part gjson.Result) ([]byte, bool) {
+	inline := part.Get("inlineData")
+	if !inline.Exists() {
+		inline = part.Get("inline_data")
+	}
+	if !inline.Exists() {
+		return nil, false
+	}
+	data := inline.Get("data").String()
+	if data == "" {
+		return nil, false
+	}
+	mimeType := inline.Get("mimeType").String()
+	if mimeType == "" {
+		mimeType = inline.Get("mime_type").String()
+	}
+	if mimeType == "" {
+		// Cloud Code Assist ignores inlineData without mimeType.
+		mimeType = "image/png"
+	}
+	out := []byte(`{"inlineData":{"mimeType":"","data":""}}`)
+	out, _ = sjson.SetBytes(out, "inlineData.mimeType", mimeType)
+	out, _ = sjson.SetBytes(out, "inlineData.data", data)
+	return out, true
+}
+
+func attachInlineDataToFunctionResponse(response gjson.Result, images [][]byte) gjson.Result {
+	if len(images) == 0 {
+		return response
+	}
+	target := []byte(response.Raw)
+	for _, img := range images {
+		target, _ = sjson.SetRawBytes(target, "functionResponse.parts.-1", img)
+	}
+	return gjson.ParseBytes(target)
+}
+
+// collectFunctionResponsesWithSiblingInlineData keeps functionResponse parts and
+// moves sibling inline_data/inlineData onto the nearest preceding functionResponse.
+// Leading images before the first functionResponse attach to that first response.
+func collectFunctionResponsesWithSiblingInlineData(parts gjson.Result) []gjson.Result {
+	responses := make([]gjson.Result, 0)
+	leadingImages := make([][]byte, 0)
+	current := -1
+	parts.ForEach(func(_, part gjson.Result) bool {
+		if part.Get("functionResponse").Exists() {
+			responses = append(responses, part)
+			current = len(responses) - 1
+			if len(leadingImages) > 0 {
+				responses[current] = attachInlineDataToFunctionResponse(responses[current], leadingImages)
+				leadingImages = nil
+			}
+			return true
+		}
+		imagePart, ok := normalizeAntigravityInlineDataPart(part)
+		if !ok {
+			return true
+		}
+		if current >= 0 {
+			responses[current] = attachInlineDataToFunctionResponse(responses[current], [][]byte{imagePart})
+			return true
+		}
+		leadingImages = append(leadingImages, imagePart)
+		return true
+	})
+	return responses
+}
+
 // FunctionCallGroup represents a group of function calls and their responses
 type FunctionCallGroup struct {
 	ResponsesNeeded int
@@ -749,14 +817,8 @@ func fixCLIToolResponse(input []byte) ([]byte, error) {
 		role := value.Get("role").String()
 		parts := value.Get("parts")
 
-		// Check if this content has function responses
-		var responsePartsInThisContent []gjson.Result
-		parts.ForEach(func(_, part gjson.Result) bool {
-			if part.Get("functionResponse").Exists() {
-				responsePartsInThisContent = append(responsePartsInThisContent, part)
-			}
-			return true
-		})
+		// Collect function responses and attach sibling inlineData to the nearest one.
+		responsePartsInThisContent := collectFunctionResponsesWithSiblingInlineData(parts)
 
 		// If this content has function responses, collect them
 		if len(responsePartsInThisContent) > 0 {

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
@@ -925,6 +925,193 @@ func TestSanitizeAntigravityClaudeGeminiRequestSignatures_StringValueNotTreatedA
 	}
 }
 
+func TestFixCLIToolResponse_AttachesSiblingInlineDataToNearestFunctionResponse(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts string
+		want  []struct {
+			id   string
+			mime string
+			data string
+		}
+	}{
+		{
+			name: "snake_case sibling after single response",
+			parts: `{"functionResponse":{"name":"read","response":{"result":"Read image file [image/png]"},"id":"call_1"}},` +
+				`{"inline_data":{"mime_type":"image/png","data":"QUJD"}}`,
+			want: []struct {
+				id   string
+				mime string
+				data string
+			}{{id: "call_1", mime: "image/png", data: "QUJD"}},
+		},
+		{
+			name: "camelCase sibling after single response",
+			parts: `{"functionResponse":{"name":"read","response":{"result":"ok"},"id":"call_1"}},` +
+				`{"inlineData":{"mimeType":"image/webp","data":"NEW"}}`,
+			want: []struct {
+				id   string
+				mime string
+				data string
+			}{{id: "call_1", mime: "image/webp", data: "NEW"}},
+		},
+		{
+			name: "append sibling onto existing functionResponse.parts",
+			parts: `{"functionResponse":{"name":"read","response":{"result":"ok"},"id":"call_1","parts":[{"inlineData":{"mimeType":"image/gif","data":"OLD"}}]}},` +
+				`{"inlineData":{"mimeType":"image/webp","data":"NEW"}}`,
+			want: []struct {
+				id   string
+				mime string
+				data string
+			}{
+				{id: "call_1", mime: "image/gif", data: "OLD"},
+			},
+		},
+		{
+			name: "interleaved siblings attach to nearest response",
+			parts: `{"functionResponse":{"name":"read","response":{"result":"A"},"id":"call_a"}},` +
+				`{"inline_data":{"mime_type":"image/png","data":"AAA"}},` +
+				`{"functionResponse":{"name":"read","response":{"result":"B"},"id":"call_b"}},` +
+				`{"inline_data":{"mime_type":"image/jpeg","data":"BBB"}}`,
+			want: []struct {
+				id   string
+				mime string
+				data string
+			}{
+				{id: "call_a", mime: "image/png", data: "AAA"},
+				{id: "call_b", mime: "image/jpeg", data: "BBB"},
+			},
+		},
+		{
+			name: "leading sibling attaches to first response",
+			parts: `{"inline_data":{"mime_type":"image/png","data":"LEAD"}},` +
+				`{"functionResponse":{"name":"read","response":{"result":"A"},"id":"call_a"}},` +
+				`{"functionResponse":{"name":"read","response":{"result":"B"},"id":"call_b"}}`,
+			want: []struct {
+				id   string
+				mime string
+				data string
+			}{
+				{id: "call_a", mime: "image/png", data: "LEAD"},
+			},
+		},
+		{
+			name: "missing mimeType defaults to image/png",
+			parts: `{"functionResponse":{"name":"read","response":{"result":"ok"},"id":"call_1"}},` +
+				`{"inlineData":{"data":"QUJD"}}`,
+			want: []struct {
+				id   string
+				mime string
+				data string
+			}{{id: "call_1", mime: "image/png", data: "QUJD"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			modelParts := `{"functionCall":{"name":"read","id":"call_1"}}`
+			if tt.name == "interleaved siblings attach to nearest response" || tt.name == "leading sibling attaches to first response" {
+				modelParts = `{"functionCall":{"name":"read","id":"call_a"}},{"functionCall":{"name":"read","id":"call_b"}}`
+			}
+			input := `{"request":{"contents":[` +
+				`{"role":"model","parts":[` + modelParts + `]},` +
+				`{"role":"user","parts":[` + tt.parts + `]}` +
+				`]}}`
+			result, err := fixCLIToolResponse([]byte(input))
+			if err != nil {
+				t.Fatalf("fixCLIToolResponse failed: %v", err)
+			}
+			contents := gjson.GetBytes(result, "request.contents").Array()
+			if len(contents) != 2 {
+				t.Fatalf("contents = %d, want 2. Output: %s", len(contents), result)
+			}
+			funcParts := contents[1].Get("parts").Array()
+			gotByID := map[string][]gjson.Result{}
+			for _, part := range funcParts {
+				fr := part.Get("functionResponse")
+				gotByID[fr.Get("id").String()] = fr.Get("parts").Array()
+			}
+			for _, want := range tt.want {
+				images := gotByID[want.id]
+				found := false
+				for _, img := range images {
+					if img.Get("inlineData.data").String() == want.data && img.Get("inlineData.mimeType").String() == want.mime {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("id=%s missing inlineData mime=%s data=%s. Output: %s", want.id, want.mime, want.data, result)
+				}
+			}
+			if tt.name == "interleaved siblings attach to nearest response" {
+				if len(gotByID["call_a"]) != 1 || len(gotByID["call_b"]) != 1 {
+					t.Fatalf("nearest attribution failed: A=%d B=%d. Output: %s", len(gotByID["call_a"]), len(gotByID["call_b"]), result)
+				}
+			}
+			if tt.name == "leading sibling attaches to first response" {
+				if len(gotByID["call_b"]) != 0 {
+					t.Fatalf("leading image leaked onto call_b. Output: %s", result)
+				}
+			}
+			if tt.name == "append sibling onto existing functionResponse.parts" {
+				images := gotByID["call_1"]
+				if len(images) != 2 {
+					t.Fatalf("existing+sibling parts = %d, want 2. Output: %s", len(images), result)
+				}
+				if images[1].Get("inlineData.data").String() != "NEW" {
+					t.Fatalf("appended sibling data = %q, want NEW. Output: %s", images[1].Get("inlineData.data").String(), result)
+				}
+			}
+		})
+	}
+}
+
+func TestConvertGeminiRequestToAntigravity_PreservesSiblingToolImageOnUserRole(t *testing.T) {
+	input := []byte(`{
+		"contents": [
+			{"role":"user","parts":[{"text":"read file"}]},
+			{"role":"model","parts":[{"functionCall":{"name":"read","args":{},"id":"call_1"}}]},
+			{"role":"user","parts":[
+				{"functionResponse":{"name":"read","response":{"result":"Read image file [image/png]"},"id":"call_1"}},
+				{"inline_data":{"mime_type":"image/png","data":"QUJD"}}
+			]}
+		]
+	}`)
+	out := ConvertGeminiRequestToAntigravity("gemini-3-flash", input, false)
+	contents := gjson.GetBytes(out, "request.contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("contents = %d, want 3. Output: %s", len(contents), out)
+	}
+	funcContent := contents[2]
+	if got := funcContent.Get("role").String(); got != "user" {
+		t.Fatalf("role = %q, want user after Antigravity normalization. Output: %s", got, out)
+	}
+	funcResp := funcContent.Get("parts.0.functionResponse")
+	if !funcResp.Exists() {
+		t.Fatalf("functionResponse missing. Output: %s", out)
+	}
+	if got := funcResp.Get("id").String(); got != "call_1" {
+		t.Fatalf("id = %q, want call_1", got)
+	}
+	if got := funcResp.Get("response.result").String(); got != "Read image file [image/png]" {
+		t.Fatalf("result = %q", got)
+	}
+	inlineData := funcResp.Get("parts.0.inlineData")
+	if !inlineData.Exists() {
+		t.Fatalf("functionResponse.parts.0.inlineData missing. Output: %s", out)
+	}
+	if got := inlineData.Get("mimeType").String(); got != "image/png" {
+		t.Fatalf("mimeType = %q, want image/png", got)
+	}
+	if got := inlineData.Get("data").String(); got != "QUJD" {
+		t.Fatalf("data = %q, want QUJD", got)
+	}
+	if funcContent.Get("parts.1.inline_data").Exists() || funcContent.Get("parts.1.inlineData").Exists() {
+		t.Fatalf("sibling inline data should be absorbed into functionResponse.parts. Output: %s", out)
+	}
+}
+
 func TestSanitizeAntigravityClaudeGeminiRequestSignatures_LargeNumberDoesNotHaltKeyScan(t *testing.T) {
 	// A part with numbers outside float64 range should not break token scanning
 	inputJSON := []byte(`{

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
@@ -926,95 +926,95 @@ func TestSanitizeAntigravityClaudeGeminiRequestSignatures_StringValueNotTreatedA
 }
 
 func TestFixCLIToolResponse_AttachesSiblingInlineDataToNearestFunctionResponse(t *testing.T) {
+	type wantImage struct {
+		id   string
+		mime string
+		data string
+	}
 	tests := []struct {
-		name  string
-		parts string
-		want  []struct {
-			id   string
-			mime string
-			data string
-		}
+		name        string
+		modelCalls  string
+		parts       string
+		want        []wantImage
+		extraChecks func(t *testing.T, gotByID map[string][]gjson.Result)
 	}{
 		{
-			name: "snake_case sibling after single response",
+			name:       "snake_case sibling after single response",
+			modelCalls: `{"functionCall":{"name":"read","id":"call_1"}}`,
 			parts: `{"functionResponse":{"name":"read","response":{"result":"Read image file [image/png]"},"id":"call_1"}},` +
 				`{"inline_data":{"mime_type":"image/png","data":"QUJD"}}`,
-			want: []struct {
-				id   string
-				mime string
-				data string
-			}{{id: "call_1", mime: "image/png", data: "QUJD"}},
+			want: []wantImage{{id: "call_1", mime: "image/png", data: "QUJD"}},
 		},
 		{
-			name: "camelCase sibling after single response",
+			name:       "camelCase sibling after single response",
+			modelCalls: `{"functionCall":{"name":"read","id":"call_1"}}`,
 			parts: `{"functionResponse":{"name":"read","response":{"result":"ok"},"id":"call_1"}},` +
 				`{"inlineData":{"mimeType":"image/webp","data":"NEW"}}`,
-			want: []struct {
-				id   string
-				mime string
-				data string
-			}{{id: "call_1", mime: "image/webp", data: "NEW"}},
+			want: []wantImage{{id: "call_1", mime: "image/webp", data: "NEW"}},
 		},
 		{
-			name: "append sibling onto existing functionResponse.parts",
+			name:       "append sibling onto existing functionResponse.parts",
+			modelCalls: `{"functionCall":{"name":"read","id":"call_1"}}`,
 			parts: `{"functionResponse":{"name":"read","response":{"result":"ok"},"id":"call_1","parts":[{"inlineData":{"mimeType":"image/gif","data":"OLD"}}]}},` +
 				`{"inlineData":{"mimeType":"image/webp","data":"NEW"}}`,
-			want: []struct {
-				id   string
-				mime string
-				data string
-			}{
+			want: []wantImage{
 				{id: "call_1", mime: "image/gif", data: "OLD"},
+			},
+			extraChecks: func(t *testing.T, gotByID map[string][]gjson.Result) {
+				images := gotByID["call_1"]
+				if len(images) != 2 {
+					t.Fatalf("existing+sibling parts = %d, want 2", len(images))
+				}
+				if images[1].Get("inlineData.data").String() != "NEW" {
+					t.Fatalf("appended sibling data = %q, want NEW", images[1].Get("inlineData.data").String())
+				}
 			},
 		},
 		{
-			name: "interleaved siblings attach to nearest response",
+			name:       "interleaved siblings attach to nearest response",
+			modelCalls: `{"functionCall":{"name":"read","id":"call_a"}},{"functionCall":{"name":"read","id":"call_b"}}`,
 			parts: `{"functionResponse":{"name":"read","response":{"result":"A"},"id":"call_a"}},` +
 				`{"inline_data":{"mime_type":"image/png","data":"AAA"}},` +
 				`{"functionResponse":{"name":"read","response":{"result":"B"},"id":"call_b"}},` +
 				`{"inline_data":{"mime_type":"image/jpeg","data":"BBB"}}`,
-			want: []struct {
-				id   string
-				mime string
-				data string
-			}{
+			want: []wantImage{
 				{id: "call_a", mime: "image/png", data: "AAA"},
 				{id: "call_b", mime: "image/jpeg", data: "BBB"},
 			},
-		},
-		{
-			name: "leading sibling attaches to first response",
-			parts: `{"inline_data":{"mime_type":"image/png","data":"LEAD"}},` +
-				`{"functionResponse":{"name":"read","response":{"result":"A"},"id":"call_a"}},` +
-				`{"functionResponse":{"name":"read","response":{"result":"B"},"id":"call_b"}}`,
-			want: []struct {
-				id   string
-				mime string
-				data string
-			}{
-				{id: "call_a", mime: "image/png", data: "LEAD"},
+			extraChecks: func(t *testing.T, gotByID map[string][]gjson.Result) {
+				if len(gotByID["call_a"]) != 1 || len(gotByID["call_b"]) != 1 {
+					t.Fatalf("nearest attribution failed: A=%d B=%d", len(gotByID["call_a"]), len(gotByID["call_b"]))
+				}
 			},
 		},
 		{
-			name: "missing mimeType defaults to image/png",
+			name:       "leading sibling attaches to first response",
+			modelCalls: `{"functionCall":{"name":"read","id":"call_a"}},{"functionCall":{"name":"read","id":"call_b"}}`,
+			parts: `{"inline_data":{"mime_type":"image/png","data":"LEAD"}},` +
+				`{"functionResponse":{"name":"read","response":{"result":"A"},"id":"call_a"}},` +
+				`{"functionResponse":{"name":"read","response":{"result":"B"},"id":"call_b"}}`,
+			want: []wantImage{
+				{id: "call_a", mime: "image/png", data: "LEAD"},
+			},
+			extraChecks: func(t *testing.T, gotByID map[string][]gjson.Result) {
+				if len(gotByID["call_b"]) != 0 {
+					t.Fatalf("leading image leaked onto call_b")
+				}
+			},
+		},
+		{
+			name:       "missing mimeType defaults to image/png",
+			modelCalls: `{"functionCall":{"name":"read","id":"call_1"}}`,
 			parts: `{"functionResponse":{"name":"read","response":{"result":"ok"},"id":"call_1"}},` +
 				`{"inlineData":{"data":"QUJD"}}`,
-			want: []struct {
-				id   string
-				mime string
-				data string
-			}{{id: "call_1", mime: "image/png", data: "QUJD"}},
+			want: []wantImage{{id: "call_1", mime: "image/png", data: "QUJD"}},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			modelParts := `{"functionCall":{"name":"read","id":"call_1"}}`
-			if tt.name == "interleaved siblings attach to nearest response" || tt.name == "leading sibling attaches to first response" {
-				modelParts = `{"functionCall":{"name":"read","id":"call_a"}},{"functionCall":{"name":"read","id":"call_b"}}`
-			}
 			input := `{"request":{"contents":[` +
-				`{"role":"model","parts":[` + modelParts + `]},` +
+				`{"role":"model","parts":[` + tt.modelCalls + `]},` +
 				`{"role":"user","parts":[` + tt.parts + `]}` +
 				`]}}`
 			result, err := fixCLIToolResponse([]byte(input))
@@ -1044,24 +1044,8 @@ func TestFixCLIToolResponse_AttachesSiblingInlineDataToNearestFunctionResponse(t
 					t.Fatalf("id=%s missing inlineData mime=%s data=%s. Output: %s", want.id, want.mime, want.data, result)
 				}
 			}
-			if tt.name == "interleaved siblings attach to nearest response" {
-				if len(gotByID["call_a"]) != 1 || len(gotByID["call_b"]) != 1 {
-					t.Fatalf("nearest attribution failed: A=%d B=%d. Output: %s", len(gotByID["call_a"]), len(gotByID["call_b"]), result)
-				}
-			}
-			if tt.name == "leading sibling attaches to first response" {
-				if len(gotByID["call_b"]) != 0 {
-					t.Fatalf("leading image leaked onto call_b. Output: %s", result)
-				}
-			}
-			if tt.name == "append sibling onto existing functionResponse.parts" {
-				images := gotByID["call_1"]
-				if len(images) != 2 {
-					t.Fatalf("existing+sibling parts = %d, want 2. Output: %s", len(images), result)
-				}
-				if images[1].Get("inlineData.data").String() != "NEW" {
-					t.Fatalf("appended sibling data = %q, want NEW. Output: %s", images[1].Get("inlineData.data").String(), result)
-				}
+			if tt.extraChecks != nil {
+				tt.extraChecks(t, gotByID)
 			}
 		})
 	}

--- a/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
+++ b/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
@@ -250,6 +250,96 @@ func TestConvertOpenAIResponsesRequestToAntigravity_EmptyClaudeReasoningBeforeFu
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToAntigravity_PreservesToolResultImage(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3-flash",
+		"input": [
+			{"role": "user", "content": [{"type": "input_text", "text": "请帮我读取分析这张图片"}]},
+			{"type": "function_call", "id": "fc_read", "call_id": "call_read_1", "name": "read", "arguments": "{\"path\":\"/path/to/image.png\"}"},
+			{
+				"type": "function_call_output",
+				"call_id": "call_read_1",
+				"output": [
+					{"type": "input_text", "text": "Read image file [image/png]"},
+					{"type": "input_image", "detail": "auto", "image_url": "data:image/png;base64,QUJD"}
+				]
+			}
+		]
+	}`
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3-flash", []byte(inputJSON), false)
+	contents := gjson.GetBytes(out, "request.contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("expected 3 contents, got %d. Output: %s", len(contents), out)
+	}
+	funcContent := contents[2]
+	if got := funcContent.Get("role").String(); got != "user" {
+		t.Fatalf("role = %q, want user. Output: %s", got, out)
+	}
+	funcResp := funcContent.Get("parts.0.functionResponse")
+	if !funcResp.Exists() {
+		t.Fatalf("functionResponse should exist. Output: %s", out)
+	}
+	if got := funcResp.Get("id").String(); got != "call_read_1" {
+		t.Fatalf("id = %q, want call_read_1", got)
+	}
+	if got := funcResp.Get("name").String(); got != "read" {
+		t.Fatalf("name = %q, want read", got)
+	}
+	inlineData := funcResp.Get("parts.0.inlineData")
+	if !inlineData.Exists() {
+		t.Fatalf("expected functionResponse.parts.0.inlineData to exist, got: %s", out)
+	}
+	if got := inlineData.Get("mimeType").String(); got != "image/png" {
+		t.Errorf("expected mimeType image/png, got %q", got)
+	}
+	if got := inlineData.Get("data").String(); got != "QUJD" {
+		t.Errorf("expected data QUJD, got %q", got)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToAntigravity_AttachesParallelToolImagesToNearestResponse(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3-flash",
+		"input": [
+			{"role": "user", "content": [{"type": "input_text", "text": "read both"}]},
+			{"type": "function_call", "id": "fc_a", "call_id": "call_a", "name": "read", "arguments": "{\"path\":\"/tmp/a.png\"}"},
+			{"type": "function_call", "id": "fc_b", "call_id": "call_b", "name": "read", "arguments": "{\"path\":\"/tmp/b.png\"}"},
+			{
+				"type": "function_call_output",
+				"call_id": "call_a",
+				"output": [
+					{"type": "input_text", "text": "file A"},
+					{"type": "input_image", "image_url": "data:image/png;base64,AAA"}
+				]
+			},
+			{
+				"type": "function_call_output",
+				"call_id": "call_b",
+				"output": [
+					{"type": "input_text", "text": "file B"},
+					{"type": "input_image", "image_url": "data:image/jpeg;base64,BBB"}
+				]
+			}
+		]
+	}`
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3-flash", []byte(inputJSON), false)
+	parts := gjson.GetBytes(out, "request.contents.2.parts").Array()
+	if len(parts) != 2 {
+		t.Fatalf("function parts = %d, want 2. Output: %s", len(parts), out)
+	}
+	got := map[string]string{}
+	for _, part := range parts {
+		fr := part.Get("functionResponse")
+		got[fr.Get("id").String()] = fr.Get("parts.0.inlineData.data").String()
+	}
+	if got["call_a"] != "AAA" {
+		t.Fatalf("call_a image = %q, want AAA. Output: %s", got["call_a"], out)
+	}
+	if got["call_b"] != "BBB" {
+		t.Fatalf("call_b image = %q, want BBB. Output: %s", got["call_b"], out)
+	}
+}
+
 func TestConvertOpenAIResponsesRequestToAntigravity_GeminiReasoningUsesNativeThoughtSignaturePlacement(t *testing.T) {
 	sig := "EjQKMgEMOdbHO0Gd+c9Mxk4ELwPGbpCEcp2mFfYYLix2UVtBH3fL8GECc4+JITVnHF4qZDsA"
 	raw := []byte(`{"model":"gemini-3.5-flash","input":[{"type":"reasoning","encrypted_content":"gemini#` + sig + `","summary":[{"type":"summary_text","text":"reasoning summary"}]}]}`)

--- a/internal/translator/claude/gemini-cli/claude_gemini-cli_request_test.go
+++ b/internal/translator/claude/gemini-cli/claude_gemini-cli_request_test.go
@@ -1,0 +1,166 @@
+package geminiCLI
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertGeminiCLIRequestToClaude_HappyPath(t *testing.T) {
+	input := []byte(`{
+		"model": "claude-sonnet-4-6",
+		"request": {
+			"contents": [
+				{"role": "user", "parts": [{"text": "hello"}]},
+				{"role": "model", "parts": [{"text": "hi"}]}
+			]
+		}
+	}`)
+
+	out := ConvertGeminiCLIRequestToClaude("claude-sonnet-4-6", input, false)
+	if got := gjson.GetBytes(out, "model").String(); got != "claude-sonnet-4-6" {
+		t.Fatalf("model = %q, want claude-sonnet-4-6. Output: %s", got, out)
+	}
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 2 {
+		t.Fatalf("messages length = %d, want 2. Output: %s", len(messages), out)
+	}
+	if got := messages[0].Get("role").String(); got != "user" {
+		t.Fatalf("first message role = %q, want user. Output: %s", got, out)
+	}
+	if got := messages[1].Get("role").String(); got != "assistant" {
+		t.Fatalf("second message role = %q, want assistant. Output: %s", got, out)
+	}
+	if got := messages[1].Get("content.0.text").String(); got != "hi" {
+		t.Fatalf("second message text = %q, want hi. Output: %s", got, out)
+	}
+}
+
+func TestConvertGeminiCLIRequestToClaude_SystemInstruction(t *testing.T) {
+	input := []byte(`{
+		"model": "claude-sonnet-4-6",
+		"request": {
+			"systemInstruction": {"parts": [{"text": "sys"}]},
+			"contents": [{"role": "user", "parts": [{"text": "hello"}]}]
+		}
+	}`)
+
+	out := ConvertGeminiCLIRequestToClaude("claude-sonnet-4-6", input, false)
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) < 1 {
+		t.Fatalf("expected at least one message, got %d. Output: %s", len(messages), out)
+	}
+	found := false
+	for _, msg := range messages {
+		for _, part := range msg.Get("content").Array() {
+			if part.Get("text").String() == "sys" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("system instruction text not found in messages. Output: %s", out)
+	}
+}
+
+func TestConvertGeminiCLIRequestToClaude_ToolCallAndResponse(t *testing.T) {
+	input := []byte(`{
+		"model": "claude-sonnet-4-6",
+		"request": {
+			"contents": [
+				{"role": "model", "parts": [{"functionCall": {"name": "lookup", "args": {"q": "x"}, "id": "call_1"}}]},
+				{"role": "user", "parts": [{"functionResponse": {"name": "lookup", "response": {"result": "ok"}, "id": "call_1"}}]}
+			]
+		}
+	}`)
+
+	out := ConvertGeminiCLIRequestToClaude("claude-sonnet-4-6", input, false)
+	toolCallID := gjson.GetBytes(out, "messages.0.content.0.id").String()
+	if toolCallID == "" {
+		t.Fatalf("tool call id missing. Output: %s", out)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "lookup" {
+		t.Fatalf("tool call name = %q, want lookup. Output: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.tool_use_id").String(); got != toolCallID {
+		t.Fatalf("tool result id = %q, want %q. Output: %s", got, toolCallID, out)
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.content").String(); got != "ok" {
+		t.Fatalf("tool result content = %q, want ok. Output: %s", got, out)
+	}
+}
+
+func TestConvertGeminiCLIRequestToClaude_Tools(t *testing.T) {
+	input := []byte(`{
+		"model": "claude-sonnet-4-6",
+		"request": {
+			"contents": [{"role": "user", "parts": [{"text": "hello"}]}],
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"name": "read",
+							"description": "Read file",
+							"parameters": {"type": "object", "properties": {"path": {"type": "string"}}}
+						}
+					]
+				}
+			]
+		}
+	}`)
+
+	out := ConvertGeminiCLIRequestToClaude("claude-sonnet-4-6", input, false)
+	tools := gjson.GetBytes(out, "tools").Array()
+	if len(tools) != 1 {
+		t.Fatalf("tools length = %d, want 1. Output: %s", len(tools), out)
+	}
+	if got := tools[0].Get("name").String(); got != "read" {
+		t.Fatalf("tool name = %q, want read. Output: %s", got, out)
+	}
+	if got := tools[0].Get("input_schema.properties.path.type").String(); got != "string" {
+		t.Fatalf("tool schema path type = %q, want string. Output: %s", got, out)
+	}
+}
+
+func TestConvertClaudeResponseToGeminiCLI_TextAndUsage(t *testing.T) {
+	events := []byte(`data:{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+data:{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":10,"output_tokens":5}}
+`)
+
+	out := ConvertClaudeResponseToGeminiCLINonStream(context.Background(), "gemini-3-flash", nil, nil, events, nil)
+	if got := gjson.GetBytes(out, "response.candidates.0.content.parts.0.text").String(); got != "Hello" {
+		t.Fatalf("text = %q, want Hello. Output: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "response.usageMetadata.promptTokenCount").Int(); got != 10 {
+		t.Fatalf("promptTokenCount = %d, want 10. Output: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "response.usageMetadata.candidatesTokenCount").Int(); got != 5 {
+		t.Fatalf("candidatesTokenCount = %d, want 5. Output: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "response.usageMetadata.totalTokenCount").Int(); got != 15 {
+		t.Fatalf("totalTokenCount = %d, want 15. Output: %s", got, out)
+	}
+}
+
+func TestConvertClaudeResponseToGeminiCLI_ToolCall(t *testing.T) {
+	events := []byte(`data:{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","name":"list_dir","id":"tu_1"}}
+data:{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\": \"/\"}"}}
+data:{"type":"content_block_stop","index":0}
+`)
+
+	out := ConvertClaudeResponseToGeminiCLINonStream(context.Background(), "gemini-3-flash", nil, nil, events, nil)
+	parts := gjson.GetBytes(out, "response.candidates.0.content.parts").Array()
+	if len(parts) != 1 {
+		t.Fatalf("parts length = %d, want 1. Output: %s", len(parts), out)
+	}
+	if got := parts[0].Get("functionCall.name").String(); got != "list_dir" {
+		t.Fatalf("functionCall.name = %q, want list_dir. Output: %s", got, out)
+	}
+	if got := parts[0].Get("functionCall.args.path").String(); got != "/" {
+		t.Fatalf("functionCall.args.path = %q, want /. Output: %s", got, out)
+	}
+	if got := parts[0].Get("functionCall.id").String(); got != "tu_1" {
+		t.Fatalf("functionCall.id = %q, want tu_1. Output: %s", got, out)
+	}
+}

--- a/internal/translator/gemini-cli/gemini/gemini-cli_gemini_request.go
+++ b/internal/translator/gemini-cli/gemini/gemini-cli_gemini_request.go
@@ -127,6 +127,73 @@ type FunctionCallGroup struct {
 }
 
 // backfillFunctionResponseName ensures that a functionResponse JSON object has a non-empty name,
+func normalizeInlineDataPart(part gjson.Result) ([]byte, bool) {
+	inline := part.Get("inlineData")
+	if !inline.Exists() {
+		inline = part.Get("inline_data")
+	}
+	if !inline.Exists() {
+		return nil, false
+	}
+	data := inline.Get("data").String()
+	if data == "" {
+		return nil, false
+	}
+	mimeType := inline.Get("mimeType").String()
+	if mimeType == "" {
+		mimeType = inline.Get("mime_type").String()
+	}
+	if mimeType == "" {
+		mimeType = "image/png"
+	}
+	out := []byte(`{"inlineData":{"mimeType":"","data":""}}`)
+	out, _ = sjson.SetBytes(out, "inlineData.mimeType", mimeType)
+	out, _ = sjson.SetBytes(out, "inlineData.data", data)
+	return out, true
+}
+
+func attachInlineDataToFunctionResponse(response gjson.Result, images [][]byte) gjson.Result {
+	if len(images) == 0 {
+		return response
+	}
+	target := []byte(response.Raw)
+	for _, img := range images {
+		target, _ = sjson.SetRawBytes(target, "functionResponse.parts.-1", img)
+	}
+	return gjson.ParseBytes(target)
+}
+
+// collectFunctionResponsesWithSiblingInlineData keeps functionResponse parts and
+// moves sibling inline_data/inlineData onto the nearest preceding functionResponse.
+// Leading images before the first functionResponse attach to that first response.
+func collectFunctionResponsesWithSiblingInlineData(parts gjson.Result) []gjson.Result {
+	responses := make([]gjson.Result, 0)
+	leadingImages := make([][]byte, 0)
+	current := -1
+	parts.ForEach(func(_, part gjson.Result) bool {
+		if part.Get("functionResponse").Exists() {
+			responses = append(responses, part)
+			current = len(responses) - 1
+			if len(leadingImages) > 0 {
+				responses[current] = attachInlineDataToFunctionResponse(responses[current], leadingImages)
+				leadingImages = nil
+			}
+			return true
+		}
+		imagePart, ok := normalizeInlineDataPart(part)
+		if !ok {
+			return true
+		}
+		if current >= 0 {
+			responses[current] = attachInlineDataToFunctionResponse(responses[current], [][]byte{imagePart})
+			return true
+		}
+		leadingImages = append(leadingImages, imagePart)
+		return true
+	})
+	return responses
+}
+
 // falling back to fallbackName if the original is empty.
 func backfillFunctionResponseName(raw string, fallbackName string) string {
 	name := gjson.Get(raw, "functionResponse.name").String()
@@ -171,14 +238,8 @@ func fixCLIToolResponse(input string) (string, error) {
 		role := value.Get("role").String()
 		parts := value.Get("parts")
 
-		// Check if this content has function responses
-		var responsePartsInThisContent []gjson.Result
-		parts.ForEach(func(_, part gjson.Result) bool {
-			if part.Get("functionResponse").Exists() {
-				responsePartsInThisContent = append(responsePartsInThisContent, part)
-			}
-			return true
-		})
+		// Collect function responses and attach sibling inlineData to the nearest one.
+		responsePartsInThisContent := collectFunctionResponsesWithSiblingInlineData(parts)
 
 		// If this content has function responses, collect them
 		if len(responsePartsInThisContent) > 0 {

--- a/internal/translator/gemini-cli/gemini/gemini-cli_gemini_request.go
+++ b/internal/translator/gemini-cli/gemini/gemini-cli_gemini_request.go
@@ -126,7 +126,8 @@ type FunctionCallGroup struct {
 	CallNames       []string // ordered function call names for backfilling empty response names
 }
 
-// backfillFunctionResponseName ensures that a functionResponse JSON object has a non-empty name,
+// normalizeInlineDataPart extracts inline image data from a part, normalizing
+// snake_case and camelCase keys and defaulting the mime type to image/png.
 func normalizeInlineDataPart(part gjson.Result) ([]byte, bool) {
 	inline := part.Get("inlineData")
 	if !inline.Exists() {
@@ -152,6 +153,7 @@ func normalizeInlineDataPart(part gjson.Result) ([]byte, bool) {
 	return out, true
 }
 
+// attachInlineDataToFunctionResponse appends inline image parts to a functionResponse.
 func attachInlineDataToFunctionResponse(response gjson.Result, images [][]byte) gjson.Result {
 	if len(images) == 0 {
 		return response
@@ -194,6 +196,7 @@ func collectFunctionResponsesWithSiblingInlineData(parts gjson.Result) []gjson.R
 	return responses
 }
 
+// backfillFunctionResponseName ensures that a functionResponse JSON object has a non-empty name,
 // falling back to fallbackName if the original is empty.
 func backfillFunctionResponseName(raw string, fallbackName string) string {
 	name := gjson.Get(raw, "functionResponse.name").String()

--- a/internal/translator/gemini-cli/gemini/gemini-cli_gemini_request_test.go
+++ b/internal/translator/gemini-cli/gemini/gemini-cli_gemini_request_test.go
@@ -89,6 +89,45 @@ func TestConvertGeminiRequestToGeminiCLI_ToolCallAndResponse(t *testing.T) {
 	}
 }
 
+func TestConvertGeminiRequestToGeminiCLI_PreservesSiblingToolImage(t *testing.T) {
+	input := []byte(`{
+		"model": "gemini-3-flash",
+		"contents": [
+			{"role": "model", "parts": [{"functionCall": {"name": "read", "args": {"path": "/tmp"}, "id": "call_1"}}]},
+			{"role": "user", "parts": [
+				{"functionResponse": {"name": "read", "response": {"result": "Read image file [image/png]"}, "id": "call_1"}},
+				{"inline_data": {"mime_type": "image/png", "data": "QUJD"}}
+			]}
+		]
+	}`)
+
+	out := ConvertGeminiRequestToGeminiCLI("gemini-3-flash", input, false)
+	contents := gjson.GetBytes(out, "request.contents").Array()
+	if len(contents) != 2 {
+		t.Fatalf("contents length = %d, want 2. Output: %s", len(contents), out)
+	}
+	funcResp := contents[1].Get("parts.0.functionResponse")
+	if !funcResp.Exists() {
+		t.Fatalf("functionResponse missing. Output: %s", out)
+	}
+	if got := funcResp.Get("id").String(); got != "call_1" {
+		t.Fatalf("id = %q, want call_1. Output: %s", got, out)
+	}
+	inlineData := funcResp.Get("parts.0.inlineData")
+	if !inlineData.Exists() {
+		t.Fatalf("functionResponse.parts.0.inlineData missing. Output: %s", out)
+	}
+	if got := inlineData.Get("mimeType").String(); got != "image/png" {
+		t.Fatalf("mimeType = %q, want image/png. Output: %s", got, out)
+	}
+	if got := inlineData.Get("data").String(); got != "QUJD" {
+		t.Fatalf("data = %q, want QUJD. Output: %s", got, out)
+	}
+	if contents[1].Get("parts.1.inline_data").Exists() || contents[1].Get("parts.1.inlineData").Exists() {
+		t.Fatalf("sibling inline data should be absorbed into functionResponse.parts. Output: %s", out)
+	}
+}
+
 func TestConvertGeminiCliResponseToGemini_Stream(t *testing.T) {
 	ctx := context.WithValue(context.Background(), "alt", "")
 	resp := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hi"}]}}],"usageMetadata":{"totalTokenCount":5}}}`)

--- a/internal/translator/gemini-cli/gemini/gemini-cli_gemini_request_test.go
+++ b/internal/translator/gemini-cli/gemini/gemini-cli_gemini_request_test.go
@@ -1,0 +1,113 @@
+package gemini
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertGeminiRequestToGeminiCLI_HappyPath(t *testing.T) {
+	input := []byte(`{
+		"model": "gemini-3-flash",
+		"contents": [
+			{"role": "user", "parts": [{"text": "hello"}]}
+		]
+	}`)
+
+	out := ConvertGeminiRequestToGeminiCLI("gemini-3-flash", input, false)
+	if got := gjson.GetBytes(out, "project").String(); got != "" {
+		t.Fatalf("project = %q, want empty. Output: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "model").String(); got != "gemini-3-flash" {
+		t.Fatalf("model = %q, want gemini-3-flash. Output: %s", got, out)
+	}
+	contents := gjson.GetBytes(out, "request.contents").Array()
+	if len(contents) != 1 {
+		t.Fatalf("contents length = %d, want 1. Output: %s", len(contents), out)
+	}
+	if got := contents[0].Get("role").String(); got != "user" {
+		t.Fatalf("content role = %q, want user. Output: %s", got, out)
+	}
+	if got := contents[0].Get("parts.0.text").String(); got != "hello" {
+		t.Fatalf("content text = %q, want hello. Output: %s", got, out)
+	}
+	if !gjson.GetBytes(out, "request.safetySettings").Exists() {
+		t.Fatalf("safetySettings missing. Output: %s", out)
+	}
+}
+
+func TestConvertGeminiRequestToGeminiCLI_Tools(t *testing.T) {
+	input := []byte(`{
+		"model": "gemini-3-flash",
+		"contents": [{"role": "user", "parts": [{"text": "hello"}]}],
+		"tools": [
+			{
+				"function_declarations": [
+					{
+						"name": "read",
+						"parameters": {"type": "object", "properties": {"path": {"type": "string"}}}
+					}
+				]
+			}
+		]
+	}`)
+
+	out := ConvertGeminiRequestToGeminiCLI("gemini-3-flash", input, false)
+	if got := gjson.GetBytes(out, "request.tools.0.function_declarations.0.name").String(); got != "read" {
+		t.Fatalf("tool name = %q, want read. Output: %s", got, out)
+	}
+	if !gjson.GetBytes(out, "request.tools.0.function_declarations.0.parametersJsonSchema").Exists() {
+		t.Fatalf("parametersJsonSchema missing. Output: %s", out)
+	}
+}
+
+func TestConvertGeminiRequestToGeminiCLI_ToolCallAndResponse(t *testing.T) {
+	input := []byte(`{
+		"model": "gemini-3-flash",
+		"contents": [
+			{"role": "model", "parts": [{"functionCall": {"name": "read", "args": {"path": "/tmp"}, "id": "call_1"}}]},
+			{"role": "user", "parts": [
+				{"functionResponse": {"name": "read", "response": {"result": "ok"}, "id": "call_1"}}
+			]}
+		]
+	}`)
+
+	out := ConvertGeminiRequestToGeminiCLI("gemini-3-flash", input, false)
+	contents := gjson.GetBytes(out, "request.contents").Array()
+	if len(contents) != 2 {
+		t.Fatalf("contents length = %d, want 2. Output: %s", len(contents), out)
+	}
+	if got := contents[1].Get("role").String(); got != "user" {
+		t.Fatalf("response content role = %q, want user. Output: %s", got, out)
+	}
+	if got := contents[1].Get("parts.0.functionResponse.name").String(); got != "read" {
+		t.Fatalf("functionResponse name = %q, want read. Output: %s", got, out)
+	}
+	if got := contents[1].Get("parts.0.functionResponse.id").String(); got != "call_1" {
+		t.Fatalf("functionResponse id = %q, want call_1. Output: %s", got, out)
+	}
+}
+
+func TestConvertGeminiCliResponseToGemini_Stream(t *testing.T) {
+	ctx := context.WithValue(context.Background(), "alt", "")
+	resp := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hi"}]}}],"usageMetadata":{"totalTokenCount":5}}}`)
+	out := ConvertGeminiCliResponseToGemini(ctx, "gemini-3-flash", nil, nil, resp, nil)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 output, got %d", len(out))
+	}
+	if got := gjson.GetBytes(out[0], "candidates.0.content.parts.0.text").String(); got != "Hi" {
+		t.Fatalf("text = %q, want Hi. Output: %s", got, out[0])
+	}
+}
+
+func TestConvertGeminiCliResponseToGemini_NonStream(t *testing.T) {
+	resp := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hi"}]}}],"usageMetadata":{"totalTokenCount":5}}}`)
+	out := ConvertGeminiCliResponseToGeminiNonStream(context.Background(), "gemini-3-flash", nil, nil, resp, nil)
+	if got := gjson.GetBytes(out, "candidates.0.content.parts.0.text").String(); got != "Hi" {
+		t.Fatalf("text = %q, want Hi. Output: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "usageMetadata.totalTokenCount").Int(); got != 5 {
+		t.Fatalf("totalTokenCount = %d, want 5. Output: %s", got, out)
+	}
+}

--- a/internal/translator/gemini-cli/openai/responses/gemini-cli_openai-responses_request_test.go
+++ b/internal/translator/gemini-cli/openai/responses/gemini-cli_openai-responses_request_test.go
@@ -1,0 +1,94 @@
+package responses
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertOpenAIResponsesRequestToGeminiCLI_HappyPath(t *testing.T) {
+	input := []byte(`{
+		"model": "gemini-3-flash",
+		"input": [
+			{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToGeminiCLI("gemini-3-flash", input, false)
+	if !gjson.GetBytes(out, "request.contents").Exists() {
+		t.Fatalf("request.contents missing. Output: %s", out)
+	}
+	contents := gjson.GetBytes(out, "request.contents").Array()
+	if len(contents) != 1 {
+		t.Fatalf("contents length = %d, want 1. Output: %s", len(contents), out)
+	}
+	if got := contents[0].Get("role").String(); got != "user" {
+		t.Fatalf("content role = %q, want user. Output: %s", got, out)
+	}
+	if got := contents[0].Get("parts.0.text").String(); got != "hello" {
+		t.Fatalf("content text = %q, want hello. Output: %s", got, out)
+	}
+	if !gjson.GetBytes(out, "request.safetySettings").Exists() {
+		t.Fatalf("safetySettings missing. Output: %s", out)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToGeminiCLI_ToolCallAndOutput(t *testing.T) {
+	input := []byte(`{
+		"model": "gemini-3-flash",
+		"input": [
+			{"role": "user", "content": [{"type": "input_text", "text": "read"}]},
+			{"type": "function_call", "call_id": "call_1", "name": "read", "arguments": "{\"path\":\"/tmp\"}"},
+			{"type": "function_call_output", "call_id": "call_1", "output": "ok"}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToGeminiCLI("gemini-3-flash", input, false)
+	contents := gjson.GetBytes(out, "request.contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("contents length = %d, want 3. Output: %s", len(contents), out)
+	}
+	if got := contents[1].Get("role").String(); got != "model" {
+		t.Fatalf("function call content role = %q, want model. Output: %s", got, out)
+	}
+	if got := contents[1].Get("parts.0.functionCall.name").String(); got != "read" {
+		t.Fatalf("functionCall name = %q, want read. Output: %s", got, out)
+	}
+	if got := contents[2].Get("role").String(); got != "user" {
+		t.Fatalf("function response content role = %q, want user. Output: %s", got, out)
+	}
+	if got := contents[2].Get("parts.0.functionResponse.name").String(); got != "read" {
+		t.Fatalf("functionResponse name = %q, want read. Output: %s", got, out)
+	}
+}
+
+func TestConvertGeminiCLIResponseToOpenAIResponses_NonStream(t *testing.T) {
+	resp := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hi"}]}}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":2,"totalTokenCount":3}}}`)
+	out := ConvertGeminiCLIResponseToOpenAIResponsesNonStream(context.Background(), "gemini-3-flash", nil, nil, resp, nil)
+	if got := gjson.GetBytes(out, "status").String(); got != "completed" {
+		t.Fatalf("status = %q, want completed. Output: %s", got, out)
+	}
+	output := gjson.GetBytes(out, "output").Array()
+	if len(output) == 0 {
+		t.Fatalf("expected non-empty output. Output: %s", out)
+	}
+	if got := output[0].Get("content.0.text").String(); got != "Hi" {
+		t.Fatalf("output text = %q, want Hi. Output: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "usage.total_tokens").Int(); got != 3 {
+		t.Fatalf("total_tokens = %d, want 3. Output: %s", got, out)
+	}
+}
+
+func TestConvertGeminiCLIResponseToOpenAIResponses_Stream(t *testing.T) {
+	chunk := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hi"}]}}],"usageMetadata":{"totalTokenCount":3}}}`)
+	var param any
+	out := ConvertGeminiCLIResponseToOpenAIResponses(context.Background(), "gemini-3-flash", nil, nil, chunk, &param)
+	if len(out) == 0 {
+		t.Fatalf("expected non-empty stream output")
+	}
+	if got := gjson.GetBytes(out[0], "type").String(); got == "" {
+		t.Fatalf("event type missing. Output: %s", out[0])
+	}
+}

--- a/internal/translator/gemini/gemini-cli/gemini_gemini-cli_request_test.go
+++ b/internal/translator/gemini/gemini-cli/gemini_gemini-cli_request_test.go
@@ -1,0 +1,108 @@
+package geminiCLI
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertGeminiCLIRequestToGemini_HappyPath(t *testing.T) {
+	input := []byte(`{
+		"model": "gemini-3-flash",
+		"request": {
+			"contents": [
+				{"role": "user", "parts": [{"text": "hello"}]}
+			]
+		}
+	}`)
+
+	out := ConvertGeminiCLIRequestToGemini("gemini-3-flash", input, false)
+	if got := gjson.GetBytes(out, "model").String(); got != "gemini-3-flash" {
+		t.Fatalf("model = %q, want gemini-3-flash. Output: %s", got, out)
+	}
+	contents := gjson.GetBytes(out, "contents").Array()
+	if len(contents) != 1 {
+		t.Fatalf("contents length = %d, want 1. Output: %s", len(contents), out)
+	}
+	if got := contents[0].Get("role").String(); got != "user" {
+		t.Fatalf("content role = %q, want user. Output: %s", got, out)
+	}
+	if got := contents[0].Get("parts.0.text").String(); got != "hello" {
+		t.Fatalf("content text = %q, want hello. Output: %s", got, out)
+	}
+	if !gjson.GetBytes(out, "safetySettings").Exists() {
+		t.Fatalf("safetySettings missing. Output: %s", out)
+	}
+}
+
+func TestConvertGeminiCLIRequestToGemini_SystemInstruction(t *testing.T) {
+	input := []byte(`{
+		"model": "gemini-3-flash",
+		"request": {
+			"systemInstruction": {"parts": [{"text": "sys"}]},
+			"contents": [{"role": "user", "parts": [{"text": "hello"}]}]
+		}
+	}`)
+
+	out := ConvertGeminiCLIRequestToGemini("gemini-3-flash", input, false)
+	if got := gjson.GetBytes(out, "system_instruction.parts.0.text").String(); got != "sys" {
+		t.Fatalf("system_instruction text = %q, want sys. Output: %s", got, out)
+	}
+	if gjson.GetBytes(out, "systemInstruction").Exists() {
+		t.Fatalf("systemInstruction should be renamed. Output: %s", out)
+	}
+}
+
+func TestConvertGeminiCLIRequestToGemini_Tools(t *testing.T) {
+	input := []byte(`{
+		"model": "gemini-3-flash",
+		"request": {
+			"contents": [{"role": "user", "parts": [{"text": "hello"}]}],
+			"tools": [
+				{
+					"function_declarations": [
+						{
+							"name": "read",
+							"parameters": {"type": "object", "properties": {"path": {"type": "string"}}}
+						}
+					]
+				}
+			]
+		}
+	}`)
+
+	out := ConvertGeminiCLIRequestToGemini("gemini-3-flash", input, false)
+	if got := gjson.GetBytes(out, "tools.0.function_declarations.0.name").String(); got != "read" {
+		t.Fatalf("tool name = %q, want read. Output: %s", got, out)
+	}
+	if !gjson.GetBytes(out, "tools.0.function_declarations.0.parametersJsonSchema").Exists() {
+		t.Fatalf("parametersJsonSchema missing. Output: %s", out)
+	}
+}
+
+func TestConvertGeminiResponseToGeminiCLI_Stream(t *testing.T) {
+	chunk := []byte(`data:{"candidates":[{"content":{"role":"model","parts":[{"text":"Hi"}]}}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":2,"totalTokenCount":3}}`)
+	var param any
+	out := ConvertGeminiResponseToGeminiCLI(context.Background(), "gemini-3-flash", nil, nil, chunk, &param)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 output, got %d", len(out))
+	}
+	if got := gjson.GetBytes(out[0], "response.candidates.0.content.parts.0.text").String(); got != "Hi" {
+		t.Fatalf("text = %q, want Hi. Output: %s", got, out[0])
+	}
+	if got := gjson.GetBytes(out[0], "response.usageMetadata.totalTokenCount").Int(); got != 3 {
+		t.Fatalf("totalTokenCount = %d, want 3. Output: %s", got, out[0])
+	}
+}
+
+func TestConvertGeminiResponseToGeminiCLI_NonStream(t *testing.T) {
+	resp := []byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"Hi"}]}}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":2,"totalTokenCount":3}}`)
+	out := ConvertGeminiResponseToGeminiCLINonStream(context.Background(), "gemini-3-flash", nil, nil, resp, nil)
+	if got := gjson.GetBytes(out, "response.candidates.0.content.parts.0.text").String(); got != "Hi" {
+		t.Fatalf("text = %q, want Hi. Output: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "response.usageMetadata.totalTokenCount").Int(); got != 3 {
+		t.Fatalf("totalTokenCount = %d, want 3. Output: %s", got, out)
+	}
+}

--- a/internal/translator/openai/gemini-cli/openai_gemini_request_test.go
+++ b/internal/translator/openai/gemini-cli/openai_gemini_request_test.go
@@ -1,0 +1,137 @@
+package geminiCLI
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertGeminiCLIRequestToOpenAI_HappyPath(t *testing.T) {
+	input := []byte(`{
+		"model": "gpt-5.4",
+		"request": {
+			"contents": [
+				{"role": "user", "parts": [{"text": "hello"}]}
+			]
+		}
+	}`)
+
+	out := ConvertGeminiCLIRequestToOpenAI("gpt-5.4", input, false)
+	if got := gjson.GetBytes(out, "model").String(); got != "gpt-5.4" {
+		t.Fatalf("model = %q, want gpt-5.4. Output: %s", got, out)
+	}
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 1 {
+		t.Fatalf("messages length = %d, want 1. Output: %s", len(messages), out)
+	}
+	if got := messages[0].Get("role").String(); got != "user" {
+		t.Fatalf("message role = %q, want user. Output: %s", got, out)
+	}
+	if got := messages[0].Get("content").String(); got != "hello" {
+		t.Fatalf("message content = %q, want hello. Output: %s", got, out)
+	}
+}
+
+func TestConvertGeminiCLIRequestToOpenAI_SystemInstruction(t *testing.T) {
+	input := []byte(`{
+		"model": "gpt-5.4",
+		"request": {
+			"systemInstruction": {"parts": [{"text": "sys"}]},
+			"contents": [{"role": "user", "parts": [{"text": "hello"}]}]
+		}
+	}`)
+
+	out := ConvertGeminiCLIRequestToOpenAI("gpt-5.4", input, false)
+	if got := gjson.GetBytes(out, "messages.0.role").String(); got != "system" {
+		t.Fatalf("first message role = %q, want system. Output: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.text").String(); got != "sys" {
+		t.Fatalf("system content = %q, want sys. Output: %s", got, out)
+	}
+}
+
+func TestConvertGeminiCLIRequestToOpenAI_Tools(t *testing.T) {
+	input := []byte(`{
+		"model": "gpt-5.4",
+		"request": {
+			"contents": [{"role": "user", "parts": [{"text": "hello"}]}],
+			"tools": [
+				{
+					"functionDeclarations": [
+						{
+							"name": "read",
+							"parameters": {"type": "object", "properties": {"path": {"type": "string"}}}
+						}
+					]
+				}
+			]
+		}
+	}`)
+
+	out := ConvertGeminiCLIRequestToOpenAI("gpt-5.4", input, false)
+	tools := gjson.GetBytes(out, "tools").Array()
+	if len(tools) != 1 {
+		t.Fatalf("tools length = %d, want 1. Output: %s", len(tools), out)
+	}
+	if got := tools[0].Get("type").String(); got != "function" {
+		t.Fatalf("tool type = %q, want function. Output: %s", got, out)
+	}
+	if got := tools[0].Get("function.name").String(); got != "read" {
+		t.Fatalf("tool name = %q, want read. Output: %s", got, out)
+	}
+}
+
+func TestConvertGeminiCLIRequestToOpenAI_ToolCallAndResponse(t *testing.T) {
+	input := []byte(`{
+		"model": "gpt-5.4",
+		"request": {
+			"contents": [
+				{"role": "model", "parts": [{"functionCall": {"name": "lookup", "args": {"q": "x"}, "id": "call_1"}}]},
+				{"role": "user", "parts": [{"functionResponse": {"name": "lookup", "response": {"result": "ok"}, "id": "call_1"}}]}
+			]
+		}
+	}`)
+
+	out := ConvertGeminiCLIRequestToOpenAI("gpt-5.4", input, false)
+	toolCallID := gjson.GetBytes(out, "messages.0.tool_calls.0.id").String()
+	if toolCallID == "" {
+		t.Fatalf("tool call id missing. Output: %s", out)
+	}
+	if got := gjson.GetBytes(out, "messages.1.tool_call_id").String(); got != toolCallID {
+		t.Fatalf("tool response id = %q, want %q. Output: %s", got, toolCallID, out)
+	}
+	content := gjson.GetBytes(out, "messages.1.content").String()
+	if !strings.Contains(content, "ok") {
+		t.Fatalf("tool response content = %q, want ok. Output: %s", content, out)
+	}
+}
+
+func TestConvertOpenAIResponseToGeminiCLI_NonStream(t *testing.T) {
+	resp := []byte(`{"choices":[{"index":0,"message":{"role":"assistant","content":"Hi"}}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`)
+	out := ConvertOpenAIResponseToGeminiCLINonStream(context.Background(), "gemini-3-flash", nil, nil, resp, nil)
+	if got := gjson.GetBytes(out, "response.candidates.0.content.parts.0.text").String(); got != "Hi" {
+		t.Fatalf("text = %q, want Hi. Output: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "response.usageMetadata.promptTokenCount").Int(); got != 1 {
+		t.Fatalf("promptTokenCount = %d, want 1. Output: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "response.usageMetadata.candidatesTokenCount").Int(); got != 2 {
+		t.Fatalf("candidatesTokenCount = %d, want 2. Output: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "response.usageMetadata.totalTokenCount").Int(); got != 3 {
+		t.Fatalf("totalTokenCount = %d, want 3. Output: %s", got, out)
+	}
+}
+
+func TestConvertOpenAIResponseToGeminiCLI_ToolCall(t *testing.T) {
+	resp := []byte(`{"choices":[{"index":0,"message":{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{\"q\":\"x\"}"}}]}}]}`)
+	out := ConvertOpenAIResponseToGeminiCLINonStream(context.Background(), "gemini-3-flash", nil, nil, resp, nil)
+	if got := gjson.GetBytes(out, "response.candidates.0.content.parts.0.functionCall.name").String(); got != "lookup" {
+		t.Fatalf("functionCall name = %q, want lookup. Output: %s", got, out)
+	}
+	if got := gjson.GetBytes(out, "response.candidates.0.content.parts.0.functionCall.id").String(); got != "call_1" {
+		t.Fatalf("functionCall id = %q, want call_1. Output: %s", got, out)
+	}
+}


### PR DESCRIPTION
## Summary
- Restore `collectFunctionResponsesWithSiblingInlineData` in `antigravity/gemini` so inline image attachments that follow tool results are preserved and attached to the nearest `functionResponse`.
- Port image-preservation tests for antigravity Gemini and OpenAI Responses translators.
- Add unit tests for the GeminiCLI translator paths (`claude/gemini-cli`, `gemini/gemini-cli`, `gemini-cli/gemini`, `gemini-cli/openai/responses`, `openai/gemini-cli`) covering happy path, system instructions, tools, tool calls/responses, and usage fields.
- Fix `gemini-cli/gemini` `fixCLIToolResponse` to also collect sibling `inlineData`/`inline_data` parts and attach them to the nearest `functionResponse`.
- Restructure `antigravity/gemini` sibling image test to use explicit `modelCalls` and `extraChecks` table fields instead of name-keyed assertions.
- Fix misplaced doc comments in `gemini-cli/gemini` helpers.

## Verification
- `go test ./...` passes.
- `go build -o test-output ./cmd/server && rm test-output` succeeds.
- `gofmt -w .` applied.

## Claim
This PR is opened by @warelik and is ready for review.