### PR TITLE
fix(executor): deterministic cache-miss user_id fallback

### DIFF
--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -91,17 +91,19 @@ func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (cloakMode string, strictMo
 }
 
 // injectFakeUserID generates and injects a fake user ID into the request metadata.
-// When useCache is false, a new user ID is generated for every call.
-func injectFakeUserID(ctx context.Context, payload []byte, apiKey string, useCache bool) ([]byte, error) {
+// When useCache is true, the user ID is cached and stable per credential.
+// When useCache is false, the device_id is fresh per request while the session_id
+// stays stable, preserving header/body session alignment.
+func injectFakeUserID(ctx context.Context, payload []byte, auth *cliproxyauth.Auth, apiKey string, useCache bool) ([]byte, error) {
 	generateID := func() (string, error) {
-		if useCache {
-			return helps.CachedUserIDRequired(ctx, apiKey)
-		}
-		sessionID, errSessionID := helps.CachedSessionIDRequired(ctx, apiKey)
+		sessionID, errSessionID := helps.CachedSessionIDRequired(ctx, apiKey, auth)
 		if errSessionID != nil {
 			return "", errSessionID
 		}
-		return helps.GenerateFakeUserIDWithSessionID(sessionID), nil
+		if useCache {
+			return helps.CachedUserIDRequired(ctx, apiKey, auth)
+		}
+		return helps.GenerateRandomFakeUserIDForSession(sessionID), nil
 	}
 
 	metadata := gjson.GetBytes(payload, "metadata")
@@ -1033,7 +1035,7 @@ func applyCloaking(
 	// Other non-OAuth cloaking keeps the legacy per-request fake user_id.
 	if !policy.ProfileClaudeCodeCLI {
 		var errFakeUserID error
-		payload, errFakeUserID = injectFakeUserID(ctx, payload, apiKey, settings.cacheUserID)
+		payload, errFakeUserID = injectFakeUserID(ctx, payload, auth, apiKey, settings.cacheUserID)
 		if errFakeUserID != nil {
 			return nil, false, errFakeUserID
 		}

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -874,7 +874,7 @@ func applyClaudeHeadersWithNativeProfile(
 		r.Header.Set("X-Claude-Code-Session-Id", sessionID)
 	} else {
 		var errSessionID error
-		sessionID, errSessionID = helps.CachedSessionIDRequired(r.Context(), apiKey)
+		sessionID, errSessionID = helps.CachedSessionIDRequired(r.Context(), apiKey, auth)
 		if errSessionID != nil {
 			return errSessionID
 		}

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -6452,3 +6452,140 @@ func TestClaudeExecutor_CacheTTLIsPairedWithExtendedCacheTTLBeta(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyCloaking_DeterministicUserID(t *testing.T) {
+	cfg := &config.Config{}
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-123", "cloak_mode": "always", "cloak_cache_user_id": "true"}}
+	payload := []byte(`{"model":"claude-opus-5","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`)
+
+	first, cloaked, err := applyCloaking(context.Background(), cfg, auth, payload, "key-123", false, false)
+	if err != nil {
+		t.Fatalf("applyCloaking() error = %v", err)
+	}
+	if !cloaked {
+		t.Fatal("applyCloaking() cloaked = false, want true")
+	}
+
+	second, cloaked2, err2 := applyCloaking(context.Background(), cfg, auth, payload, "key-123", false, false)
+	if err2 != nil {
+		t.Fatalf("applyCloaking() second error = %v", err2)
+	}
+	if !cloaked2 {
+		t.Fatal("applyCloaking() second cloaked = false, want true")
+	}
+
+	userID1 := gjson.GetBytes(first, "metadata.user_id").String()
+	userID2 := gjson.GetBytes(second, "metadata.user_id").String()
+	if userID1 == "" {
+		t.Fatal("metadata.user_id is empty")
+	}
+	if userID1 != userID2 {
+		t.Fatalf("same conversation produced different metadata.user_id: %q vs %q", userID1, userID2)
+	}
+
+	// Different credentials must produce different user IDs.
+	auth2 := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-456", "cloak_mode": "always", "cloak_cache_user_id": "true"}}
+	third, _, _ := applyCloaking(context.Background(), cfg, auth2, payload, "key-456", false, false)
+	userID3 := gjson.GetBytes(third, "metadata.user_id").String()
+	if userID1 == userID3 {
+		t.Fatalf("different api keys produced same metadata.user_id: %q", userID1)
+	}
+
+	// Caller-supplied metadata.user_id is preserved.
+	callerUserID := `{"device_id":"0000000000000000000000000000000000000000000000000000000000000000","session_id":"11111111-2222-4333-8444-555555555555"}`
+	payloadWithUser, _ := sjson.SetBytes(payload, "metadata.user_id", callerUserID)
+	fourth, _, err4 := applyCloaking(context.Background(), cfg, auth, payloadWithUser, "key-123", false, false)
+	if err4 != nil {
+		t.Fatalf("applyCloaking() caller user_id error = %v", err4)
+	}
+	if got := gjson.GetBytes(fourth, "metadata.user_id").String(); got != callerUserID {
+		t.Fatalf("caller-supplied metadata.user_id not preserved, got %q want %q", got, callerUserID)
+	}
+}
+
+func TestApplyCloaking_NonCachedUserIDIsRandom(t *testing.T) {
+	cfg := &config.Config{}
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-123", "cloak_mode": "always"}}
+	payload := []byte(`{"model":"claude-opus-5","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`)
+
+	first, cloaked, err := applyCloaking(context.Background(), cfg, auth, payload, "key-123", false, false)
+	if err != nil {
+		t.Fatalf("applyCloaking() error = %v", err)
+	}
+	if !cloaked {
+		t.Fatal("applyCloaking() cloaked = false, want true")
+	}
+
+	second, cloaked2, err2 := applyCloaking(context.Background(), cfg, auth, payload, "key-123", false, false)
+	if err2 != nil {
+		t.Fatalf("applyCloaking() second error = %v", err2)
+	}
+	if !cloaked2 {
+		t.Fatal("applyCloaking() second cloaked = false, want true")
+	}
+
+	userID1 := gjson.GetBytes(first, "metadata.user_id").String()
+	userID2 := gjson.GetBytes(second, "metadata.user_id").String()
+	if userID1 == "" || userID2 == "" {
+		t.Fatal("metadata.user_id is empty")
+	}
+	if !helps.IsValidUserID(userID1) || !helps.IsValidUserID(userID2) {
+		t.Fatalf("metadata.user_id is not valid: %q, %q", userID1, userID2)
+	}
+	if userID1 == userID2 {
+		t.Fatalf("cache-user-id:false produced the same metadata.user_id on two calls: %q", userID1)
+	}
+}
+
+func TestInjectFakeUserID_CacheEnabledIsDeterministic(t *testing.T) {
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-cache-enabled"}}
+	payload := []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
+	first, errFirst := injectFakeUserID(context.Background(), payload, auth, "key-cache-enabled", true)
+	if errFirst != nil {
+		t.Fatalf("first injectFakeUserID error: %v", errFirst)
+	}
+	second, errSecond := injectFakeUserID(context.Background(), payload, auth, "key-cache-enabled", true)
+	if errSecond != nil {
+		t.Fatalf("second injectFakeUserID error: %v", errSecond)
+	}
+
+	firstID := gjson.GetBytes(first, "metadata.user_id").String()
+	secondID := gjson.GetBytes(second, "metadata.user_id").String()
+	if firstID == "" || secondID == "" {
+		t.Fatalf("user_id not injected: first=%q second=%q", firstID, secondID)
+	}
+	if firstID != secondID {
+		t.Fatalf("cache-user-id:true must produce a stable user_id, got %q and %q", firstID, secondID)
+	}
+}
+
+func TestInjectFakeUserID_CacheDisabledIsRandomPerRequest(t *testing.T) {
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-cache-disabled"}}
+	payload := []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
+	first, errFirst := injectFakeUserID(context.Background(), payload, auth, "key-cache-disabled", false)
+	if errFirst != nil {
+		t.Fatalf("first injectFakeUserID error: %v", errFirst)
+	}
+	second, errSecond := injectFakeUserID(context.Background(), payload, auth, "key-cache-disabled", false)
+	if errSecond != nil {
+		t.Fatalf("second injectFakeUserID error: %v", errSecond)
+	}
+
+	firstID := gjson.GetBytes(first, "metadata.user_id").String()
+	secondID := gjson.GetBytes(second, "metadata.user_id").String()
+	if firstID == "" || secondID == "" {
+		t.Fatalf("user_id not injected: first=%q second=%q", firstID, secondID)
+	}
+
+	firstDevice := gjson.Get(firstID, "device_id").String()
+	secondDevice := gjson.Get(secondID, "device_id").String()
+	if firstDevice == secondDevice {
+		t.Fatalf("cache-user-id:false must produce a fresh device_id per request, got %q", firstDevice)
+	}
+
+	firstSession := gjson.Get(firstID, "session_id").String()
+	secondSession := gjson.Get(secondID, "session_id").String()
+	if firstSession == "" || firstSession != secondSession {
+		t.Fatalf("cache-user-id:false must keep the stable session_id, got %q vs %q", firstSession, secondSession)
+	}
+}

--- a/internal/runtime/executor/helps/cloak_utils.go
+++ b/internal/runtime/executor/helps/cloak_utils.go
@@ -1,12 +1,13 @@
 package helps
 
 import (
-	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"regexp"
 
 	"github.com/google/uuid"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
 var claudeMetadataDeviceIDPattern = regexp.MustCompile(`^[a-f0-9]{64}$`)
@@ -19,18 +20,31 @@ type claudeMetadataUserID struct {
 
 // generateFakeUserID generates metadata.user_id in the JSON string format used
 // by Claude Code 2.1.78 and newer.
-func generateFakeUserID() string {
-	return generateFakeUserIDWithSessionID(uuid.New().String())
+// The device_id is derived deterministically from the credential seed +
+// session, preserving prompt-cache prefix stability even on cache-miss paths.
+func generateFakeUserID(apiKey string, auth *cliproxyauth.Auth) string {
+	seed := claudeCredentialSeed(apiKey, auth)
+	return generateDeterministicFakeUserID(seed, CachedSessionID(apiKey, auth))
 }
 
 func generateFakeUserIDWithSessionID(sessionID string) string {
+	return generateDeterministicFakeUserID("", sessionID)
+}
+
+// GenerateRandomFakeUserIDForSession returns a metadata.user_id with a fresh
+// random device_id while keeping the session_id stable. This is the legacy
+// per-request random behavior used when cache-user-id is false.
+func GenerateRandomFakeUserIDForSession(sessionID string) string {
+	return generateDeterministicFakeUserID(uuid.New().String(), sessionID)
+}
+
+func generateDeterministicFakeUserID(seed, sessionID string) string {
 	if _, errParse := uuid.Parse(sessionID); errParse != nil {
 		sessionID = uuid.New().String()
 	}
-	hexBytes := make([]byte, 32)
-	_, _ = rand.Read(hexBytes)
+	h := sha256.Sum256([]byte(seed + ":" + sessionID))
 	value, _ := json.Marshal(claudeMetadataUserID{
-		DeviceID:    hex.EncodeToString(hexBytes),
+		DeviceID:    hex.EncodeToString(h[:]),
 		AccountUUID: "",
 		SessionID:   sessionID,
 	})
@@ -57,7 +71,7 @@ func isValidUserID(userID string) bool {
 }
 
 func GenerateFakeUserID() string {
-	return generateFakeUserID()
+	return generateFakeUserID("", nil)
 }
 
 func GenerateFakeUserIDWithSessionID(sessionID string) string {

--- a/internal/runtime/executor/helps/session_id_cache.go
+++ b/internal/runtime/executor/helps/session_id_cache.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	homekv "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
 type sessionIDCacheEntry struct {
@@ -60,31 +61,66 @@ func purgeExpiredSessionIDs() {
 	sessionIDCacheMu.Unlock()
 }
 
-func sessionIDCacheKey(apiKey string) string {
-	sum := sha256.Sum256([]byte(apiKey))
+func claudeCredentialSeed(apiKey string, auth *cliproxyauth.Auth) string {
+	if seed := strings.TrimSpace(apiKey); seed != "" {
+		return seed
+	}
+	if auth != nil {
+		if id := strings.TrimSpace(auth.ID); id != "" {
+			return "auth-id|" + id
+		}
+		if index := strings.TrimSpace(auth.Index); index != "" {
+			return "auth-index|" + index
+		}
+		if fileName := strings.TrimSpace(auth.FileName); fileName != "" {
+			return "auth-file|" + fileName
+		}
+		if label := strings.TrimSpace(auth.Label); label != "" {
+			return "auth-label|" + label
+		}
+		if provider := strings.TrimSpace(auth.Provider); provider != "" {
+			return "auth-provider|" + provider
+		}
+	}
+	return "anonymous"
+}
+
+func sessionIDCacheKey(seed string) string {
+	sum := sha256.Sum256([]byte(seed))
 	return hex.EncodeToString(sum[:])
 }
 
-// CachedSessionID returns a stable session UUID per apiKey, refreshing the TTL on each access.
-func CachedSessionID(apiKey string) string {
-	value, errValue := CachedSessionIDRequired(context.Background(), apiKey)
+// CachedSessionID returns a stable session UUID per credential, refreshing the TTL on each access.
+func CachedSessionID(apiKey string, auth *cliproxyauth.Auth) string {
+	value, errValue := CachedSessionIDRequired(context.Background(), apiKey, auth)
 	if errValue == nil && value != "" {
 		return value
 	}
-	return uuid.New().String()
+	return deterministicSessionID(claudeCredentialSeed(apiKey, auth))
 }
 
-// CachedSessionIDRequired returns a stable session UUID per apiKey for request-time paths.
-func CachedSessionIDRequired(ctx context.Context, apiKey string) (string, error) {
-	if apiKey == "" {
-		return uuid.New().String(), nil
+// deterministicSessionID returns a version-5 UUID derived from the credential
+// seed so different workers and cache misses produce the same session for the
+// same credential. No stable identity falls back to a stable anonymous UUID.
+func deterministicSessionID(seed string) string {
+	if seed == "" || seed == "anonymous" {
+		return uuid.NewSHA1(uuid.NameSpaceURL, []byte("cpa:claude:session:anonymous")).String()
+	}
+	return uuid.NewSHA1(uuid.NameSpaceURL, []byte(seed)).String()
+}
+
+// CachedSessionIDRequired returns a stable session UUID per credential for request-time paths.
+func CachedSessionIDRequired(ctx context.Context, apiKey string, auth *cliproxyauth.Auth) (string, error) {
+	seed := claudeCredentialSeed(apiKey, auth)
+	if seed == "anonymous" {
+		return deterministicSessionID(seed), nil
 	}
 	client, homeMode, errClient := currentClaudeIDKVClient()
 	if homeMode {
 		if errClient != nil {
 			return "", errClient
 		}
-		key := claudeSessionIDKVKey(apiKey)
+		key := claudeSessionIDKVKey(seed)
 		raw, found, errGet := client.KVGet(ctx, key)
 		if errGet != nil {
 			return "", errGet
@@ -95,7 +131,7 @@ func CachedSessionIDRequired(ctx context.Context, apiKey string) (string, error)
 			}
 			return strings.TrimSpace(string(raw)), nil
 		}
-		newID := uuid.New().String()
+		newID := deterministicSessionID(seed)
 		if _, errSet := client.KVSetNX(ctx, key, []byte(newID), sessionIDTTL); errSet != nil {
 			return "", errSet
 		}
@@ -111,7 +147,7 @@ func CachedSessionIDRequired(ctx context.Context, apiKey string) (string, error)
 
 	sessionIDCacheCleanupOnce.Do(startSessionIDCacheCleanup)
 
-	key := sessionIDCacheKey(apiKey)
+	key := sessionIDCacheKey(seed)
 	now := time.Now()
 
 	sessionIDCacheMu.RLock()
@@ -130,7 +166,7 @@ func CachedSessionIDRequired(ctx context.Context, apiKey string) (string, error)
 		sessionIDCacheMu.Unlock()
 	}
 
-	newID := uuid.New().String()
+	newID := deterministicSessionID(seed)
 
 	sessionIDCacheMu.Lock()
 	entry, ok = sessionIDCache[key]
@@ -143,6 +179,6 @@ func CachedSessionIDRequired(ctx context.Context, apiKey string) (string, error)
 	return entry.value, nil
 }
 
-func claudeSessionIDKVKey(apiKey string) string {
-	return "cpa:claude:session-id:" + homekv.HashKeyPart(apiKey)
+func claudeSessionIDKVKey(seed string) string {
+	return "cpa:claude:session-id:" + homekv.HashKeyPart(seed)
 }

--- a/internal/runtime/executor/helps/session_id_cache_test.go
+++ b/internal/runtime/executor/helps/session_id_cache_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
 func resetSessionIDCache() {
@@ -84,12 +85,12 @@ func TestCachedSessionIDRequiredHomeReusesKVAcrossLocalCacheReset(t *testing.T) 
 	client := newFakeClaudeIDKVClient()
 	useFakeClaudeIDKVClient(t, client, true, nil)
 
-	first, errFirst := CachedSessionIDRequired(context.Background(), "api-key-1")
+	first, errFirst := CachedSessionIDRequired(context.Background(), "api-key-1", nil)
 	if errFirst != nil {
 		t.Fatalf("CachedSessionIDRequired() first error = %v", errFirst)
 	}
 	resetSessionIDCache()
-	second, errSecond := CachedSessionIDRequired(context.Background(), "api-key-1")
+	second, errSecond := CachedSessionIDRequired(context.Background(), "api-key-1", nil)
 	if errSecond != nil {
 		t.Fatalf("CachedSessionIDRequired() second error = %v", errSecond)
 	}
@@ -114,7 +115,7 @@ func TestCachedSessionIDRequiredEmptyAPIKeyDoesNotUseHomeKV(t *testing.T) {
 	client := newFakeClaudeIDKVClient()
 	useFakeClaudeIDKVClient(t, client, true, nil)
 
-	value, errValue := CachedSessionIDRequired(context.Background(), "")
+	value, errValue := CachedSessionIDRequired(context.Background(), "", nil)
 	if errValue != nil {
 		t.Fatalf("CachedSessionIDRequired(empty) error = %v", errValue)
 	}
@@ -139,7 +140,7 @@ func TestCachedSessionIDRequiredHomeKVFailures(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			useFakeClaudeIDKVClient(t, tc.client, true, nil)
-			if _, errValue := CachedSessionIDRequired(context.Background(), "api-key-1"); errValue == nil {
+			if _, errValue := CachedSessionIDRequired(context.Background(), "api-key-1", nil); errValue == nil {
 				t.Fatalf("CachedSessionIDRequired() error = nil, want error")
 			}
 		})
@@ -151,7 +152,7 @@ func TestCachedSessionIDRequiredHomeRequiresReadAfterSet(t *testing.T) {
 	client.setNoPersist = true
 	useFakeClaudeIDKVClient(t, client, true, nil)
 
-	if _, errValue := CachedSessionIDRequired(context.Background(), "api-key-1"); errValue == nil {
+	if _, errValue := CachedSessionIDRequired(context.Background(), "api-key-1", nil); errValue == nil {
 		t.Fatalf("CachedSessionIDRequired() error = nil, want missing-after-set error")
 	}
 }
@@ -161,11 +162,11 @@ func TestCachedSessionIDRequiredNonHomeModeUsesLocalMap(t *testing.T) {
 	client := newFakeClaudeIDKVClient()
 	useFakeClaudeIDKVClient(t, client, false, nil)
 
-	first, errFirst := CachedSessionIDRequired(context.Background(), "api-key-1")
+	first, errFirst := CachedSessionIDRequired(context.Background(), "api-key-1", nil)
 	if errFirst != nil {
 		t.Fatalf("CachedSessionIDRequired() first error = %v", errFirst)
 	}
-	second, errSecond := CachedSessionIDRequired(context.Background(), "api-key-1")
+	second, errSecond := CachedSessionIDRequired(context.Background(), "api-key-1", nil)
 	if errSecond != nil {
 		t.Fatalf("CachedSessionIDRequired() second error = %v", errSecond)
 	}
@@ -174,5 +175,33 @@ func TestCachedSessionIDRequiredNonHomeModeUsesLocalMap(t *testing.T) {
 	}
 	if client.getCount != 0 || client.setCount != 0 || client.expireCount != 0 {
 		t.Fatalf("KV calls = get %d set %d expire %d, want all zero", client.getCount, client.setCount, client.expireCount)
+	}
+}
+
+func TestCachedSessionIDRequiredDistinctEmptyAPIKeyCredentials(t *testing.T) {
+	resetSessionIDCache()
+
+	authA := &cliproxyauth.Auth{ID: "custom-header-cred-a"}
+	authB := &cliproxyauth.Auth{ID: "custom-header-cred-b"}
+
+	a, errA := CachedSessionIDRequired(context.Background(), "", authA)
+	if errA != nil {
+		t.Fatalf("CachedSessionIDRequired(authA) error = %v", errA)
+	}
+	b, errB := CachedSessionIDRequired(context.Background(), "", authB)
+	if errB != nil {
+		t.Fatalf("CachedSessionIDRequired(authB) error = %v", errB)
+	}
+	if a == b {
+		t.Fatalf("custom-header-only credentials share the same session id %q", a)
+	}
+
+	// Same credential stays stable.
+	a2, errA2 := CachedSessionIDRequired(context.Background(), "", authA)
+	if errA2 != nil {
+		t.Fatalf("CachedSessionIDRequired(authA) second error = %v", errA2)
+	}
+	if a != a2 {
+		t.Fatalf("same credential got different session ids: %q vs %q", a, a2)
 	}
 }

--- a/internal/runtime/executor/helps/user_id_cache.go
+++ b/internal/runtime/executor/helps/user_id_cache.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	homekv "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
 type userIDCacheEntry struct {
@@ -49,30 +50,31 @@ func purgeExpiredUserIDs() {
 	userIDCacheMu.Unlock()
 }
 
-func userIDCacheKey(apiKey string) string {
-	sum := sha256.Sum256([]byte(apiKey))
+func userIDCacheKey(seed string) string {
+	sum := sha256.Sum256([]byte(seed))
 	return hex.EncodeToString(sum[:])
 }
 
-func CachedUserID(apiKey string) string {
-	value, errValue := CachedUserIDRequired(context.Background(), apiKey)
+func CachedUserID(apiKey string, auth *cliproxyauth.Auth) string {
+	value, errValue := CachedUserIDRequired(context.Background(), apiKey, auth)
 	if errValue == nil && value != "" {
 		return value
 	}
-	return generateFakeUserID()
+	return generateFakeUserID(apiKey, auth)
 }
 
-// CachedUserIDRequired returns a stable fake user ID per apiKey for request-time paths.
-func CachedUserIDRequired(ctx context.Context, apiKey string) (string, error) {
+// CachedUserIDRequired returns a stable fake user ID per credential for request-time paths.
+func CachedUserIDRequired(ctx context.Context, apiKey string, auth *cliproxyauth.Auth) (string, error) {
+	seed := claudeCredentialSeed(apiKey, auth)
 	newUserID := func() (string, error) {
-		sessionID, errSessionID := CachedSessionIDRequired(ctx, apiKey)
+		sessionID, errSessionID := CachedSessionIDRequired(ctx, apiKey, auth)
 		if errSessionID != nil {
 			return "", errSessionID
 		}
-		return generateFakeUserIDWithSessionID(sessionID), nil
+		return generateDeterministicFakeUserID(seed, sessionID), nil
 	}
 
-	if apiKey == "" {
+	if seed == "anonymous" {
 		return newUserID()
 	}
 	client, homeMode, errClient := currentClaudeIDKVClient()
@@ -80,7 +82,7 @@ func CachedUserIDRequired(ctx context.Context, apiKey string) (string, error) {
 		if errClient != nil {
 			return "", errClient
 		}
-		key := claudeUserIDKVKey(apiKey)
+		key := claudeUserIDKVKey(seed)
 		raw, found, errGet := client.KVGet(ctx, key)
 		if errGet != nil {
 			return "", errGet
@@ -110,7 +112,7 @@ func CachedUserIDRequired(ctx context.Context, apiKey string) (string, error) {
 
 	userIDCacheCleanupOnce.Do(startUserIDCacheCleanup)
 
-	key := userIDCacheKey(apiKey)
+	key := userIDCacheKey(seed)
 	now := time.Now()
 
 	userIDCacheMu.RLock()
@@ -145,6 +147,6 @@ func CachedUserIDRequired(ctx context.Context, apiKey string) (string, error) {
 	return entry.value, nil
 }
 
-func claudeUserIDKVKey(apiKey string) string {
-	return "cpa:claude:user-id:" + homekv.HashKeyPart(apiKey)
+func claudeUserIDKVKey(seed string) string {
+	return "cpa:claude:user-id:" + homekv.HashKeyPart(seed)
 }

--- a/internal/runtime/executor/helps/user_id_cache_test.go
+++ b/internal/runtime/executor/helps/user_id_cache_test.go
@@ -33,8 +33,8 @@ func TestCachedUserIDUsesCachedClaudeSessionID(t *testing.T) {
 	resetSessionIDCache()
 
 	const key = "api-key-shared-session"
-	sessionID := CachedSessionID(key)
-	userID := CachedUserID(key)
+	sessionID := CachedSessionID(key, nil)
+	userID := CachedUserID(key, nil)
 	var value claudeMetadataUserID
 	if errUnmarshal := json.Unmarshal([]byte(userID), &value); errUnmarshal != nil {
 		t.Fatalf("unmarshal user ID: %v", errUnmarshal)
@@ -47,8 +47,8 @@ func TestCachedUserIDUsesCachedClaudeSessionID(t *testing.T) {
 func TestCachedUserID_ReusesWithinTTL(t *testing.T) {
 	resetUserIDCache()
 
-	first := CachedUserID("api-key-1")
-	second := CachedUserID("api-key-1")
+	first := CachedUserID("api-key-1", nil)
+	second := CachedUserID("api-key-1", nil)
 
 	if first == "" {
 		t.Fatal("expected generated user_id to be non-empty")
@@ -61,7 +61,7 @@ func TestCachedUserID_ReusesWithinTTL(t *testing.T) {
 func TestCachedUserID_ExpiresAfterTTL(t *testing.T) {
 	resetUserIDCache()
 
-	expiredID := CachedUserID("api-key-expired")
+	expiredID := CachedUserID("api-key-expired", nil)
 	cacheKey := userIDCacheKey("api-key-expired")
 	userIDCacheMu.Lock()
 	userIDCache[cacheKey] = userIDCacheEntry{
@@ -70,20 +70,32 @@ func TestCachedUserID_ExpiresAfterTTL(t *testing.T) {
 	}
 	userIDCacheMu.Unlock()
 
-	newID := CachedUserID("api-key-expired")
-	if newID == expiredID {
-		t.Fatalf("expected expired user_id to be replaced, got %q", newID)
-	}
+	newID := CachedUserID("api-key-expired", nil)
 	if newID == "" {
 		t.Fatal("expected regenerated user_id to be non-empty")
+	}
+	if !IsValidUserID(newID) {
+		t.Fatalf("regenerated user_id %q is not valid", newID)
+	}
+	// The derived user_id is deterministic, so it is the same value with a
+	// refreshed TTL rather than a new random replacement.
+	if newID != expiredID {
+		t.Fatalf("expected deterministic user_id to be stable after expiry, got %q want %q", newID, expiredID)
+	}
+
+	userIDCacheMu.RLock()
+	entry := userIDCache[cacheKey]
+	userIDCacheMu.RUnlock()
+	if !entry.expire.After(time.Now().Add(30 * time.Minute)) {
+		t.Fatalf("expected expired cache entry to be refreshed, got expire %v", entry.expire)
 	}
 }
 
 func TestCachedUserID_IsScopedByAPIKey(t *testing.T) {
 	resetUserIDCache()
 
-	first := CachedUserID("api-key-1")
-	second := CachedUserID("api-key-2")
+	first := CachedUserID("api-key-1", nil)
+	second := CachedUserID("api-key-2", nil)
 
 	if first == second {
 		t.Fatalf("expected different API keys to have different user_ids, got %q", first)
@@ -94,7 +106,7 @@ func TestCachedUserID_RenewsTTLOnHit(t *testing.T) {
 	resetUserIDCache()
 
 	key := "api-key-renew"
-	id := CachedUserID(key)
+	id := CachedUserID(key, nil)
 	cacheKey := userIDCacheKey(key)
 
 	soon := time.Now()
@@ -105,7 +117,7 @@ func TestCachedUserID_RenewsTTLOnHit(t *testing.T) {
 	}
 	userIDCacheMu.Unlock()
 
-	if refreshed := CachedUserID(key); refreshed != id {
+	if refreshed := CachedUserID(key, nil); refreshed != id {
 		t.Fatalf("expected cached user_id to be reused before expiry, got %q", refreshed)
 	}
 
@@ -123,12 +135,12 @@ func TestCachedUserIDRequiredHomeReusesKVAcrossLocalCacheReset(t *testing.T) {
 	client := newFakeClaudeIDKVClient()
 	useFakeClaudeIDKVClient(t, client, true, nil)
 
-	first, errFirst := CachedUserIDRequired(context.Background(), "api-key-1")
+	first, errFirst := CachedUserIDRequired(context.Background(), "api-key-1", nil)
 	if errFirst != nil {
 		t.Fatalf("CachedUserIDRequired() first error = %v", errFirst)
 	}
 	resetUserIDCache()
-	second, errSecond := CachedUserIDRequired(context.Background(), "api-key-1")
+	second, errSecond := CachedUserIDRequired(context.Background(), "api-key-1", nil)
 	if errSecond != nil {
 		t.Fatalf("CachedUserIDRequired() second error = %v", errSecond)
 	}
@@ -153,7 +165,7 @@ func TestCachedUserIDRequiredEmptyAPIKeyDoesNotUseHomeKV(t *testing.T) {
 	client := newFakeClaudeIDKVClient()
 	useFakeClaudeIDKVClient(t, client, true, nil)
 
-	value, errValue := CachedUserIDRequired(context.Background(), "")
+	value, errValue := CachedUserIDRequired(context.Background(), "", nil)
 	if errValue != nil {
 		t.Fatalf("CachedUserIDRequired(empty) error = %v", errValue)
 	}
@@ -178,10 +190,39 @@ func TestCachedUserIDRequiredHomeKVFailures(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			useFakeClaudeIDKVClient(t, tc.client, true, nil)
-			if _, errValue := CachedUserIDRequired(context.Background(), "api-key-1"); errValue == nil {
+			if _, errValue := CachedUserIDRequired(context.Background(), "api-key-1", nil); errValue == nil {
 				t.Fatalf("CachedUserIDRequired() error = nil, want error")
 			}
 		})
+	}
+}
+
+func TestCachedUserIDFallbackIsDeterministic(t *testing.T) {
+	resetUserIDCache()
+	client := newFakeClaudeIDKVClient()
+	useFakeClaudeIDKVClient(t, client, true, errors.New("kv down"))
+
+	// Forcing CachedUserIDRequired to fall through to the no-cache path; the
+	// fallback must still derive a stable, auth-seeded user_id.
+	first := CachedUserID("fallback-key", nil)
+	if !IsValidUserID(first) {
+		t.Fatalf("fallback user_id %q is not valid", first)
+	}
+
+	second := CachedUserID("fallback-key", nil)
+	if first != second {
+		t.Fatalf("fallback user_id not deterministic: %q vs %q", first, second)
+	}
+}
+
+func TestGenerateFakeUserIDIsDeterministic(t *testing.T) {
+	first := GenerateFakeUserID()
+	second := GenerateFakeUserID()
+	if !IsValidUserID(first) {
+		t.Fatalf("GenerateFakeUserID() %q is not valid", first)
+	}
+	if first != second {
+		t.Fatalf("GenerateFakeUserID() not deterministic: %q vs %q", first, second)
 	}
 }
 
@@ -190,7 +231,7 @@ func TestCachedUserIDRequiredHomeRequiresReadAfterSet(t *testing.T) {
 	client.setNoPersist = true
 	useFakeClaudeIDKVClient(t, client, true, nil)
 
-	if _, errValue := CachedUserIDRequired(context.Background(), "api-key-1"); errValue == nil {
+	if _, errValue := CachedUserIDRequired(context.Background(), "api-key-1", nil); errValue == nil {
 		t.Fatalf("CachedUserIDRequired() error = nil, want missing-after-set error")
 	}
 }


### PR DESCRIPTION
## Summary

Cache-audit finding 2 (executor path). `internal/runtime/executor/helps/cloak_utils.go` and `internal/runtime/executor/helps/user_id_cache.go` generated a fresh random `device_id` on every cache miss, and `session_id_cache.go` used a shared anonymous UUID when `apiKey` was empty.

This PR reconciles the `cloak_cache_user_id` flag with its documented contract:

- `cloak_cache_user_id: false` (default) — legacy privacy/opt-out behavior: a fresh random `metadata.user_id` is generated for every request. This is **not** cache-warm.
- `cloak_cache_user_id: true` — deterministic per-credential `metadata.user_id`. Operators who want cache warmth set `cloak_cache_user_id: true`.

Implementation:

- `cloak_utils.go`: `generateFakeUserID(apiKey, auth)` derives `device_id` from the credential seed + `CachedSessionID(apiKey, auth)` (cached path). `GenerateRandomFakeUserIDForSession(sessionID)` keeps the cached credential `session_id` but uses a fresh random `device_id` for the default `cache-user-id:false` path.
- `injectFakeUserID`: uses `CachedUserIDRequired` when `cloak_cache_user_id` is `true` (deterministic per credential); uses `GenerateRandomFakeUserIDForSession(CachedSessionIDRequired(...))` when `false` (per-request random `metadata.user_id`).
- `session_id_cache.go`: `claudeCredentialSeed(apiKey, auth)` uses `apiKey` if present, otherwise falls back to `auth.ID`/`Index`/`FileName`/`Label`/`Provider` before the anonymous namespace.
- `user_id_cache.go`: `CachedUserID`/`CachedUserIDRequired` now take `auth` so the cache-miss fallback is per-credential.
- `claude_executor_cloaking.go` / `claude_executor_request.go`: pass `auth` into the helpers.
- Added `TestApplyCloaking_DeterministicUserID` (with `cloak_cache_user_id=true`), `TestApplyCloaking_NonCachedUserIDIsRandom` (default `cloak_cache_user_id=false`), `TestCachedUserIDFallbackIsDeterministic`, `TestGenerateFakeUserIDIsDeterministic`, and `TestCachedSessionIDRequiredDistinctEmptyAPIKeyCredentials`.

Plus translator finding 1 already lives in https://github.com/kaitranntt/CLIProxyAPIPlus/pull/209 (`internal/translator/common/claude_user_id.go`). This PR does not touch `internal/translator`.

## Test plan

- `go build -o cli-proxy-api ./cmd/server`
- `go test ./internal/runtime/executor/helps`
- `go test ./internal/runtime/executor -run 'Claude|Session|FakeUserID|Cloaking'`

## Cross-links

- Stock issue for finding 1 (translator): https://github.com/router-for-me/CLIProxyAPI/issues/5153
- Stock PR for finding 2 (executor): https://github.com/router-for-me/CLIProxyAPI/pull/5152
- Stock PR for Kimi cache_control strip: https://github.com/router-for-me/CLIProxyAPI/pull/5154
