### PR TITLE
feat(auth,config): configurable quota cooldown floor and per-status transient cooldown

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -677,6 +677,8 @@ func main() {
 	redisqueue.SetRetentionSeconds(cfg.RedisUsageQueueRetentionSeconds)
 	coreauth.SetQuotaCooldownDisabled(cfg.DisableCooling)
 	coreauth.SetTransientErrorCooldownSeconds(cfg.TransientErrorCooldownSeconds)
+	coreauth.SetQuotaCooldownFloorSeconds(cfg.QuotaCooldownFloorSeconds)
+	coreauth.SetTransientCooldownByStatus(cfg.TransientCooldownByStatus)
 
 	if err = logging.ConfigureLogOutput(cfg); err != nil {
 		log.Errorf("failed to configure log output: %v", err)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -168,7 +168,22 @@ save-cooldown-status: false
 
 # Cooldown duration in seconds for transient upstream errors (408/500/502/503/504).
 # Set to 0 to keep the legacy 60-second cooldown; set to -1 to disable transient error cooldowns.
+# After PR #205 (fix/auth-lower-transient-cooldown), 0 means 10 s.
 transient-error-cooldown-seconds: 0
+
+# Per-status overrides for transient error cooldowns.
+# Statuses not listed fall back to transient-error-cooldown-seconds.
+# Example:
+# transient-cooldown-by-status:
+#   - status: 408
+#     cooldown-seconds: 2
+#   - status: 503
+#     cooldown-seconds: 10
+
+# Minimum base in seconds for the quota cooldown ladder.
+# Sub-second Retry-After hints are never allowed below this floor. Default 1.
+# Stacks on PR #198 (fix/quota-backoff-hint-floor) / router-for-me/CLIProxyAPI#5130.
+quota-cooldown-floor-seconds: 1
 
 # When true, globally disable Claude request cloaking (the Claude Code CLI disguise and
 # system prompt replacement), so the original system prompt is passed through to Claude as-is.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -168,7 +168,6 @@ save-cooldown-status: false
 
 # Cooldown duration in seconds for transient upstream errors (408/500/502/503/504).
 # Set to 0 to keep the legacy 60-second cooldown; set to -1 to disable transient error cooldowns.
-# After PR #205 (fix/auth-lower-transient-cooldown), 0 means 10 s.
 transient-error-cooldown-seconds: 0
 
 # Per-status overrides for transient error cooldowns.
@@ -182,7 +181,7 @@ transient-error-cooldown-seconds: 0
 
 # Minimum base in seconds for the quota cooldown ladder.
 # Sub-second Retry-After hints are never allowed below this floor. Default 1.
-# Stacks on PR #198 (fix/quota-backoff-hint-floor) / router-for-me/CLIProxyAPI#5130.
+# Values above 1800 (30 minutes) are clamped to 1800 because the ladder is capped at 30 minutes.
 quota-cooldown-floor-seconds: 1
 
 # When true, globally disable Claude request cloaking (the Claude Code CLI disguise and

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -205,6 +205,8 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	managementasset.SetCurrentConfig(cfg)
 	auth.SetQuotaCooldownDisabled(cfg.DisableCooling)
 	auth.SetTransientErrorCooldownSeconds(cfg.TransientErrorCooldownSeconds)
+	auth.SetQuotaCooldownFloorSeconds(cfg.QuotaCooldownFloorSeconds)
+	auth.SetTransientCooldownByStatus(cfg.TransientCooldownByStatus)
 	applySignatureCacheConfig(nil, cfg)
 	// Initialize management handler
 	s.mgmt = managementHandlers.NewHandler(cfg, configFilePath, authManager)

--- a/internal/api/server_reload.go
+++ b/internal/api/server_reload.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/access"
@@ -19,20 +20,16 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func transientCooldownByStatusEqual(a, b []config.TransientCooldownByStatusRule) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	m := make(map[int]int, len(a))
-	for _, r := range a {
+func transientCooldownByStatusMap(rules []config.TransientCooldownByStatusRule) map[int]int {
+	m := make(map[int]int, len(rules))
+	for _, r := range rules {
 		m[r.Status] = r.CooldownSeconds
 	}
-	for _, r := range b {
-		if m[r.Status] != r.CooldownSeconds {
-			return false
-		}
-	}
-	return true
+	return m
+}
+
+func transientCooldownByStatusEqual(a, b []config.TransientCooldownByStatusRule) bool {
+	return reflect.DeepEqual(transientCooldownByStatusMap(a), transientCooldownByStatusMap(b))
 }
 
 func (s *Server) applyAccessConfig(oldCfg, newCfg *config.Config) bool {

--- a/internal/api/server_reload.go
+++ b/internal/api/server_reload.go
@@ -19,6 +19,22 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func transientCooldownByStatusEqual(a, b []config.TransientCooldownByStatusRule) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	m := make(map[int]int, len(a))
+	for _, r := range a {
+		m[r.Status] = r.CooldownSeconds
+	}
+	for _, r := range b {
+		if m[r.Status] != r.CooldownSeconds {
+			return false
+		}
+	}
+	return true
+}
+
 func (s *Server) applyAccessConfig(oldCfg, newCfg *config.Config) bool {
 	if s == nil || s.accessManager == nil || newCfg == nil {
 		return false
@@ -110,6 +126,12 @@ func (s *Server) UpdateClientsContext(ctx context.Context, cfg *config.Config) b
 	}
 	if oldCfg == nil || oldCfg.TransientErrorCooldownSeconds != cfg.TransientErrorCooldownSeconds {
 		auth.SetTransientErrorCooldownSeconds(cfg.TransientErrorCooldownSeconds)
+	}
+	if oldCfg == nil || oldCfg.QuotaCooldownFloorSeconds != cfg.QuotaCooldownFloorSeconds {
+		auth.SetQuotaCooldownFloorSeconds(cfg.QuotaCooldownFloorSeconds)
+	}
+	if oldCfg == nil || !transientCooldownByStatusEqual(oldCfg.TransientCooldownByStatus, cfg.TransientCooldownByStatus) {
+		auth.SetTransientCooldownByStatus(cfg.TransientCooldownByStatus)
 	}
 
 	if oldCfg != nil && oldCfg.DisableImageGeneration != cfg.DisableImageGeneration {

--- a/internal/api/server_reload_test.go
+++ b/internal/api/server_reload_test.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestTransientCooldownByStatusEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []config.TransientCooldownByStatusRule
+		b    []config.TransientCooldownByStatusRule
+		want bool
+	}{
+		{
+			name: "identical",
+			a:    []config.TransientCooldownByStatusRule{{Status: 408, CooldownSeconds: 2}, {Status: 503, CooldownSeconds: 10}},
+			b:    []config.TransientCooldownByStatusRule{{Status: 408, CooldownSeconds: 2}, {Status: 503, CooldownSeconds: 10}},
+			want: true,
+		},
+		{
+			name: "different values",
+			a:    []config.TransientCooldownByStatusRule{{Status: 408, CooldownSeconds: 2}},
+			b:    []config.TransientCooldownByStatusRule{{Status: 408, CooldownSeconds: 5}},
+			want: false,
+		},
+		{
+			name: "new drops a status",
+			a:    []config.TransientCooldownByStatusRule{{Status: 408, CooldownSeconds: 2}, {Status: 503, CooldownSeconds: 10}},
+			b:    []config.TransientCooldownByStatusRule{{Status: 408, CooldownSeconds: 2}},
+			want: false,
+		},
+		{
+			name: "new duplicates a status",
+			a:    []config.TransientCooldownByStatusRule{{Status: 408, CooldownSeconds: 2}, {Status: 503, CooldownSeconds: 10}},
+			b:    []config.TransientCooldownByStatusRule{{Status: 408, CooldownSeconds: 2}, {Status: 408, CooldownSeconds: 2}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := transientCooldownByStatusEqual(tt.a, tt.b); got != tt.want {
+				t.Fatalf("transientCooldownByStatusEqual(%+v, %+v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,6 +72,14 @@ type Config struct {
 	// 0 keeps the legacy default cooldown. Negative values disable these cooldowns.
 	TransientErrorCooldownSeconds int `yaml:"transient-error-cooldown-seconds" json:"transient-error-cooldown-seconds"`
 
+	// QuotaCooldownFloorSeconds is the minimum base for the quota cooldown ladder.
+	// Sub-second Retry-After hints are never allowed below this floor. Default 1.
+	QuotaCooldownFloorSeconds int `yaml:"quota-cooldown-floor-seconds" json:"quota-cooldown-floor-seconds"`
+
+	// TransientCooldownByStatus lets operators override the transient cooldown per HTTP status.
+	// Statuses not listed fall back to TransientErrorCooldownSeconds.
+	TransientCooldownByStatus []TransientCooldownByStatusRule `yaml:"transient-cooldown-by-status,omitempty" json:"transient-cooldown-by-status,omitempty"`
+
 	// AuthAutoRefreshWorkers overrides the size of the core auth auto-refresh worker pool.
 	// When <= 0, the default worker count is used.
 	AuthAutoRefreshWorkers int `yaml:"auth-auto-refresh-workers" json:"auth-auto-refresh-workers"`

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -72,6 +72,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.DisableCooling = false
 	cfg.SaveCooldownStatus = false
 	cfg.TransientErrorCooldownSeconds = 0
+	cfg.QuotaCooldownFloorSeconds = 1
 	cfg.DisableImageGeneration = DisableImageGenerationOff
 	cfg.WebsocketAuth = true
 	cfg.Pprof.Enable = false

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -69,6 +69,16 @@ type KiroRateLimitConfig struct {
 	SuspendCooldown   string  `yaml:"suspend-cooldown,omitempty" json:"suspend-cooldown,omitempty"`
 }
 
+// TransientCooldownByStatusRule overrides the transient cooldown duration for a single HTTP status.
+// Statuses not listed fall back to the global TransientErrorCooldownSeconds.
+type TransientCooldownByStatusRule struct {
+	// Status is the HTTP status code to match (e.g. 408, 500, 502, 503, 504).
+	Status int `yaml:"status" json:"status"`
+	// CooldownSeconds is the cooldown applied when this status is seen.
+	// 0 keeps the legacy default for this status; negative values disable the cooldown.
+	CooldownSeconds int `yaml:"cooldown-seconds" json:"cooldown-seconds"`
+}
+
 // RequestScopedErrorRule configures custom classification and handling for upstream errors.
 type RequestScopedErrorRule struct {
 	// Status matches the HTTP status code of the upstream response (e.g. 400).

--- a/internal/config/cooldown_config_test.go
+++ b/internal/config/cooldown_config_test.go
@@ -1,0 +1,60 @@
+package config
+
+import "testing"
+
+func TestCooldownConfigDefaults(t *testing.T) {
+	data := []byte(`
+host: "127.0.0.1"
+port: 8080
+`)
+	cfg, err := ParseConfigBytes(data)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if cfg.TransientErrorCooldownSeconds != 0 {
+		t.Fatalf("TransientErrorCooldownSeconds default = %d, want 0", cfg.TransientErrorCooldownSeconds)
+	}
+	if cfg.QuotaCooldownFloorSeconds != 1 {
+		t.Fatalf("QuotaCooldownFloorSeconds default = %d, want 1", cfg.QuotaCooldownFloorSeconds)
+	}
+	if cfg.TransientCooldownByStatus != nil {
+		t.Fatalf("TransientCooldownByStatus default = %v, want nil", cfg.TransientCooldownByStatus)
+	}
+}
+
+func TestCooldownConfigParse(t *testing.T) {
+	data := []byte(`
+host: "127.0.0.1"
+port: 8080
+transient-error-cooldown-seconds: 10
+quota-cooldown-floor-seconds: 5
+transient-cooldown-by-status:
+  - status: 408
+    cooldown-seconds: 2
+  - status: 503
+    cooldown-seconds: 15
+`)
+	cfg, err := ParseConfigBytes(data)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if cfg.TransientErrorCooldownSeconds != 10 {
+		t.Fatalf("TransientErrorCooldownSeconds = %d, want 10", cfg.TransientErrorCooldownSeconds)
+	}
+	if cfg.QuotaCooldownFloorSeconds != 5 {
+		t.Fatalf("QuotaCooldownFloorSeconds = %d, want 5", cfg.QuotaCooldownFloorSeconds)
+	}
+	if len(cfg.TransientCooldownByStatus) != 2 {
+		t.Fatalf("TransientCooldownByStatus len = %d, want 2", len(cfg.TransientCooldownByStatus))
+	}
+	found := map[int]int{}
+	for _, r := range cfg.TransientCooldownByStatus {
+		found[r.Status] = r.CooldownSeconds
+	}
+	if found[408] != 2 {
+		t.Fatalf("status 408 cooldown = %d, want 2", found[408])
+	}
+	if found[503] != 15 {
+		t.Fatalf("status 503 cooldown = %d, want 15", found[503])
+	}
+}

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -31,6 +31,7 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	cfg.DisableCooling = false
 	cfg.SaveCooldownStatus = false
 	cfg.TransientErrorCooldownSeconds = 0
+	cfg.QuotaCooldownFloorSeconds = 1
 	cfg.DisableImageGeneration = DisableImageGenerationOff
 	cfg.WebsocketAuth = true
 	cfg.Pprof.Enable = false

--- a/internal/runtime/executor/antigravity_executor_cooldown_transient_test.go
+++ b/internal/runtime/executor/antigravity_executor_cooldown_transient_test.go
@@ -1,0 +1,90 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+// TestAntigravityShortCooldownErrorIsTransient pins the classification of the
+// synthetic 429 the executor raises while an auth sits in a short cooldown.
+// The cooldown is a local, self-imposed pause of at most a few minutes, so the
+// conductor has to read it as a transient rate limit and rotate to the next
+// auth. Unclassified, the same error looks like an exhausted quota carrying a
+// retry hint, and the conductor escalates BackoffLevel toward the 30 minute
+// ceiling — parking an account that was never actually throttled upstream.
+func TestAntigravityShortCooldownErrorIsTransient(t *testing.T) {
+	resetAntigravityCreditsRetryState()
+	t.Cleanup(resetAntigravityCreditsRetryState)
+	client := newFakeAntigravityKVClient()
+	useFakeAntigravityKVClient(t, client, true, nil)
+
+	exec := NewAntigravityExecutor(&config.Config{})
+	opts := cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatGemini,
+		ResponseFormat: sdktranslator.FormatGemini,
+	}
+	payload := []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`)
+
+	for _, tc := range []struct {
+		name  string
+		model string
+		call  func(auth *cliproxyauth.Auth, model string) error
+	}{
+		{
+			name:  "execute",
+			model: "gemini-3.6-flash",
+			call: func(auth *cliproxyauth.Auth, model string) error {
+				_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{Model: model, Payload: payload}, opts)
+				return err
+			},
+		},
+		{
+			name:  "execute-claude",
+			model: "claude-sonnet-4-5",
+			call: func(auth *cliproxyauth.Auth, model string) error {
+				_, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{Model: model, Payload: payload}, opts)
+				return err
+			},
+		},
+		{
+			name:  "execute-stream",
+			model: "gemini-3.6-flash",
+			call: func(auth *cliproxyauth.Auth, model string) error {
+				_, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{Model: model, Payload: payload}, opts)
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			auth := &cliproxyauth.Auth{ID: "cooldown-transient-" + tc.name}
+			if errMark := markAntigravityShortCooldownRequired(context.Background(), auth, tc.model, time.Now(), 30*time.Second); errMark != nil {
+				t.Fatalf("markAntigravityShortCooldownRequired() error = %v", errMark)
+			}
+
+			err := tc.call(auth, tc.model)
+			if err == nil {
+				t.Fatal("expected the short cooldown to surface a 429")
+			}
+
+			var classified interface{ TransientRateLimit() bool }
+			if !errors.As(err, &classified) {
+				t.Fatalf("short-cooldown error carries no 429 classification: %T", err)
+			}
+			if !classified.TransientRateLimit() {
+				t.Fatal("expected the synthetic short-cooldown 429 to be transient so the conductor rotates instead of escalating backoff")
+			}
+
+			var hinted interface{ RetryAfter() *time.Duration }
+			if !errors.As(err, &hinted) || hinted.RetryAfter() == nil || *hinted.RetryAfter() <= 0 {
+				t.Fatalf("expected a positive retry hint on the short-cooldown 429, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/antigravity_executor_credits.go
+++ b/internal/runtime/executor/antigravity_executor_credits.go
@@ -341,7 +341,13 @@ func newAntigravityStatusErr(statusCode int, body []byte) statusErr {
 		}
 		// Only a decisively rate-limited 429 may keep its raw retry hint downstream;
 		// exhausted quota and unclassified bodies stay on the escalating cooldown ladder.
-		err.transientRateLimit = classifyAntigravity429(body) == antigravity429RateLimited
+		// A RATE_LIMIT_EXCEEDED reason without a RetryInfo hint is still a short-lived
+		// throttle, not an exhausted quota, so it is transient too — but only when the
+		// classification comes from the ErrorInfo reason, not from the bare
+		// "too many requests" message heuristic.
+		category := classifyAntigravity429(body)
+		err.transientRateLimit = category == antigravity429RateLimited ||
+			(category == antigravity429SoftRateLimit && strings.EqualFold(decideAntigravity429(body).reason, "RATE_LIMIT_EXCEEDED"))
 	}
 	return err
 }

--- a/internal/runtime/executor/antigravity_executor_credits.go
+++ b/internal/runtime/executor/antigravity_executor_credits.go
@@ -339,6 +339,9 @@ func newAntigravityStatusErr(statusCode int, body []byte) statusErr {
 		if retryAfter, parseErr := helps.ParseRetryDelay(body); parseErr == nil && retryAfter != nil {
 			err.retryAfter = retryAfter
 		}
+		// Only a decisively rate-limited 429 may keep its raw retry hint downstream;
+		// exhausted quota and unclassified bodies stay on the escalating cooldown ladder.
+		err.transientRateLimit = classifyAntigravity429(body) == antigravity429RateLimited
 	}
 	return err
 }

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -819,3 +819,47 @@ func TestParseMetaFloat(t *testing.T) {
 		})
 	}
 }
+
+func TestAntigravityCountTokensClassifiesTransient429(t *testing.T) {
+	body := `{
+		"error": {
+			"code": 429,
+			"status": "RESOURCE_EXHAUSTED",
+			"details": [
+				{"@type": "type.googleapis.com/google.rpc.ErrorInfo", "reason": "RATE_LIMIT_EXCEEDED"},
+				{"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "0.479417207s"}
+			]
+		}
+	}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	exec := NewAntigravityExecutor(&config.Config{RequestRetry: 1})
+	_, errCount := exec.CountTokens(context.Background(), testAntigravityAuth(server.URL), cliproxyexecutor.Request{
+		Model:   "gemini-3.6-flash-high",
+		Payload: []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatGemini,
+		ResponseFormat: sdktranslator.FormatGemini,
+	})
+	if errCount == nil {
+		t.Fatal("expected CountTokens to fail on an upstream 429")
+	}
+
+	var classified interface{ TransientRateLimit() bool }
+	if !errors.As(errCount, &classified) {
+		t.Fatalf("CountTokens error carries no 429 classification: %T", errCount)
+	}
+	if !classified.TransientRateLimit() {
+		t.Fatal("expected a RATE_LIMIT_EXCEEDED token-count 429 to be marked transient")
+	}
+
+	var hinted interface{ RetryAfter() *time.Duration }
+	if !errors.As(errCount, &hinted) || hinted.RetryAfter() == nil {
+		t.Fatal("expected the provider retry hint to survive the token-count path")
+	}
+}

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -225,6 +225,60 @@ func TestClassifyAntigravity429(t *testing.T) {
 	})
 }
 
+func TestNewAntigravityStatusErrMarksTransientRateLimit(t *testing.T) {
+	rateLimited := []byte(`{
+		"error": {
+			"code": 429,
+			"message": "You have exhausted your capacity on this model. Your quota will reset after 0s.",
+			"status": "RESOURCE_EXHAUSTED",
+			"details": [
+				{
+					"@type": "type.googleapis.com/google.rpc.ErrorInfo",
+					"reason": "RATE_LIMIT_EXCEEDED",
+					"domain": "cloudcode-pa.googleapis.com"
+				},
+				{
+					"@type": "type.googleapis.com/google.rpc.RetryInfo",
+					"retryDelay": "0.479417207s"
+				}
+			]
+		}
+	}`)
+	transient := newAntigravityStatusErr(http.StatusTooManyRequests, rateLimited)
+	if !transient.TransientRateLimit() {
+		t.Fatal("expected a RATE_LIMIT_EXCEEDED 429 with a sub-second hint to be marked transient")
+	}
+	if transient.RetryAfter() == nil {
+		t.Fatal("expected the provider retry hint to be preserved on a transient rate limit")
+	}
+
+	exhausted := []byte(`{
+		"error": {
+			"code": 429,
+			"status": "RESOURCE_EXHAUSTED",
+			"details": [
+				{"@type": "type.googleapis.com/google.rpc.ErrorInfo", "reason": "QUOTA_EXHAUSTED"},
+				{"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": "0.479417207s"}
+			]
+		}
+	}`)
+	quotaErr := newAntigravityStatusErr(http.StatusTooManyRequests, exhausted)
+	if quotaErr.TransientRateLimit() {
+		t.Fatal("expected a QUOTA_EXHAUSTED 429 not to be marked transient")
+	}
+	if quotaErr.RetryAfter() == nil {
+		t.Fatal("expected the provider retry hint to be preserved on an exhausted quota")
+	}
+
+	if soft := newAntigravityStatusErr(http.StatusTooManyRequests, []byte(`{"error":{"message":"too many requests"}}`)); soft.TransientRateLimit() {
+		t.Fatal("expected an unclassified 429 to stay on the escalating cooldown ladder")
+	}
+
+	if nonRateLimit := newAntigravityStatusErr(http.StatusServiceUnavailable, rateLimited); nonRateLimit.TransientRateLimit() {
+		t.Fatal("expected a non-429 status not to be marked transient")
+	}
+}
+
 func TestAntigravityShouldRetryNoCapacity_Standard503(t *testing.T) {
 	body := []byte(`{
 		"error": {

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -274,6 +274,25 @@ func TestNewAntigravityStatusErrMarksTransientRateLimit(t *testing.T) {
 		t.Fatal("expected an unclassified 429 to stay on the escalating cooldown ladder")
 	}
 
+	// A reasoned RATE_LIMIT_EXCEEDED without a RetryInfo hint is still a
+	// short-lived throttle, not an exhausted quota.
+	noHint := []byte(`{
+		"error": {
+			"code": 429,
+			"status": "RESOURCE_EXHAUSTED",
+			"details": [
+				{"@type": "type.googleapis.com/google.rpc.ErrorInfo", "reason": "RATE_LIMIT_EXCEEDED", "domain": "cloudcode-pa.googleapis.com"}
+			]
+		}
+	}`)
+	noHintErr := newAntigravityStatusErr(http.StatusTooManyRequests, noHint)
+	if !noHintErr.TransientRateLimit() {
+		t.Fatal("expected a RATE_LIMIT_EXCEEDED 429 without RetryInfo to be marked transient")
+	}
+	if noHintErr.RetryAfter() != nil {
+		t.Fatal("expected no retry hint when Google omits RetryInfo")
+	}
+
 	if nonRateLimit := newAntigravityStatusErr(http.StatusServiceUnavailable, rateLimited); nonRateLimit.TransientRateLimit() {
 		t.Fatal("expected a non-429 status not to be marked transient")
 	}

--- a/internal/runtime/executor/antigravity_executor_execute.go
+++ b/internal/runtime/executor/antigravity_executor_execute.go
@@ -33,7 +33,7 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	} else if inCooldown && !antigravityShouldBypassShortCooldown(ctx, e.cfg) {
 		log.Debugf("antigravity executor: auth %s in short cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
 		d := remaining
-		return resp, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d}
+		return resp, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d, transientRateLimit: true}
 	}
 
 	isClaude := strings.Contains(strings.ToLower(baseModel), "claude")
@@ -264,7 +264,7 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 	} else if inCooldown && !antigravityShouldBypassShortCooldown(ctx, e.cfg) {
 		log.Debugf("antigravity executor: auth %s in short cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
 		d := remaining
-		return resp, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d}
+		return resp, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d, transientRateLimit: true}
 	}
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)

--- a/internal/runtime/executor/antigravity_executor_stream.go
+++ b/internal/runtime/executor/antigravity_executor_stream.go
@@ -32,7 +32,7 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 	} else if inCooldown && !antigravityShouldBypassShortCooldown(ctx, e.cfg) {
 		log.Debugf("antigravity executor: auth %s in short cooldown for model %s (%s remaining), returning 429 to switch auth", auth.ID, baseModel, remaining)
 		d := remaining
-		return nil, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d}
+		return nil, statusErr{code: http.StatusTooManyRequests, msg: fmt.Sprintf("auth in short cooldown, %s remaining", remaining), retryAfter: &d, transientRateLimit: true}
 	}
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)

--- a/internal/runtime/executor/antigravity_executor_tokens.go
+++ b/internal/runtime/executor/antigravity_executor_tokens.go
@@ -164,24 +164,12 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 			log.Debugf("antigravity executor: rate limited on base url %s, retrying with fallback base url: %s", baseURL, baseURLs[idx+1])
 			continue
 		}
-		sErr := statusErr{code: httpResp.StatusCode, msg: string(bodyBytes)}
-		if httpResp.StatusCode == http.StatusTooManyRequests {
-			if retryAfter, parseErr := helps.ParseRetryDelay(bodyBytes); parseErr == nil && retryAfter != nil {
-				sErr.retryAfter = retryAfter
-			}
-		}
-		return cliproxyexecutor.Response{}, sErr
+		return cliproxyexecutor.Response{}, newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
 	}
 
 	switch {
 	case lastStatus != 0:
-		sErr := statusErr{code: lastStatus, msg: string(lastBody)}
-		if lastStatus == http.StatusTooManyRequests {
-			if retryAfter, parseErr := helps.ParseRetryDelay(lastBody); parseErr == nil && retryAfter != nil {
-				sErr.retryAfter = retryAfter
-			}
-		}
-		return cliproxyexecutor.Response{}, sErr
+		return cliproxyexecutor.Response{}, newAntigravityStatusErr(lastStatus, lastBody)
 	case lastErr != nil:
 		return cliproxyexecutor.Response{}, lastErr
 	default:

--- a/internal/runtime/executor/antigravity_executor_transport_test.go
+++ b/internal/runtime/executor/antigravity_executor_transport_test.go
@@ -224,10 +224,15 @@ func TestAntigravityConcurrentRequestsReusePooledConnections(t *testing.T) {
 	mu.Unlock()
 	// The first wave legitimately opens perWave connections. Later waves must reuse
 	// them; with MaxIdleConnsPerHost=2 only two survive each wave and distinct grows
-	// towards totalConns instead.
-	if distinct > perWave {
+	// towards totalConns instead. A wave boundary can cost one extra dial when a
+	// connection is retired between waves (the server closes an idle connection at
+	// exactly the wrong moment), so allow one stray dial per later wave: that still
+	// cleanly separates the pooled case from the MaxIdleConnsPerHost=2 regression
+	// (which would open roughly totalConns - 2*(waves-1) distinct connections).
+	maxAllowed := perWave + (waves - 1)
+	if distinct > maxAllowed {
 		t.Fatalf("%d waves of %d concurrent requests opened %d connections, want at most %d (unpooled worst case is %d)",
-			waves, perWave, distinct, perWave, totalConns)
+			waves, perWave, distinct, maxAllowed, totalConns)
 	}
 }
 

--- a/internal/runtime/executor/claude_executor_beta_policy_test.go
+++ b/internal/runtime/executor/claude_executor_beta_policy_test.go
@@ -293,3 +293,31 @@ func TestClassifyClaudeUpstreamError_OtherStatusesUnaffected(t *testing.T) {
 		t.Fatal("non-429 status was misclassified as request-scoped")
 	}
 }
+
+// An ordinary model-level Claude 429 (no unified 5h/7d rejection headers) is
+// a transient throttle: the conductor must rotate to the next credential
+// instead of escalating BackoffLevel as if quota were exhausted.
+func TestClassifyClaudeUpstreamError_OrdinaryRateLimitIsTransient(t *testing.T) {
+	body := []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Number of requests has exceeded your rate limit."}}`)
+	err := classifyClaudeUpstreamError(http.StatusTooManyRequests, nil, body)
+
+	var transient interface{ TransientRateLimit() bool }
+	if !errors.As(err, &transient) || !transient.TransientRateLimit() {
+		t.Fatalf("ordinary Claude 429 = %v, want a transient rate limit", err)
+	}
+}
+
+// The unified 5h/7d rejection stays on the quota ladder: it must NOT be
+// reported as a transient rate limit.
+func TestClassifyClaudeUpstreamError_UnifiedRejectionNotTransient(t *testing.T) {
+	headers := http.Header{
+		"Anthropic-Ratelimit-Unified-5h-Status": []string{"rejected"},
+		"Anthropic-Ratelimit-Unified-7d-Status": []string{"allowed"},
+	}
+	err := classifyClaudeUpstreamError(http.StatusTooManyRequests, headers, []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Shared usage window rejected."}}`))
+
+	var transient interface{ TransientRateLimit() bool }
+	if errors.As(err, &transient) && transient.TransientRateLimit() {
+		t.Fatal("unified 5h/7d rejection must stay on the quota ladder, not be marked transient")
+	}
+}

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -304,7 +304,10 @@ func classifyClaudeUpstreamError(statusCode int, headers http.Header, body []byt
 		if claudeBodyIndicatesFastModeCredits(body) {
 			return claudeEntitlementError{err}
 		}
-		// Ordinary model-level Claude 429 (not a unified 5h/7d rejection)
+		// Ordinary model-level Claude 429 (not a unified 5h/7d rejection): a
+		// transient throttle, so the conductor rotates instead of escalating
+		// BackoffLevel as if quota were exhausted.
+		err.transientRateLimit = true
 		return claudeRateLimitError{statusErr: err, credentialScoped: false}
 	}
 	return err

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -1011,9 +1011,10 @@ func openAICompatStreamDataError(payload []byte, eventName string) (statusErr, b
 }
 
 type statusErr struct {
-	code       int
-	msg        string
-	retryAfter *time.Duration
+	code               int
+	msg                string
+	retryAfter         *time.Duration
+	transientRateLimit bool
 }
 
 func (e statusErr) Error() string {
@@ -1024,3 +1025,7 @@ func (e statusErr) Error() string {
 }
 func (e statusErr) StatusCode() int            { return e.code }
 func (e statusErr) RetryAfter() *time.Duration { return e.retryAfter }
+
+// TransientRateLimit reports whether the upstream 429 was classified as a
+// short-lived rate limit rather than an exhausted quota window.
+func (e statusErr) TransientRateLimit() bool { return e.transientRateLimit }

--- a/internal/runtime/executor/qoder_executor_test.go
+++ b/internal/runtime/executor/qoder_executor_test.go
@@ -474,7 +474,7 @@ func (p *captureQoderUsagePlugin) HandleUsage(_ context.Context, record usage.Re
 
 func waitForQoderUsageRecord(t *testing.T, records <-chan usage.Record, authID, model string) usage.Record {
 	t.Helper()
-	timeout := time.After(5 * time.Second) // generous for CI scheduling jitter; correctness comes from matching the record, not the deadline
+	timeout := time.After(30 * time.Second) // generous for CI scheduling jitter; correctness comes from matching the record, not the deadline
 	for {
 		select {
 		case record := <-records:

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -52,6 +52,12 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.TransientErrorCooldownSeconds != newCfg.TransientErrorCooldownSeconds {
 		changes = append(changes, fmt.Sprintf("transient-error-cooldown-seconds: %d -> %d", oldCfg.TransientErrorCooldownSeconds, newCfg.TransientErrorCooldownSeconds))
 	}
+	if oldCfg.QuotaCooldownFloorSeconds != newCfg.QuotaCooldownFloorSeconds {
+		changes = append(changes, fmt.Sprintf("quota-cooldown-floor-seconds: %d -> %d", oldCfg.QuotaCooldownFloorSeconds, newCfg.QuotaCooldownFloorSeconds))
+	}
+	if !reflect.DeepEqual(collapseTransientCooldownByStatus(oldCfg.TransientCooldownByStatus), collapseTransientCooldownByStatus(newCfg.TransientCooldownByStatus)) {
+		changes = append(changes, fmt.Sprintf("transient-cooldown-by-status: %d rules -> %d rules", len(oldCfg.TransientCooldownByStatus), len(newCfg.TransientCooldownByStatus)))
+	}
 	if oldCfg.DisableClaudeCloakMode != newCfg.DisableClaudeCloakMode {
 		changes = append(changes, fmt.Sprintf("disable-claude-cloak-mode: %t -> %t", oldCfg.DisableClaudeCloakMode, newCfg.DisableClaudeCloakMode))
 	}
@@ -579,4 +585,12 @@ func formatURL(raw string) string {
 		return host
 	}
 	return scheme + "://" + host
+}
+
+func collapseTransientCooldownByStatus(rules []config.TransientCooldownByStatusRule) map[int]int {
+	m := make(map[int]int, len(rules))
+	for _, r := range rules {
+		m[r.Status] = r.CooldownSeconds
+	}
+	return m
 }

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -645,6 +645,30 @@ func TestBuildConfigChangeDetails_CountBranches(t *testing.T) {
 	expectContains(t, changes, "vertex-api-key count: 0 -> 1")
 }
 
+func TestBuildConfigChangeDetails_CooldownKnobs(t *testing.T) {
+	oldCfg := &config.Config{
+		TransientErrorCooldownSeconds: 0,
+		QuotaCooldownFloorSeconds:     1,
+		TransientCooldownByStatus: []config.TransientCooldownByStatusRule{
+			{Status: 408, CooldownSeconds: 2},
+			{Status: 503, CooldownSeconds: 10},
+		},
+	}
+	newCfg := &config.Config{
+		TransientErrorCooldownSeconds: 10,
+		QuotaCooldownFloorSeconds:     2,
+		TransientCooldownByStatus: []config.TransientCooldownByStatusRule{
+			{Status: 408, CooldownSeconds: 2},
+			{Status: 408, CooldownSeconds: 2},
+		},
+	}
+
+	changes := BuildConfigChangeDetails(oldCfg, newCfg)
+	expectContains(t, changes, "transient-error-cooldown-seconds: 0 -> 10")
+	expectContains(t, changes, "quota-cooldown-floor-seconds: 1 -> 2")
+	expectContains(t, changes, "transient-cooldown-by-status: 2 rules -> 2 rules")
+}
+
 func TestTrimStrings(t *testing.T) {
 	out := trimStrings([]string{" a ", "b", "  c"})
 	if len(out) != 3 || out[0] != "a" || out[1] != "b" || out[2] != "c" {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -54,6 +54,10 @@ type Result struct {
 	Success bool
 	// RetryAfter carries a provider supplied retry hint (e.g. 429 retryDelay).
 	RetryAfter *time.Duration
+	// TransientRateLimit marks a 429 the provider classified as a short-lived rate
+	// limit rather than an exhausted quota window. Such failures keep RetryAfter
+	// verbatim instead of being floored at the escalating quota cooldown ladder.
+	TransientRateLimit bool
 	// CredentialScope indicates that the failure affects the whole credential across models (e.g. Anthropic 5h/7d unified limits).
 	CredentialScope bool
 	// Error describes the failure when Success is false.

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -862,12 +862,23 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							var next time.Time
 							backoffLevel := state.Quota.BackoffLevel
 							if !disableCooling {
-								if result.RetryAfter != nil && (*result.RetryAfter <= 0 || result.TransientRateLimit) {
-									// Zero-delay retries and 429s the provider classified as a short-lived
-									// rate limit keep their hint verbatim: flooring them at the quota ladder
-									// would park a still-usable credential for up to the full ladder step.
+								switch {
+								case result.TransientRateLimit:
+									// A 429 the provider classified as a short-lived rate limit bypasses
+									// the quota ladder entirely: flooring a transient throttle at the
+									// escalating ladder would park a still-usable credential. With no
+									// parseable hint, fall back to the standard transient-error cooldown.
+									if result.RetryAfter != nil {
+										next = now.Add(*result.RetryAfter)
+									} else {
+										next = nextTransientErrorRetryAfter(now)
+									}
+								case result.RetryAfter != nil && *result.RetryAfter <= 0:
+									// Zero-delay retries keep their hint verbatim: flooring them at the
+									// quota ladder would park a still-usable credential for up to the
+									// full ladder step.
 									next = now.Add(*result.RetryAfter)
-								} else {
+								default:
 									next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
 									if result.RetryAfter != nil {
 										// An exhausted-quota hint can be sub-second even when the quota is gone
@@ -2026,12 +2037,22 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.Quota.Reason = "quota"
 		var next time.Time
 		if !disableCooling {
-			if retryAfter != nil && (*retryAfter <= 0 || transientRateLimit) {
-				// Zero-delay retries and 429s the provider classified as a short-lived rate
-				// limit keep their hint verbatim: flooring them at the quota ladder would park
-				// a still-usable credential for up to the full ladder step.
+			switch {
+			case transientRateLimit:
+				// A 429 the provider classified as a short-lived rate limit bypasses the
+				// quota ladder entirely: flooring a transient throttle at the escalating
+				// ladder would park a still-usable credential. With no parseable hint,
+				// fall back to the standard transient-error cooldown.
+				if retryAfter != nil {
+					next = now.Add(*retryAfter)
+				} else {
+					next = nextTransientErrorRetryAfter(now)
+				}
+			case retryAfter != nil && *retryAfter <= 0:
+				// Zero-delay retries keep their hint verbatim: flooring them at the quota
+				// ladder would park a still-usable credential for up to the full ladder step.
 				next = now.Add(*retryAfter)
-			} else {
+			default:
 				next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now)
 				if retryAfter != nil {
 					// An exhausted-quota hint can be sub-second even when the quota is gone for

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1954,6 +1954,8 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	if shouldSkipCredentialCooldown(resultErr) {
 		return
 	}
+	prevUnavailable := auth.Unavailable
+	prevNextRetry := auth.NextRetryAfter
 	defer func() {
 		if disableCooling && auth.NextRetryAfter.IsZero() && auth.Quota.NextRecoverAt.IsZero() {
 			auth.Unavailable = false
@@ -2087,6 +2089,8 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			auth.StatusMessage = prevStatusMessage
 			auth.Quota.Exceeded = prevExceeded
 			auth.Quota.Reason = prevReason
+			auth.Unavailable = prevUnavailable
+			auth.NextRetryAfter = prevNextRetry
 			break
 		}
 		auth.Quota.NextRecoverAt = next

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -862,13 +862,16 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							var next time.Time
 							backoffLevel := state.Quota.BackoffLevel
 							if !disableCooling {
-								if result.RetryAfter != nil && *result.RetryAfter <= 0 {
+								if result.RetryAfter != nil && (*result.RetryAfter <= 0 || result.TransientRateLimit) {
+									// Zero-delay retries and 429s the provider classified as a short-lived
+									// rate limit keep their hint verbatim: flooring them at the quota ladder
+									// would park a still-usable credential for up to the full ladder step.
 									next = now.Add(*result.RetryAfter)
 								} else {
 									next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
 									if result.RetryAfter != nil {
-										// A provider hint can be sub-second even when the quota is exhausted for
-										// the whole day, so never let it undercut the escalating quota ladder.
+										// An exhausted-quota hint can be sub-second even when the quota is gone
+										// for the whole day, so never let it undercut the escalating ladder.
 										if hinted := now.Add(*result.RetryAfter); hinted.After(next) {
 											next = hinted
 										}
@@ -944,7 +947,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				if result.Error != nil && result.Error.Code == ErrorCodeForceCooldown {
 					disableCooling = false
 				}
-				applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling)
+				applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling, result.TransientRateLimit)
 			}
 		}
 
@@ -1503,6 +1506,19 @@ func retryAfterFromError(err error) *time.Duration {
 	return &value
 }
 
+// isTransientRateLimitError reports whether the executor classified the failure
+// as a short-lived provider rate limit rather than an exhausted quota window.
+func isTransientRateLimitError(err error) bool {
+	if err == nil {
+		return false
+	}
+	type transientRateLimitProvider interface {
+		TransientRateLimit() bool
+	}
+	var trp transientRateLimitProvider
+	return errors.As(err, &trp) && trp != nil && trp.TransientRateLimit()
+}
+
 func isCredentialScopedError(err error) bool {
 	if err == nil {
 		return false
@@ -1910,7 +1926,7 @@ func isRequestInvalidError(err error) bool {
 	return false
 }
 
-func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time, disableCooling bool) {
+func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time, disableCooling bool, transientRateLimit bool) {
 	if auth == nil {
 		return
 	}
@@ -2010,13 +2026,16 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.Quota.Reason = "quota"
 		var next time.Time
 		if !disableCooling {
-			if retryAfter != nil && *retryAfter <= 0 {
+			if retryAfter != nil && (*retryAfter <= 0 || transientRateLimit) {
+				// Zero-delay retries and 429s the provider classified as a short-lived rate
+				// limit keep their hint verbatim: flooring them at the quota ladder would park
+				// a still-usable credential for up to the full ladder step.
 				next = now.Add(*retryAfter)
 			} else {
 				next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now)
 				if retryAfter != nil {
-					// A provider hint can be sub-second even when the quota is exhausted for the
-					// whole day, so never let it undercut the escalating quota ladder.
+					// An exhausted-quota hint can be sub-second even when the quota is gone for
+					// the whole day, so never let it undercut the escalating quota ladder.
 					if hinted := now.Add(*retryAfter); hinted.After(next) {
 						next = hinted
 					}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -39,9 +39,13 @@ func SetTransientErrorCooldownSeconds(seconds int) {
 
 // SetQuotaCooldownFloorSeconds sets the minimum base for the quota cooldown ladder.
 // Sub-second Retry-After hints are never allowed below this floor. Default 1 second.
+// Values above 1800 (30 minutes) are clamped to 1800 because the ladder is capped at quotaBackoffMax.
 func SetQuotaCooldownFloorSeconds(seconds int) {
 	if seconds <= 0 {
 		seconds = 1
+	}
+	if maxSeconds := int(quotaBackoffMax / time.Second); seconds > maxSeconds {
+		seconds = maxSeconds
 	}
 	quotaCooldownFloorSeconds.Store(int64(seconds))
 }

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -861,6 +861,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						case 429:
 							var next time.Time
 							backoffLevel := state.Quota.BackoffLevel
+							transientCooldownOff := false
 							if !disableCooling {
 								switch {
 								case result.TransientRateLimit:
@@ -873,6 +874,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 									} else {
 										next = nextTransientErrorRetryAfter(now)
 									}
+									transientCooldownOff = next.IsZero()
 								case result.RetryAfter != nil && *result.RetryAfter <= 0:
 									// Zero-delay retries keep their hint verbatim: flooring them at the
 									// quota ladder would park a still-usable credential for up to the
@@ -891,6 +893,14 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								if state.Quota.Exceeded && state.Quota.NextRecoverAt.After(next) {
 									next = state.Quota.NextRecoverAt
 								}
+							}
+							if transientCooldownOff && !state.Quota.Exceeded {
+								// Transient cooldowns are disabled for this auth: keep the model
+								// available instead of recording a zero-time quota block. A
+								// pre-existing quota block is left untouched.
+								state.Unavailable = false
+								state.NextRetryAfter = time.Time{}
+								break
 							}
 							state.NextRetryAfter = next
 							state.Quota = QuotaState{
@@ -2032,10 +2042,13 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			auth.NextRetryAfter = now.Add(12 * time.Hour)
 		}
 	case 429:
+		prevStatusMessage := auth.StatusMessage
+		prevExceeded, prevReason := auth.Quota.Exceeded, auth.Quota.Reason
 		auth.StatusMessage = "quota exhausted"
 		auth.Quota.Exceeded = true
 		auth.Quota.Reason = "quota"
 		var next time.Time
+		transientCooldownOff := false
 		if !disableCooling {
 			switch {
 			case transientRateLimit:
@@ -2048,6 +2061,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 				} else {
 					next = nextTransientErrorRetryAfter(now)
 				}
+				transientCooldownOff = next.IsZero()
 			case retryAfter != nil && *retryAfter <= 0:
 				// Zero-delay retries keep their hint verbatim: flooring them at the quota
 				// ladder would park a still-usable credential for up to the full ladder step.
@@ -2065,6 +2079,15 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			if auth.Quota.Exceeded && auth.Quota.NextRecoverAt.After(next) {
 				next = auth.Quota.NextRecoverAt
 			}
+		}
+		if transientCooldownOff && !prevExceeded {
+			// Transient cooldowns are disabled: keep the credential available
+			// instead of recording a zero-time quota block. A pre-existing quota
+			// block is left untouched.
+			auth.StatusMessage = prevStatusMessage
+			auth.Quota.Exceeded = prevExceeded
+			auth.Quota.Reason = prevReason
+			break
 		}
 		auth.Quota.NextRecoverAt = next
 		auth.NextRetryAfter = next

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -23,6 +23,8 @@ import (
 var quotaCooldownDisabled atomic.Bool
 
 var transientErrorCooldownSeconds atomic.Int64
+var quotaCooldownFloorSeconds atomic.Int64
+var transientCooldownByStatus atomic.Value
 
 // SetQuotaCooldownDisabled toggles auth/model cooldown scheduling globally.
 func SetQuotaCooldownDisabled(disable bool) {
@@ -33,6 +35,37 @@ func SetQuotaCooldownDisabled(disable bool) {
 // 0 keeps the legacy default; negative values disable transient error cooldowns.
 func SetTransientErrorCooldownSeconds(seconds int) {
 	transientErrorCooldownSeconds.Store(int64(seconds))
+}
+
+// SetQuotaCooldownFloorSeconds sets the minimum base for the quota cooldown ladder.
+// Sub-second Retry-After hints are never allowed below this floor. Default 1 second.
+func SetQuotaCooldownFloorSeconds(seconds int) {
+	if seconds <= 0 {
+		seconds = 1
+	}
+	quotaCooldownFloorSeconds.Store(int64(seconds))
+}
+
+// SetTransientCooldownByStatus configures per-status transient cooldown overrides.
+// Statuses missing from the map fall back to SetTransientErrorCooldownSeconds.
+func SetTransientCooldownByStatus(rules []internalconfig.TransientCooldownByStatusRule) {
+	m := make(map[int]int, len(rules))
+	for _, r := range rules {
+		m[r.Status] = r.CooldownSeconds
+	}
+	transientCooldownByStatus.Store(m)
+}
+
+func transientCooldownSecondsForStatus(status int) int {
+	v := transientCooldownByStatus.Load()
+	if v == nil {
+		return 0
+	}
+	m, ok := v.(map[int]int)
+	if !ok {
+		return 0
+	}
+	return m[status]
 }
 
 func quotaCooldownDisabledForAuth(auth *Auth) bool {
@@ -85,8 +118,11 @@ func providerCoolingOverrideForAuth(auth *Auth, cfg *internalconfig.Config) (boo
 	return *entry.DisableCooling, true
 }
 
-func nextTransientErrorRetryAfter(now time.Time) time.Time {
+func nextTransientErrorRetryAfter(now time.Time, status int) time.Time {
 	seconds := transientErrorCooldownSeconds.Load()
+	if perStatus := transientCooldownSecondsForStatus(status); perStatus != 0 {
+		seconds = int64(perStatus)
+	}
 	if seconds < 0 {
 		return time.Time{}
 	}
@@ -96,11 +132,11 @@ func nextTransientErrorRetryAfter(now time.Time) time.Time {
 	return now.Add(time.Duration(seconds) * time.Second)
 }
 
-func recoverableFailureRetryAfter(now time.Time, disableCooling bool) time.Time {
+func recoverableFailureRetryAfter(now time.Time, status int, disableCooling bool) time.Time {
 	if disableCooling {
 		return time.Time{}
 	}
-	return nextTransientErrorRetryAfter(now)
+	return nextTransientErrorRetryAfter(now, status)
 }
 
 // SetConfig updates the runtime config snapshot used by request-time helpers.
@@ -872,7 +908,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 									if result.RetryAfter != nil {
 										next = now.Add(*result.RetryAfter)
 									} else {
-										next = nextTransientErrorRetryAfter(now)
+										next = nextTransientErrorRetryAfter(now, statusCode)
 									}
 									transientCooldownOff = next.IsZero()
 								case result.RetryAfter != nil && *result.RetryAfter <= 0:
@@ -943,10 +979,10 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								auth.NextRetryAfter = authNext
 							}
 						case 408, 500, 502, 503, 504:
-							state.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+							state.NextRetryAfter = recoverableFailureRetryAfter(now, statusCode, disableCooling)
 							state.Unavailable = !state.NextRetryAfter.IsZero()
 						default:
-							state.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+							state.NextRetryAfter = recoverableFailureRetryAfter(now, statusCode, disableCooling)
 							state.Unavailable = !state.NextRetryAfter.IsZero()
 						}
 					}
@@ -2061,7 +2097,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 				if retryAfter != nil {
 					next = now.Add(*retryAfter)
 				} else {
-					next = nextTransientErrorRetryAfter(now)
+					next = nextTransientErrorRetryAfter(now, statusCode)
 				}
 				transientCooldownOff = next.IsZero()
 			case retryAfter != nil && *retryAfter <= 0:
@@ -2097,13 +2133,13 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.NextRetryAfter = next
 	case 408, 500, 502, 503, 504:
 		auth.StatusMessage = "transient upstream error"
-		auth.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+		auth.NextRetryAfter = recoverableFailureRetryAfter(now, statusCode, disableCooling)
 		auth.Unavailable = !auth.NextRetryAfter.IsZero()
 	default:
 		if auth.StatusMessage == "" {
 			auth.StatusMessage = "request failed"
 		}
-		auth.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+		auth.NextRetryAfter = recoverableFailureRetryAfter(now, statusCode, disableCooling)
 		auth.Unavailable = !auth.NextRetryAfter.IsZero()
 	}
 	if resultErr != nil && resultErr.Code == ErrorCodeForceCooldown && auth.NextRetryAfter.IsZero() {
@@ -2137,9 +2173,13 @@ func nextQuotaCooldown(prevLevel int, disableCooling bool) (time.Duration, int) 
 	if disableCooling {
 		return 0, prevLevel
 	}
-	cooldown := quotaBackoffBase * time.Duration(1<<prevLevel)
-	if cooldown < quotaBackoffBase {
-		cooldown = quotaBackoffBase
+	base := time.Duration(quotaCooldownFloorSeconds.Load()) * time.Second
+	if base <= 0 {
+		base = quotaBackoffBase
+	}
+	cooldown := base * time.Duration(1<<prevLevel)
+	if cooldown < base {
+		cooldown = base
 	}
 	if cooldown >= quotaBackoffMax {
 		return quotaBackoffMax, prevLevel

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -862,12 +862,16 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							var next time.Time
 							backoffLevel := state.Quota.BackoffLevel
 							if !disableCooling {
-								next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
-								if result.RetryAfter != nil {
-									// A provider hint can be sub-second even when the quota is exhausted for
-									// the whole day, so never let it undercut the escalating quota ladder.
-									if hinted := now.Add(*result.RetryAfter); hinted.After(next) {
-										next = hinted
+								if result.RetryAfter != nil && *result.RetryAfter <= 0 {
+									next = now.Add(*result.RetryAfter)
+								} else {
+									next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
+									if result.RetryAfter != nil {
+										// A provider hint can be sub-second even when the quota is exhausted for
+										// the whole day, so never let it undercut the escalating quota ladder.
+										if hinted := now.Add(*result.RetryAfter); hinted.After(next) {
+											next = hinted
+										}
 									}
 								}
 								if state.Quota.Exceeded && state.Quota.NextRecoverAt.After(next) {
@@ -2006,12 +2010,16 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.Quota.Reason = "quota"
 		var next time.Time
 		if !disableCooling {
-			next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now)
-			if retryAfter != nil {
-				// A provider hint can be sub-second even when the quota is exhausted for the
-				// whole day, so never let it undercut the escalating quota ladder.
-				if hinted := now.Add(*retryAfter); hinted.After(next) {
-					next = hinted
+			if retryAfter != nil && *retryAfter <= 0 {
+				next = now.Add(*retryAfter)
+			} else {
+				next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now)
+				if retryAfter != nil {
+					// A provider hint can be sub-second even when the quota is exhausted for the
+					// whole day, so never let it undercut the escalating quota ladder.
+					if hinted := now.Add(*retryAfter); hinted.After(next) {
+						next = hinted
+					}
 				}
 			}
 			if auth.Quota.Exceeded && auth.Quota.NextRecoverAt.After(next) {

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -862,10 +862,13 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							var next time.Time
 							backoffLevel := state.Quota.BackoffLevel
 							if !disableCooling {
+								next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
 								if result.RetryAfter != nil {
-									next = now.Add(*result.RetryAfter)
-								} else {
-									next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
+									// A provider hint can be sub-second even when the quota is exhausted for
+									// the whole day, so never let it undercut the escalating quota ladder.
+									if hinted := now.Add(*result.RetryAfter); hinted.After(next) {
+										next = hinted
+									}
 								}
 								if state.Quota.Exceeded && state.Quota.NextRecoverAt.After(next) {
 									next = state.Quota.NextRecoverAt
@@ -2003,10 +2006,13 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.Quota.Reason = "quota"
 		var next time.Time
 		if !disableCooling {
+			next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now)
 			if retryAfter != nil {
-				next = now.Add(*retryAfter)
-			} else {
-				next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now)
+				// A provider hint can be sub-second even when the quota is exhausted for the
+				// whole day, so never let it undercut the escalating quota ladder.
+				if hinted := now.Add(*retryAfter); hinted.After(next) {
+					next = hinted
+				}
 			}
 			if auth.Quota.Exceeded && auth.Quota.NextRecoverAt.After(next) {
 				next = auth.Quota.NextRecoverAt

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -433,6 +433,9 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
 				}
+				if isTransientRateLimitError(errExec) {
+					result.TransientRateLimit = true
+				}
 				if isCredentialScopedError(errExec) {
 					result.CredentialScope = true
 				}
@@ -600,6 +603,9 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
+				}
+				if isTransientRateLimitError(errExec) {
+					result.TransientRateLimit = true
 				}
 				action, okAction := matchRequestScopedErrorAction(auth, errExec, m.runtimeConfigSnapshot())
 				applyRequestScopedActionToResult(action, okAction, &result)

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -1121,6 +1121,9 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
 				}
+				if isTransientRateLimitError(errExec) {
+					result.TransientRateLimit = true
+				}
 				if isCredentialScopedError(errExec) {
 					result.CredentialScope = true
 				}

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -192,6 +192,7 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			}
 			result.Error = resultErrorFromError(errExecute)
 			result.RetryAfter = retryAfterFromError(errExecute)
+			result.TransientRateLimit = isTransientRateLimitError(errExecute)
 			if isCredentialScopedError(errExecute) {
 				result.CredentialScope = true
 			}

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -951,6 +951,65 @@ func TestManager_MarkResult_TransientErrorCooldownDefault(t *testing.T) {
 	}
 }
 
+// A transient 429 without any parseable retry hint must bypass the quota
+// ladder on both the per-model and the credential level: it falls back to the
+// standard transient-error cooldown instead of parking a still-usable
+// credential on the escalating quota backoff.
+func TestManager_MarkResult_Transient429WithoutHintBypassesQuotaLadder(t *testing.T) {
+	prevQuota := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(0)
+	t.Cleanup(func() {
+		quotaCooldownDisabled.Store(prevQuota)
+		transientErrorCooldownSeconds.Store(prevTransient)
+	})
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-transient-429-nohint", Provider: "claude"}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	model := "test-model-transient-429-nohint"
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    model,
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: http.StatusTooManyRequests,
+			Message:    "rate limited",
+		},
+		TransientRateLimit: true,
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("auth %s missing after MarkResult", auth.ID)
+	}
+
+	if updated.Quota.BackoffLevel != 0 {
+		t.Fatalf("expected credential quota ladder to stay at level 0 for a transient 429 without hint, got %d", updated.Quota.BackoffLevel)
+	}
+	diff := time.Until(updated.NextRetryAfter)
+	if diff < 55*time.Second || diff > 65*time.Second {
+		t.Fatalf("expected credential NextRetryAfter ~60s transient cooldown, got %v", diff)
+	}
+
+	state := updated.ModelStates[model]
+	if state == nil || state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected per-model cooldown state for %s, got %+v", model, state)
+	}
+	if state.Quota.BackoffLevel != 0 {
+		t.Fatalf("expected per-model quota ladder to stay at level 0, got %d", state.Quota.BackoffLevel)
+	}
+	modelDiff := time.Until(state.NextRetryAfter)
+	if modelDiff < 55*time.Second || modelDiff > 65*time.Second {
+		t.Fatalf("expected per-model NextRetryAfter ~60s transient cooldown, got %v", modelDiff)
+	}
+}
+
 func TestManager_MarkResult_TransientErrorCooldownDisabled(t *testing.T) {
 	prevQuota := quotaCooldownDisabled.Load()
 	quotaCooldownDisabled.Store(false)

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -1071,6 +1071,51 @@ func TestManager_MarkResult_Transient429WithoutHintRespectsDisabledCooldown(t *t
 	}
 }
 
+// Same as TestManager_MarkResult_Transient429WithoutHintRespectsDisabledCooldown
+// but for an auth-level Result (empty Model), which drives applyAuthFailureState
+// instead of the per-model branch: the credential must stay available.
+func TestManager_MarkResult_Transient429WithoutHintRespectsDisabledCooldownAuthLevel(t *testing.T) {
+	prevQuota := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(-1)
+	t.Cleanup(func() {
+		quotaCooldownDisabled.Store(prevQuota)
+		transientErrorCooldownSeconds.Store(prevTransient)
+	})
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-transient-429-disabled-authlevel", Provider: "claude"}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: http.StatusTooManyRequests,
+			Message:    "rate limited",
+		},
+		TransientRateLimit: true,
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("auth %s missing after MarkResult", auth.ID)
+	}
+	if updated.Unavailable {
+		t.Fatal("expected the credential to stay available with transient cooldowns disabled")
+	}
+	if !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected credential NextRetryAfter to stay zero with transient cooldowns disabled, got %v", updated.NextRetryAfter)
+	}
+	if updated.Quota.Exceeded {
+		t.Fatal("expected the credential quota state to stay clear with transient cooldowns disabled")
+	}
+}
+
 func TestManager_MarkResult_TransientErrorCooldownDisabled(t *testing.T) {
 	prevQuota := quotaCooldownDisabled.Load()
 	quotaCooldownDisabled.Store(false)

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -1010,6 +1010,67 @@ func TestManager_MarkResult_Transient429WithoutHintBypassesQuotaLadder(t *testin
 	}
 }
 
+// With transient cooldowns disabled (transientErrorCooldownSeconds < 0) the
+// transient-429 fallback yields a zero retry time. That zero must not be
+// stored as state: an unavailable/quota-exceeded flag with an empty
+// NextRetryAfter would read as an indefinite block and hide the credential
+// forever.
+func TestManager_MarkResult_Transient429WithoutHintRespectsDisabledCooldown(t *testing.T) {
+	prevQuota := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	prevTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(-1)
+	t.Cleanup(func() {
+		quotaCooldownDisabled.Store(prevQuota)
+		transientErrorCooldownSeconds.Store(prevTransient)
+	})
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-transient-429-disabled", Provider: "claude"}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	model := "test-model-transient-429-disabled"
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    model,
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: http.StatusTooManyRequests,
+			Message:    "rate limited",
+		},
+		TransientRateLimit: true,
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("auth %s missing after MarkResult", auth.ID)
+	}
+
+	if !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected credential NextRetryAfter to stay zero with transient cooldowns disabled, got %v", updated.NextRetryAfter)
+	}
+	if updated.Quota.Exceeded {
+		t.Fatal("expected the credential quota state to stay clear with transient cooldowns disabled")
+	}
+
+	state := updated.ModelStates[model]
+	if state == nil {
+		t.Fatalf("expected per-model state for %s", model)
+	}
+	if state.Unavailable {
+		t.Fatal("expected the model to stay available with transient cooldowns disabled")
+	}
+	if !state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected per-model NextRetryAfter to stay zero, got %v", state.NextRetryAfter)
+	}
+	if state.Quota.Exceeded {
+		t.Fatal("expected the per-model quota state to stay clear with transient cooldowns disabled")
+	}
+}
+
 func TestManager_MarkResult_TransientErrorCooldownDisabled(t *testing.T) {
 	prevQuota := quotaCooldownDisabled.Load()
 	quotaCooldownDisabled.Store(false)

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -507,6 +507,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			action, okAction := matchRequestScopedErrorAction(auth, errStream, m.runtimeConfigSnapshot())
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr, Options: execOpts}
 			result.RetryAfter = retryAfterFromError(errStream)
+			result.TransientRateLimit = isTransientRateLimitError(errStream)
 			if isCredentialScopedError(errStream) {
 				result.CredentialScope = true
 			}
@@ -609,6 +610,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				rerr := resultErrorFromError(bootstrapErr)
 				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
+				result.TransientRateLimit = isTransientRateLimitError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
 				}
@@ -628,6 +630,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				rerr := resultErrorFromError(bootstrapErr)
 				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
+				result.TransientRateLimit = isTransientRateLimitError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
 				}
@@ -639,6 +642,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				rerr := resultErrorFromError(bootstrapErr)
 				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr, Options: execOpts}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
+				result.TransientRateLimit = isTransientRateLimitError(bootstrapErr)
 				if isCredentialScopedError(bootstrapErr) {
 					result.CredentialScope = true
 				}
@@ -653,6 +657,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			rerr := resultErrorFromError(bootstrapErr)
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr, Options: execOpts}
 			result.RetryAfter = retryAfterFromError(bootstrapErr)
+			result.TransientRateLimit = isTransientRateLimitError(bootstrapErr)
 			if isCredentialScopedError(bootstrapErr) {
 				result.CredentialScope = true
 			}

--- a/sdk/cliproxy/auth/conductor_stream_classification_test.go
+++ b/sdk/cliproxy/auth/conductor_stream_classification_test.go
@@ -1,0 +1,59 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type streamTransientRateLimitError struct {
+	retryAfter time.Duration
+}
+
+func (e streamTransientRateLimitError) Error() string            { return "429 rate limited" }
+func (e streamTransientRateLimitError) StatusCode() int          { return http.StatusTooManyRequests }
+func (e streamTransientRateLimitError) TransientRateLimit() bool { return true }
+
+func (e streamTransientRateLimitError) RetryAfter() *time.Duration {
+	hint := e.retryAfter
+	return &hint
+}
+
+// TestExecuteStreamKeepsProviderHintForTransientRateLimit covers the streaming
+// failure path: the provider classification must reach MarkResult, otherwise a
+// still-usable credential is parked at the quota ladder step.
+func TestExecuteStreamKeepsProviderHintForTransientRateLimit(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+
+	hint := time.Duration(observedExhaustedQuotaHint)
+	executor := &claudeCancellationTestExecutor{
+		streamFn: func(context.Context, *Auth) (*cliproxyexecutor.StreamResult, error) {
+			return nil, streamTransientRateLimitError{retryAfter: hint}
+		},
+	}
+	manager, auth, model := newClaudeCancellationTestManager(t, executor, nil)
+
+	before := time.Now()
+	_, errStream := manager.ExecuteStream(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{Stream: true})
+	if errStream == nil {
+		t.Fatal("expected the stream request to fail with the upstream 429")
+	}
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("GetByID(%q) did not return auth", auth.ID)
+	}
+	state := updated.ModelStates[model]
+	if state == nil {
+		t.Fatalf("expected model state for %q after the failure", model)
+	}
+	if state.Quota.BackoffLevel != 0 {
+		t.Fatalf("expected BackoffLevel to stay 0 for a transient rate limit, got %d", state.Quota.BackoffLevel)
+	}
+	if ceiling := before.Add(hint + time.Second); state.Quota.NextRecoverAt.After(ceiling) {
+		t.Fatalf("transient stream rate limit was floored at the quota ladder: NextRecoverAt=%v, want <= %v", state.Quota.NextRecoverAt, ceiling)
+	}
+}

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -117,7 +119,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	quotaErr := &Error{Code: "rate_limit", Message: "quota", HTTPStatus: http.StatusTooManyRequests}
 	auth := &Auth{ID: "auth-level-quota"}
 
-	applyAuthFailureState(auth, quotaErr, nil, now, false)
+	applyAuthFailureState(auth, quotaErr, nil, now, false, false)
 	if auth.Quota.BackoffLevel != 1 {
 		t.Fatalf("expected BackoffLevel 1 after first failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -127,7 +129,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	}
 
 	// In-window failure keeps the current window and level.
-	applyAuthFailureState(auth, quotaErr, nil, now.Add(100*time.Millisecond), false)
+	applyAuthFailureState(auth, quotaErr, nil, now.Add(100*time.Millisecond), false, false)
 	if auth.Quota.BackoffLevel != 1 {
 		t.Fatalf("expected BackoffLevel to stay 1 for in-window failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -136,7 +138,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	}
 
 	// A failure after the window expired escalates to the next level.
-	applyAuthFailureState(auth, quotaErr, nil, now.Add(2*time.Second), false)
+	applyAuthFailureState(auth, quotaErr, nil, now.Add(2*time.Second), false, false)
 	if auth.Quota.BackoffLevel != 2 {
 		t.Fatalf("expected BackoffLevel 2 after post-window failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -146,7 +148,7 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 
 	// A provider supplied retry hint always takes effect, even in-window.
 	retryAfter := 10 * time.Second
-	applyAuthFailureState(auth, quotaErr, &retryAfter, now.Add(3*time.Second), false)
+	applyAuthFailureState(auth, quotaErr, &retryAfter, now.Add(3*time.Second), false, false)
 	if auth.Quota.BackoffLevel != 2 {
 		t.Fatalf("expected BackoffLevel to stay 2 with retry hint, got %d", auth.Quota.BackoffLevel)
 	}
@@ -367,7 +369,7 @@ func TestApplyAuthFailureStateSubSecondQuotaHintStillEscalates(t *testing.T) {
 	hint := observedExhaustedQuotaHint
 	auth := &Auth{ID: "auth-subsecond-hint"}
 
-	applyAuthFailureState(auth, quotaErr, &hint, now, false)
+	applyAuthFailureState(auth, quotaErr, &hint, now, false, false)
 	if auth.Quota.BackoffLevel != 1 {
 		t.Fatalf("expected BackoffLevel 1 after the first hinted failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -378,7 +380,7 @@ func TestApplyAuthFailureStateSubSecondQuotaHintStillEscalates(t *testing.T) {
 	// A later failure, once the first window has closed, must climb the ladder even
 	// though the provider keeps repeating the same sub-second hint.
 	after := now.Add(20 * time.Second)
-	applyAuthFailureState(auth, quotaErr, &hint, after, false)
+	applyAuthFailureState(auth, quotaErr, &hint, after, false, false)
 	if auth.Quota.BackoffLevel != 2 {
 		t.Fatalf("expected BackoffLevel 2 after the repeated hinted failure, got %d", auth.Quota.BackoffLevel)
 	}
@@ -432,7 +434,7 @@ func TestApplyAuthFailureStateZeroRetryAfterDoesNotApplyLadderFloor(t *testing.T
 	zeroHint := time.Duration(0)
 	auth := &Auth{ID: "auth-zero-hint"}
 
-	applyAuthFailureState(auth, err, &zeroHint, now, false)
+	applyAuthFailureState(auth, err, &zeroHint, now, false, false)
 	if auth.Quota.BackoffLevel != 0 {
 		t.Fatalf("expected BackoffLevel 0 for zero RetryAfter, got %d", auth.Quota.BackoffLevel)
 	}
@@ -441,5 +443,96 @@ func TestApplyAuthFailureStateZeroRetryAfterDoesNotApplyLadderFloor(t *testing.T
 	}
 	if auth.NextRetryAfter.After(now) {
 		t.Fatalf("expected NextRetryAfter not to receive ladder floor, NextRetryAfter=%v, want %v", auth.NextRetryAfter, now)
+	}
+}
+
+func TestMarkResultTransientRateLimitKeepsProviderHint(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "auth-transient-rate-limit",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex"},
+		ModelStates: map[string]*ModelState{
+			"gpt-5": {
+				Status: StatusActive,
+				Quota:  QuotaState{BackoffLevel: 0},
+			},
+		},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("Register returned error: %v", errRegister)
+	}
+
+	hint := observedExhaustedQuotaHint
+	result := quotaResult(auth.ID, "gpt-5")
+	result.RetryAfter = &hint
+	result.TransientRateLimit = true
+
+	before := time.Now()
+	manager.MarkResult(context.Background(), result)
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil || updated.ModelStates["gpt-5"] == nil {
+		t.Fatalf("expected model state after failure")
+	}
+	state := updated.ModelStates["gpt-5"]
+	if state.Quota.BackoffLevel != 0 {
+		t.Fatalf("expected BackoffLevel to stay 0 for a transient rate limit, got %d", state.Quota.BackoffLevel)
+	}
+	if ceiling := before.Add(hint + time.Second); state.Quota.NextRecoverAt.After(ceiling) {
+		t.Fatalf("transient rate limit was floored at the quota ladder: NextRecoverAt=%v, want <= %v", state.Quota.NextRecoverAt, ceiling)
+	}
+}
+
+func TestApplyAuthFailureStateTransientRateLimitKeepsProviderHint(t *testing.T) {
+	now := time.Now()
+	rateLimitErr := &Error{Code: "rate_limit", Message: "RATE_LIMIT_EXCEEDED", HTTPStatus: http.StatusTooManyRequests}
+	hint := observedExhaustedQuotaHint
+
+	transient := &Auth{ID: "auth-transient-hint"}
+	applyAuthFailureState(transient, rateLimitErr, &hint, now, false, true)
+	if transient.Quota.BackoffLevel != 0 {
+		t.Fatalf("expected BackoffLevel to stay 0 for a transient rate limit, got %d", transient.Quota.BackoffLevel)
+	}
+	if !transient.Quota.NextRecoverAt.Equal(now.Add(hint)) {
+		t.Fatalf("expected the transient hint to be honored verbatim at %v, got %v", now.Add(hint), transient.Quota.NextRecoverAt)
+	}
+	if !transient.NextRetryAfter.Equal(now.Add(hint)) {
+		t.Fatalf("expected NextRetryAfter to honor the transient hint at %v, got %v", now.Add(hint), transient.NextRetryAfter)
+	}
+
+	// The same sub-second hint on an exhausted quota must still be floored at the ladder.
+	exhausted := &Auth{ID: "auth-exhausted-hint"}
+	applyAuthFailureState(exhausted, rateLimitErr, &hint, now, false, false)
+	if exhausted.Quota.BackoffLevel != 1 {
+		t.Fatalf("expected BackoffLevel 1 for an exhausted-quota failure, got %d", exhausted.Quota.BackoffLevel)
+	}
+	if !exhausted.Quota.NextRecoverAt.Equal(now.Add(quotaBackoffBase)) {
+		t.Fatalf("expected the exhausted-quota hint to stay floored at %v, got %v", now.Add(quotaBackoffBase), exhausted.Quota.NextRecoverAt)
+	}
+}
+
+type classifiedRateLimitError struct {
+	transient bool
+}
+
+func (e classifiedRateLimitError) Error() string            { return "429 rate limited" }
+func (e classifiedRateLimitError) StatusCode() int          { return http.StatusTooManyRequests }
+func (e classifiedRateLimitError) TransientRateLimit() bool { return e.transient }
+
+func TestIsTransientRateLimitErrorDetectsWrappedProviderClassification(t *testing.T) {
+	if isTransientRateLimitError(nil) {
+		t.Fatal("expected a nil error not to be transient")
+	}
+	if isTransientRateLimitError(errors.New("boom")) {
+		t.Fatal("expected an unclassified error not to be transient")
+	}
+	if isTransientRateLimitError(classifiedRateLimitError{}) {
+		t.Fatal("expected an exhausted-quota classification not to be transient")
+	}
+	if !isTransientRateLimitError(fmt.Errorf("upstream: %w", classifiedRateLimitError{transient: true})) {
+		t.Fatal("expected a wrapped transient rate limit classification to be detected")
 	}
 }

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
@@ -534,5 +535,51 @@ func TestIsTransientRateLimitErrorDetectsWrappedProviderClassification(t *testin
 	}
 	if !isTransientRateLimitError(fmt.Errorf("upstream: %w", classifiedRateLimitError{transient: true})) {
 		t.Fatal("expected a wrapped transient rate limit classification to be detected")
+	}
+}
+
+func TestQuotaCooldownFloorSecondsConfiguresLadderBase(t *testing.T) {
+	prev := quotaCooldownFloorSeconds.Load()
+	quotaCooldownFloorSeconds.Store(5)
+	t.Cleanup(func() { quotaCooldownFloorSeconds.Store(prev) })
+
+	now := time.Now()
+	cooldown, level := nextQuotaCooldown(0, false)
+	if cooldown != 5*time.Second {
+		t.Fatalf("level 0 cooldown with floor 5 = %v, want 5s", cooldown)
+	}
+	if level != 1 {
+		t.Fatalf("level = %d, want 1", level)
+	}
+	if got := now.Add(cooldown).Sub(now); got != 5*time.Second {
+		t.Fatalf("effective wait = %v, want 5s", got)
+	}
+
+	cooldown, level = nextQuotaCooldown(1, false)
+	if cooldown != 10*time.Second {
+		t.Fatalf("level 1 cooldown with floor 5 = %v, want 10s", cooldown)
+	}
+}
+
+func TestNextTransientErrorRetryAfterRespectsPerStatusOverride(t *testing.T) {
+	prevGlobal := transientErrorCooldownSeconds.Load()
+	transientErrorCooldownSeconds.Store(10)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevGlobal) })
+
+	SetTransientCooldownByStatus([]internalconfig.TransientCooldownByStatusRule{
+		{Status: 408, CooldownSeconds: 2},
+		{Status: 503, CooldownSeconds: -1},
+	})
+	t.Cleanup(func() { SetTransientCooldownByStatus(nil) })
+
+	now := time.Now()
+	if got := nextTransientErrorRetryAfter(now, 408); got.Sub(now) != 2*time.Second {
+		t.Fatalf("status 408 cooldown = %v, want 2s", got.Sub(now))
+	}
+	if got := nextTransientErrorRetryAfter(now, 503); !got.IsZero() {
+		t.Fatalf("status 503 should be disabled, got %v", got)
+	}
+	if got := nextTransientErrorRetryAfter(now, 504); got.Sub(now) != 10*time.Second {
+		t.Fatalf("status 504 fallback cooldown = %v, want 10s", got.Sub(now))
 	}
 }

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -308,3 +308,81 @@ func TestJitteredCooldownWaitBounds(t *testing.T) {
 		t.Fatalf("expected sub-4ns wait to stay unchanged, got %v", got)
 	}
 }
+
+// Gemini and Antigravity answer an exhausted daily quota with a RetryInfo hint of
+// well under a second (see internal/runtime/executor/helps/json_retry_helpers.go).
+// Honouring such a hint verbatim returned dead credentials to the pool a few hundred
+// milliseconds later and pinned the backoff ladder at its current level forever, so
+// every request kept walking the whole exhausted pool before failing.
+const observedExhaustedQuotaHint = 479417207 * time.Nanosecond
+
+func TestMarkResultSubSecondQuotaHintStillEscalates(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+
+	expired := time.Now().Add(-time.Second)
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "auth-quota-subsecond-hint",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex"},
+		ModelStates: map[string]*ModelState{
+			"gpt-5": {
+				Status:         StatusError,
+				Unavailable:    true,
+				NextRetryAfter: expired,
+				Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: expired, BackoffLevel: 3},
+			},
+		},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("Register returned error: %v", errRegister)
+	}
+
+	hint := observedExhaustedQuotaHint
+	result := quotaResult(auth.ID, "gpt-5")
+	result.RetryAfter = &hint
+
+	before := time.Now()
+	manager.MarkResult(context.Background(), result)
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil || updated.ModelStates["gpt-5"] == nil {
+		t.Fatalf("expected model state after failure")
+	}
+	state := updated.ModelStates["gpt-5"]
+	if state.Quota.BackoffLevel != 4 {
+		t.Fatalf("expected BackoffLevel 4 after hinted post-window failure, got %d", state.Quota.BackoffLevel)
+	}
+	if !state.Quota.NextRecoverAt.After(before.Add(hint)) {
+		t.Fatalf("sub-second hint was not floored: window closes at %v, the hint alone would close it at %v", state.Quota.NextRecoverAt, before.Add(hint))
+	}
+	if got := state.Quota.NextRecoverAt.Sub(before); got < 8*quotaBackoffBase {
+		t.Fatalf("expected at least the level-3 ladder step (%v), got %v", 8*quotaBackoffBase, got)
+	}
+}
+
+func TestApplyAuthFailureStateSubSecondQuotaHintStillEscalates(t *testing.T) {
+	now := time.Now()
+	quotaErr := &Error{Code: "rate_limit", Message: "quota", HTTPStatus: http.StatusTooManyRequests}
+	hint := observedExhaustedQuotaHint
+	auth := &Auth{ID: "auth-subsecond-hint"}
+
+	applyAuthFailureState(auth, quotaErr, &hint, now, false)
+	if auth.Quota.BackoffLevel != 1 {
+		t.Fatalf("expected BackoffLevel 1 after the first hinted failure, got %d", auth.Quota.BackoffLevel)
+	}
+	if !auth.Quota.NextRecoverAt.Equal(now.Add(quotaBackoffBase)) {
+		t.Fatalf("expected the sub-second hint to be floored at %v, got %v", now.Add(quotaBackoffBase), auth.Quota.NextRecoverAt)
+	}
+
+	// A later failure, once the first window has closed, must climb the ladder even
+	// though the provider keeps repeating the same sub-second hint.
+	after := now.Add(20 * time.Second)
+	applyAuthFailureState(auth, quotaErr, &hint, after, false)
+	if auth.Quota.BackoffLevel != 2 {
+		t.Fatalf("expected BackoffLevel 2 after the repeated hinted failure, got %d", auth.Quota.BackoffLevel)
+	}
+	if !auth.Quota.NextRecoverAt.Equal(after.Add(2 * quotaBackoffBase)) {
+		t.Fatalf("expected the escalated window to close at %v, got %v", after.Add(2*quotaBackoffBase), auth.Quota.NextRecoverAt)
+	}
+}

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -561,6 +561,33 @@ func TestQuotaCooldownFloorSecondsConfiguresLadderBase(t *testing.T) {
 	}
 }
 
+func TestSetQuotaCooldownFloorSecondsClampsAndDefaults(t *testing.T) {
+	prev := quotaCooldownFloorSeconds.Load()
+	defer quotaCooldownFloorSeconds.Store(prev)
+
+	maxSeconds := int(quotaBackoffMax / time.Second)
+
+	SetQuotaCooldownFloorSeconds(0)
+	if got := quotaCooldownFloorSeconds.Load(); got != 1 {
+		t.Fatalf("SetQuotaCooldownFloorSeconds(0) stored %d, want 1", got)
+	}
+
+	SetQuotaCooldownFloorSeconds(-5)
+	if got := quotaCooldownFloorSeconds.Load(); got != 1 {
+		t.Fatalf("SetQuotaCooldownFloorSeconds(-5) stored %d, want 1", got)
+	}
+
+	SetQuotaCooldownFloorSeconds(5)
+	if got := quotaCooldownFloorSeconds.Load(); got != 5 {
+		t.Fatalf("SetQuotaCooldownFloorSeconds(5) stored %d, want 5", got)
+	}
+
+	SetQuotaCooldownFloorSeconds(maxSeconds + 1)
+	if got := quotaCooldownFloorSeconds.Load(); got != int64(maxSeconds) {
+		t.Fatalf("SetQuotaCooldownFloorSeconds(%d) stored %d, want %d", maxSeconds+1, got, maxSeconds)
+	}
+}
+
 func TestNextTransientErrorRetryAfterRespectsPerStatusOverride(t *testing.T) {
 	prevGlobal := transientErrorCooldownSeconds.Load()
 	transientErrorCooldownSeconds.Store(10)
@@ -581,5 +608,21 @@ func TestNextTransientErrorRetryAfterRespectsPerStatusOverride(t *testing.T) {
 	}
 	if got := nextTransientErrorRetryAfter(now, 504); got.Sub(now) != 10*time.Second {
 		t.Fatalf("status 504 fallback cooldown = %v, want 10s", got.Sub(now))
+	}
+}
+
+func TestNextTransientErrorRetryAfterPerStatusZeroFallsBackToGlobal(t *testing.T) {
+	prevGlobal := transientErrorCooldownSeconds.Load()
+	transientErrorCooldownSeconds.Store(10)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevGlobal) })
+
+	SetTransientCooldownByStatus([]internalconfig.TransientCooldownByStatusRule{
+		{Status: 503, CooldownSeconds: 0},
+	})
+	t.Cleanup(func() { SetTransientCooldownByStatus(nil) })
+
+	now := time.Now()
+	if got := nextTransientErrorRetryAfter(now, 503); got.Sub(now) != 10*time.Second {
+		t.Fatalf("status 503 with per-status 0 cooldown = %v, want 10s global fallback", got.Sub(now))
 	}
 }

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -386,3 +386,60 @@ func TestApplyAuthFailureStateSubSecondQuotaHintStillEscalates(t *testing.T) {
 		t.Fatalf("expected the escalated window to close at %v, got %v", after.Add(2*quotaBackoffBase), auth.Quota.NextRecoverAt)
 	}
 }
+
+func TestMarkResultZeroRetryAfterDoesNotApplyLadderFloor(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "auth-zero-retry-after",
+		Provider: "codex",
+		Metadata: map[string]any{"type": "codex"},
+		ModelStates: map[string]*ModelState{
+			"gpt-5": {
+				Status: StatusActive,
+				Quota:  QuotaState{BackoffLevel: 0},
+			},
+		},
+	}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("Register returned error: %v", errRegister)
+	}
+
+	zeroHint := time.Duration(0)
+	result := quotaResult(auth.ID, "gpt-5")
+	result.RetryAfter = &zeroHint
+
+	now := time.Now()
+	manager.MarkResult(context.Background(), result)
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil || updated.ModelStates["gpt-5"] == nil {
+		t.Fatalf("expected model state after failure")
+	}
+	state := updated.ModelStates["gpt-5"]
+	if state.Quota.BackoffLevel != 0 {
+		t.Fatalf("expected BackoffLevel to remain 0 for zero RetryAfter, got %d", state.Quota.BackoffLevel)
+	}
+	if state.Quota.NextRecoverAt.After(now.Add(500 * time.Millisecond)) {
+		t.Fatalf("zero RetryAfter was given ladder floor: NextRecoverAt=%v, want <= %v", state.Quota.NextRecoverAt, now)
+	}
+}
+
+func TestApplyAuthFailureStateZeroRetryAfterDoesNotApplyLadderFloor(t *testing.T) {
+	now := time.Now()
+	err := &Error{Code: "rate_limit", Message: "websocket_connection_limit_reached", HTTPStatus: http.StatusTooManyRequests}
+	zeroHint := time.Duration(0)
+	auth := &Auth{ID: "auth-zero-hint"}
+
+	applyAuthFailureState(auth, err, &zeroHint, now, false)
+	if auth.Quota.BackoffLevel != 0 {
+		t.Fatalf("expected BackoffLevel 0 for zero RetryAfter, got %d", auth.Quota.BackoffLevel)
+	}
+	if auth.Quota.NextRecoverAt.After(now) {
+		t.Fatalf("expected zero RetryAfter not to receive ladder floor, NextRecoverAt=%v, want %v", auth.Quota.NextRecoverAt, now)
+	}
+	if auth.NextRetryAfter.After(now) {
+		t.Fatalf("expected NextRetryAfter not to receive ladder floor, NextRetryAfter=%v, want %v", auth.NextRetryAfter, now)
+	}
+}

--- a/sdk/cliproxy/service_auth.go
+++ b/sdk/cliproxy/service_auth.go
@@ -362,6 +362,8 @@ func (s *Service) applyRetryConfig(cfg *config.Config) {
 	maxInterval := time.Duration(cfg.MaxRetryInterval) * time.Second
 	s.coreManager.SetRetryConfig(cfg.RequestRetry, maxInterval, cfg.MaxRetryCredentials)
 	coreauth.SetTransientErrorCooldownSeconds(cfg.TransientErrorCooldownSeconds)
+	coreauth.SetQuotaCooldownFloorSeconds(cfg.QuotaCooldownFloorSeconds)
+	coreauth.SetTransientCooldownByStatus(cfg.TransientCooldownByStatus)
 }
 
 func (s *Service) configureCooldownStateStore(cfg *config.Config) {


### PR DESCRIPTION
## Summary

Adds the first two missing knobs from `reports/recommended-config.md`:

- `quota-cooldown-floor-seconds` (default `1`): makes the quota-ladder base configurable, generalizing the hardcoded floor introduced in #198 / `router-for-me/CLIProxyAPI#5130`. Operators can now raise the floor for noisy providers without rebuilding.
- `transient-cooldown-by-status`: per-HTTP-status overrides for `408/500/502/503/504` cooldowns, falling back to `transient-error-cooldown-seconds` for any status not listed. This is the missing-knob companion to #205 / `router-for-me/CLIProxyAPI#5140`.

## Stacking

This branch is based on `warelik/fix/quota-backoff-hint-floor` (#198) because the new `quota-cooldown-floor-seconds` value is consumed inside the refactored `nextQuotaCooldown` path introduced there. It will remain a draft until #198 lands, or it can be reviewed as a stack.

## Changes

- `Config` gains `QuotaCooldownFloorSeconds` and `TransientCooldownByStatus`.
- `parse.go` and `config_load.go` default `QuotaCooldownFloorSeconds` to `1`.
- `sdk/cliproxy/auth/conductor_cooldown.go` loads the floor and per-status map at runtime; `nextQuotaCooldown` and `nextTransientErrorRetryAfter` use them.
- `service_auth.go`, `internal/api/server.go`, `internal/api/server_reload.go`, and `cmd/server/main.go` wire the new setters on startup and config reload.
- `config.example.yaml` documents both knobs and their relationship to #198/#205.
- Tests: `internal/config/cooldown_config_test.go` and two new cases in `sdk/cliproxy/auth/cooldown_backoff_test.go`.

## Cross-links

- Plus: #198 (quota ladder floor), #205 (lower transient cooldown default)
- Upstream: `router-for-me/CLIProxyAPI#5130` (quota ladder floor), `router-for-me/CLIProxyAPI#5140` (lower transient cooldown default)
- Stock counterpart issue to be filed next with the patch.

## Test plan

```bash
go build ./...
go test ./sdk/cliproxy/auth/... ./internal/config/...
```