### PR TITLE
test(cache): replay-alias provenance doctrines

### DIFF
--- a/internal/cache/claude_thinking_replay_cache.go
+++ b/internal/cache/claude_thinking_replay_cache.go
@@ -701,8 +701,11 @@ func registerClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThink
 
 // rollBackClaudeThinkingReplayAliasHome removes an alias value that was
 // committed but could not be added to the index, so it does not become an
-// unindexed, uncapped KV entry. The rollback only deletes the value when no
-// other worker has modified it and the alias is not currently indexed.
+// unindexed, uncapped KV entry. The rollback is conditional only on the
+// committed value: if the alias still contains the exact bytes we wrote, it is
+// an orphan and should be removed. The index is consulted only as a best-effort
+// guard when it is readable; a failing index read does not prevent rollback
+// because the failed registration is precisely what produced the orphan.
 func rollBackClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThinkingReplayKVClient, aliasKey, indexKey string, committedAliasRaw []byte) {
 	if len(committedAliasRaw) == 0 {
 		return
@@ -714,16 +717,23 @@ func rollBackClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThink
 	if !bytes.Equal(currentRaw, committedAliasRaw) {
 		return
 	}
+
+	// If we can confirm the alias is live in the index, another worker must
+	// have made it durable; leave it alone. If the index is unreadable, the
+	// value match is the authoritative condition.
 	indexRaw, _, errIndex := client.KVGet(ctx, indexKey)
-	if errIndex != nil {
-		return
-	}
-	index, _ := decodeClaudeThinkingReplayAliasIndex(indexRaw)
-	for _, a := range index.Aliases {
-		if a.AliasKey == aliasKey {
-			return
+	if errIndex == nil {
+		if index, ok := decodeClaudeThinkingReplayAliasIndex(indexRaw); ok {
+			for _, a := range index.Aliases {
+				if a.AliasKey == aliasKey {
+					return
+				}
+			}
 		}
+	} else {
+		log.Warnf("claude thinking replay alias rollback index check failed: %v", errIndex)
 	}
+
 	if _, errDel := client.KVDel(ctx, aliasKey); errDel != nil {
 		log.Warnf("claude thinking replay alias rollback failed: %v", errDel)
 	}

--- a/internal/cache/claude_thinking_replay_cache.go
+++ b/internal/cache/claude_thinking_replay_cache.go
@@ -622,7 +622,7 @@ func registerClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThink
 	}
 
 	// Maintain the per-credential index so old aliases can be evicted.
-	var evicted []string
+	var evicted []claudeThinkingReplayAliasIndexRecord
 	indexUpdated := false
 	for attempt := 0; attempt < 4; attempt++ {
 		indexRaw, indexFound, errIndex := client.KVGet(ctx, indexKey)
@@ -643,7 +643,7 @@ func registerClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThink
 				return index.Aliases[i].Timestamp.Before(index.Aliases[j].Timestamp)
 			})
 			for len(index.Aliases) > ClaudeThinkingReplayCacheMaxAliasesPerCredential {
-				evicted = append(evicted, index.Aliases[0].AliasKey)
+				evicted = append(evicted, index.Aliases[0])
 				index.Aliases = index.Aliases[1:]
 			}
 		}
@@ -676,9 +676,10 @@ func registerClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThink
 		return
 	}
 
-	// Only delete evicted alias values after the index CAS succeeds and a fresh
-	// read confirms the alias is still absent from the index. A concurrent
-	// worker may have re-registered an evicted alias after our CAS.
+	// Only delete evicted alias values after the index CAS succeeds and both the
+	// index and the alias value itself have been rechecked. A concurrent worker may
+	// have re-registered an evicted alias after our CAS; if the value has a session
+	// newer than the evicted index record we must not delete it.
 	currentIndexRaw, _, errCurrentIndex := client.KVGet(ctx, indexKey)
 	if errCurrentIndex != nil {
 		log.Warnf("claude thinking replay alias index re-read failed: %v", errCurrentIndex)
@@ -689,11 +690,15 @@ func registerClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThink
 	for _, a := range currentIndex.Aliases {
 		present[a.AliasKey] = struct{}{}
 	}
-	for _, key := range evicted {
-		if _, ok := present[key]; ok {
+	for _, rec := range evicted {
+		if _, ok := present[rec.AliasKey]; ok {
 			continue
 		}
-		if _, errDel := client.KVDel(ctx, key); errDel != nil {
+		raw, found, errAlias := client.KVGet(ctx, rec.AliasKey)
+		if errAlias == nil && found && claudeThinkingReplayAliasValueRepopulated(raw, rec.Timestamp) {
+			continue
+		}
+		if _, errDel := client.KVDel(ctx, rec.AliasKey); errDel != nil {
 			log.Warnf("claude thinking replay alias eviction failed: %v", errDel)
 		}
 	}
@@ -794,6 +799,24 @@ func claudeThinkingReplayAliasIndexUpsert(records []claudeThinkingReplayAliasInd
 		}
 	}
 	return append(records, claudeThinkingReplayAliasIndexRecord{AliasKey: aliasKey, Timestamp: now})
+}
+
+// claudeThinkingReplayAliasValueRepopulated reports whether an alias value has
+// been refreshed by a concurrent worker after the index record for that alias
+// was evicted. We compare the session timestamps in the value against the
+// evicted index record timestamp; a session newer than the evicted record means
+// a re-registration happened and the alias value must not be deleted.
+func claudeThinkingReplayAliasValueRepopulated(raw []byte, evictedTimestamp time.Time) bool {
+	var value claudeThinkingReplayAliasHomeValue
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return false
+	}
+	for _, s := range value.Sessions {
+		if s.Timestamp.After(evictedTimestamp) {
+			return true
+		}
+	}
+	return false
 }
 
 func claudeThinkingReplayAliasHomeValueUpsert(sessions []claudeThinkingReplayAliasHomeSession, sessionKey, firstUserHash string, now time.Time) []claudeThinkingReplayAliasHomeSession {

--- a/internal/cache/claude_thinking_replay_cache.go
+++ b/internal/cache/claude_thinking_replay_cache.go
@@ -415,12 +415,8 @@ func claudeThinkingReplayUpsertAliasLocked(key, sessionKey, firstUserHash string
 }
 
 func claudeThinkingReplayResolveBestAliasLocked(modelFamily string, messages []ClaudeThinkingReplayAliasMessage, requestFirstUserHash string, now time.Time) (string, bool) {
-	type candidate struct {
-		score  int
-		latest time.Time
-	}
 	const firstUserMatchBonus = 2
-	scores := make(map[string]candidate)
+	scores := make(map[string]int)
 	for _, m := range messages {
 		key := claudeThinkingReplayAliasKey(modelFamily, m.Hash)
 		list, ok := claudeThinkingReplayAliases[key]
@@ -431,26 +427,44 @@ func claudeThinkingReplayResolveBestAliasLocked(modelFamily string, messages []C
 			if now.Sub(entry.timestamp) > ClaudeThinkingReplayCacheTTL {
 				continue
 			}
-			c := scores[entry.sessionKey]
-			c.score += m.Weight
+			scores[entry.sessionKey] += m.Weight
 			if requestFirstUserHash != "" && entry.firstUserHash == requestFirstUserHash {
-				c.score += firstUserMatchBonus
+				scores[entry.sessionKey] += firstUserMatchBonus
 			}
-			if entry.timestamp.After(c.latest) {
-				c.latest = entry.timestamp
-			}
-			scores[entry.sessionKey] = c
 		}
 	}
-	var best string
-	var bestCand candidate
-	for session, c := range scores {
-		if c.score > bestCand.score || (c.score == bestCand.score && c.latest.After(bestCand.latest)) {
+	return claudeThinkingReplayResolveBestAlias(scores)
+}
+
+// claudeThinkingReplayResolveBestAlias returns the session with the highest
+// score. If multiple sessions tie for the highest score the result is
+// ambiguous, so it returns no match rather than risk restoring the wrong
+// conversation.
+func claudeThinkingReplayResolveBestAlias(scores map[string]int) (string, bool) {
+	if len(scores) == 0 {
+		return "", false
+	}
+	maxScore := 0
+	for _, s := range scores {
+		if s > maxScore {
+			maxScore = s
+		}
+	}
+	if maxScore <= 0 {
+		return "", false
+	}
+	best := ""
+	tied := 0
+	for session, s := range scores {
+		if s == maxScore {
 			best = session
-			bestCand = c
+			tied++
 		}
 	}
-	return best, best != ""
+	if tied > 1 {
+		return "", false
+	}
+	return best, true
 }
 
 func purgeExpiredClaudeThinkingReplayAliasesLocked(now time.Time) {
@@ -545,6 +559,50 @@ func registerClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThink
 	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
 	now := time.Now()
 
+	// Update the shared alias value atomically with compare-and-swap retries.
+	// Multiple sessionless conversations can register the same message hash
+	// concurrently, so an unconditional KVSet would let the last writer discard
+	// the others.
+	for attempt := 0; attempt < 4; attempt++ {
+		var value claudeThinkingReplayAliasHomeValue
+		raw, found, errGet := client.KVGet(ctx, aliasKey)
+		if errGet != nil {
+			log.Warnf("claude thinking replay alias read failed: %v", errGet)
+			return
+		}
+		if found {
+			if err := json.Unmarshal(raw, &value); err != nil {
+				log.Warnf("claude thinking replay alias unmarshal failed: %v", err)
+				value = claudeThinkingReplayAliasHomeValue{}
+			}
+		}
+		value.Sessions = claudeThinkingReplayAliasHomeValueUpsert(value.Sessions, sessionKey, firstUserHash, now)
+		if len(value.Sessions) > ClaudeThinkingReplayCacheMaxAliasesPerKey {
+			sort.Slice(value.Sessions, func(i, j int) bool {
+				return value.Sessions[i].Timestamp.Before(value.Sessions[j].Timestamp)
+			})
+			value.Sessions = value.Sessions[len(value.Sessions)-ClaudeThinkingReplayCacheMaxAliasesPerKey:]
+		}
+		newRaw, errMarshal := json.Marshal(value)
+		if errMarshal != nil {
+			log.Warnf("claude thinking replay alias marshal failed: %v", errMarshal)
+			return
+		}
+		swapped, errSwap := client.KVCompareAndSwap(ctx, aliasKey, raw, found, newRaw, ClaudeThinkingReplayCacheTTL)
+		if errSwap != nil {
+			log.Warnf("claude thinking replay alias cas failed: %v", errSwap)
+			return
+		}
+		if swapped {
+			break
+		}
+		if attempt == 3 {
+			log.Warnf("claude thinking replay alias cas exhausted after %d attempts", attempt+1)
+			return
+		}
+	}
+
+	// Maintain the per-credential index so old aliases can be evicted.
 	for attempt := 0; attempt < 4; attempt++ {
 		indexRaw, indexFound, errIndex := client.KVGet(ctx, indexKey)
 		if errIndex != nil {
@@ -587,43 +645,11 @@ func registerClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThink
 			return
 		}
 	}
-
-	var value claudeThinkingReplayAliasHomeValue
-	raw, found, errGet := client.KVGet(ctx, aliasKey)
-	if errGet != nil {
-		log.Warnf("claude thinking replay alias read failed: %v", errGet)
-		return
-	}
-	if found {
-		if err := json.Unmarshal(raw, &value); err != nil {
-			log.Warnf("claude thinking replay alias unmarshal failed: %v", errGet)
-			value = claudeThinkingReplayAliasHomeValue{}
-		}
-	}
-	value.Sessions = claudeThinkingReplayAliasHomeValueUpsert(value.Sessions, sessionKey, firstUserHash, now)
-	if len(value.Sessions) > ClaudeThinkingReplayCacheMaxAliasesPerKey {
-		sort.Slice(value.Sessions, func(i, j int) bool {
-			return value.Sessions[i].Timestamp.Before(value.Sessions[j].Timestamp)
-		})
-		value.Sessions = value.Sessions[len(value.Sessions)-ClaudeThinkingReplayCacheMaxAliasesPerKey:]
-	}
-	raw, errMarshal := json.Marshal(value)
-	if errMarshal != nil {
-		log.Warnf("claude thinking replay alias marshal failed: %v", errMarshal)
-		return
-	}
-	if _, errSet := client.KVSet(ctx, aliasKey, raw, homekv.KVSetOptions{EX: ClaudeThinkingReplayCacheTTL}); errSet != nil {
-		log.Warnf("claude thinking replay alias set failed: %v", errSet)
-	}
 }
 
 func resolveClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThinkingReplayKVClient, modelFamily string, messages []ClaudeThinkingReplayAliasMessage, requestFirstUserHash string) (string, bool) {
-	type candidate struct {
-		score  int
-		latest time.Time
-	}
 	const firstUserMatchBonus = 2
-	scores := make(map[string]candidate)
+	scores := make(map[string]int)
 	now := time.Now()
 	for _, m := range messages {
 		raw, found, err := client.KVGet(ctx, claudeThinkingReplayAliasKVKey(modelFamily, m.Hash))
@@ -638,26 +664,13 @@ func resolveClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThinki
 			if now.Sub(s.Timestamp) > ClaudeThinkingReplayCacheTTL {
 				continue
 			}
-			c := scores[s.SessionKey]
-			c.score += m.Weight
+			scores[s.SessionKey] += m.Weight
 			if requestFirstUserHash != "" && s.FirstUserHash == requestFirstUserHash {
-				c.score += firstUserMatchBonus
+				scores[s.SessionKey] += firstUserMatchBonus
 			}
-			if s.Timestamp.After(c.latest) {
-				c.latest = s.Timestamp
-			}
-			scores[s.SessionKey] = c
 		}
 	}
-	var best string
-	var bestCand candidate
-	for session, c := range scores {
-		if c.score > bestCand.score || (c.score == bestCand.score && c.latest.After(bestCand.latest)) {
-			best = session
-			bestCand = c
-		}
-	}
-	return best, best != ""
+	return claudeThinkingReplayResolveBestAlias(scores)
 }
 
 func decodeClaudeThinkingReplayAliasIndex(raw []byte) (claudeThinkingReplayAliasIndex, bool) {

--- a/internal/cache/claude_thinking_replay_cache.go
+++ b/internal/cache/claude_thinking_replay_cache.go
@@ -38,6 +38,10 @@ const (
 	// ClaudeThinkingReplayCacheMaxTotalBytes bounds aggregate in-process Claude replay content.
 	ClaudeThinkingReplayCacheMaxTotalBytes = 256 << 20
 
+	// ClaudeThinkingReplayCacheMaxAliases bounds the number of message-to-scope
+	// aliases kept in the local fallback map.
+	ClaudeThinkingReplayCacheMaxAliases = 102400
+
 	claudeThinkingReplayCacheMaxSerializedBytes = ClaudeThinkingReplayCacheMaxBytesPerSession + 1024
 )
 
@@ -67,8 +71,14 @@ var (
 	// conversation-scoped session key that first saw it. This lets sessionless
 	// clients compact history without orphaning the replay cache: the first
 	// remaining message in a truncated request can resolve the original scope.
-	claudeThinkingReplayAliases = make(map[string]string)
+	claudeThinkingReplayAliases    = make(map[string]claudeThinkingReplayAliasEntry)
+	claudeThinkingReplayAliasBytes int
 )
+
+type claudeThinkingReplayAliasEntry struct {
+	sessionKey string
+	timestamp  time.Time
+}
 
 var currentClaudeThinkingReplayKVClient = func() (kimiThinkingReplayKVClient, bool, error) {
 	return homekv.CurrentKVClient()
@@ -290,42 +300,130 @@ func ClearClaudeThinkingReplayCache() {
 	claudeThinkingReplayMu.Unlock()
 
 	claudeThinkingReplayAliasMu.Lock()
-	claudeThinkingReplayAliases = make(map[string]string)
+	claudeThinkingReplayAliases = make(map[string]claudeThinkingReplayAliasEntry)
+	claudeThinkingReplayAliasBytes = 0
 	claudeThinkingReplayAliasMu.Unlock()
 }
 
 // RegisterClaudeThinkingReplayAlias records that a request message belongs to a
 // specific conversation scope. Compacted requests can later resolve the same
-// scope through one of their remaining messages.
-func RegisterClaudeThinkingReplayAlias(modelFamily, sessionKey, messageHash string) {
+// scope through one of their remaining messages. In Home KV mode the alias is
+// stored as a separate KV entry so different instances can resolve it.
+func RegisterClaudeThinkingReplayAlias(ctx context.Context, modelFamily, sessionKey, messageHash string) {
 	if modelFamily == "" || sessionKey == "" || messageHash == "" {
 		return
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	client, homeMode, errClient := currentClaudeThinkingReplayKVClient()
+	if homeMode {
+		if errClient != nil {
+			return
+		}
+		_, _ = client.KVSet(ctx, claudeThinkingReplayAliasKVKey(modelFamily, messageHash), []byte(sessionKey), homekv.KVSetOptions{EX: ClaudeThinkingReplayCacheTTL})
+		return
+	}
+
 	key := claudeThinkingReplayAliasKey(modelFamily, messageHash)
 	claudeThinkingReplayAliasMu.Lock()
 	defer claudeThinkingReplayAliasMu.Unlock()
-	claudeThinkingReplayAliases[key] = sessionKey
+	now := time.Now()
+	purgeExpiredClaudeThinkingReplayAliasesLocked(now)
+	enforceClaudeThinkingReplayAliasLimitsLocked()
+	old, ok := claudeThinkingReplayAliases[key]
+	if ok {
+		claudeThinkingReplayAliasBytes -= len(key) + len(old.sessionKey)
+	}
+	claudeThinkingReplayAliases[key] = claudeThinkingReplayAliasEntry{sessionKey: sessionKey, timestamp: now}
+	claudeThinkingReplayAliasBytes += len(key) + len(sessionKey)
 }
 
 // ResolveClaudeThinkingReplaySessionKey looks for an existing conversation scope
 // that any of the provided message hashes belongs to. This is used by the
 // sessionless fallback when messages.0 has changed due to compaction.
-func ResolveClaudeThinkingReplaySessionKey(modelFamily string, messageHashes []string) (string, bool) {
+func ResolveClaudeThinkingReplaySessionKey(ctx context.Context, modelFamily string, messageHashes []string) (string, bool) {
 	if modelFamily == "" || len(messageHashes) == 0 {
 		return "", false
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	client, homeMode, errClient := currentClaudeThinkingReplayKVClient()
+	if homeMode {
+		if errClient != nil {
+			return "", false
+		}
+		for _, h := range messageHashes {
+			raw, found, err := client.KVGet(ctx, claudeThinkingReplayAliasKVKey(modelFamily, h))
+			if err != nil || !found {
+				continue
+			}
+			sessionKey := string(raw)
+			if sessionKey != "" {
+				return sessionKey, true
+			}
+		}
+		return "", false
+	}
+
 	claudeThinkingReplayAliasMu.RLock()
 	defer claudeThinkingReplayAliasMu.RUnlock()
+	now := time.Now()
 	for _, h := range messageHashes {
-		if sessionKey, ok := claudeThinkingReplayAliases[claudeThinkingReplayAliasKey(modelFamily, h)]; ok {
-			return sessionKey, true
+		key := claudeThinkingReplayAliasKey(modelFamily, h)
+		entry, ok := claudeThinkingReplayAliases[key]
+		if !ok {
+			continue
 		}
+		if now.Sub(entry.timestamp) > ClaudeThinkingReplayCacheTTL {
+			continue
+		}
+		return entry.sessionKey, true
 	}
 	return "", false
 }
 
 func claudeThinkingReplayAliasKey(modelFamily, messageHash string) string {
 	return strings.Join([]string{modelFamily, messageHash}, "\x00")
+}
+
+func claudeThinkingReplayAliasKVKey(modelFamily, messageHash string) string {
+	return "cpa:claude:thinking-replay-alias:" + homekv.HashKeyPart(strings.TrimSpace(modelFamily)) + ":" + homekv.HashKeyPart(strings.TrimSpace(messageHash))
+}
+
+func purgeExpiredClaudeThinkingReplayAliasesLocked(now time.Time) {
+	for key, entry := range claudeThinkingReplayAliases {
+		if now.Sub(entry.timestamp) > ClaudeThinkingReplayCacheTTL {
+			claudeThinkingReplayAliasBytes -= len(key) + len(entry.sessionKey)
+			delete(claudeThinkingReplayAliases, key)
+		}
+	}
+}
+
+func enforceClaudeThinkingReplayAliasLimitsLocked() {
+	for len(claudeThinkingReplayAliases) > ClaudeThinkingReplayCacheMaxAliases {
+		type candidate struct {
+			key       string
+			timestamp time.Time
+		}
+		candidates := make([]candidate, 0, len(claudeThinkingReplayAliases))
+		for key, entry := range claudeThinkingReplayAliases {
+			candidates = append(candidates, candidate{key: key, timestamp: entry.timestamp})
+		}
+		sort.Slice(candidates, func(i, j int) bool {
+			return candidates[i].timestamp.Before(candidates[j].timestamp)
+		})
+		batch := ClaudeThinkingReplayCacheEvictBatchSize
+		if batch > len(candidates) {
+			batch = len(candidates)
+		}
+		for i := 0; i < batch; i++ {
+			entry := claudeThinkingReplayAliases[candidates[i].key]
+			claudeThinkingReplayAliasBytes -= len(candidates[i].key) + len(entry.sessionKey)
+			delete(claudeThinkingReplayAliases, candidates[i].key)
+		}
+	}
 }
 
 func readOrReserveClaudeThinkingReplayHomeValue(ctx context.Context, client kimiThinkingReplayKVClient, key string) ([]byte, error) {
@@ -525,4 +623,8 @@ func purgeExpiredClaudeThinkingReplayCache(now time.Time) {
 		}
 	}
 	claudeThinkingReplayMu.Unlock()
+
+	claudeThinkingReplayAliasMu.Lock()
+	purgeExpiredClaudeThinkingReplayAliasesLocked(now)
+	claudeThinkingReplayAliasMu.Unlock()
 }

--- a/internal/cache/claude_thinking_replay_cache.go
+++ b/internal/cache/claude_thinking_replay_cache.go
@@ -42,6 +42,11 @@ const (
 	// aliases kept in the local fallback map.
 	ClaudeThinkingReplayCacheMaxAliases = 102400
 
+	// ClaudeThinkingReplayCacheMaxAliasBytes bounds the aggregate byte size of
+	// the local alias map so a caller with very large model names cannot exhaust
+	// process memory under the count cap.
+	ClaudeThinkingReplayCacheMaxAliasBytes = 64 << 20
+
 	// ClaudeThinkingReplayCacheMaxAliasesPerKey bounds how many distinct
 	// conversation scopes a single message can map to in the local alias map.
 	ClaudeThinkingReplayCacheMaxAliasesPerKey = 8
@@ -84,6 +89,10 @@ var (
 	// messages resolve to the same session and breaks ties by recency.
 	claudeThinkingReplayAliases    = make(map[string][]claudeThinkingReplayAliasEntry)
 	claudeThinkingReplayAliasBytes int
+	claudeThinkingReplayAliasCount int
+
+	claudeThinkingReplayAliasPurgeInterval = 1 * time.Minute
+	claudeThinkingReplayLastAliasPurge     time.Time
 )
 
 type claudeThinkingReplayAliasEntry struct {
@@ -323,6 +332,8 @@ func ClearClaudeThinkingReplayCache() {
 	claudeThinkingReplayAliasMu.Lock()
 	claudeThinkingReplayAliases = make(map[string][]claudeThinkingReplayAliasEntry)
 	claudeThinkingReplayAliasBytes = 0
+	claudeThinkingReplayAliasCount = 0
+	claudeThinkingReplayLastAliasPurge = time.Time{}
 	claudeThinkingReplayAliasMu.Unlock()
 }
 
@@ -351,7 +362,10 @@ func RegisterClaudeThinkingReplayAlias(ctx context.Context, modelFamily, session
 	claudeThinkingReplayAliasMu.Lock()
 	defer claudeThinkingReplayAliasMu.Unlock()
 	now := time.Now()
-	purgeExpiredClaudeThinkingReplayAliasesLocked(now)
+	if now.Sub(claudeThinkingReplayLastAliasPurge) >= claudeThinkingReplayAliasPurgeInterval {
+		purgeExpiredClaudeThinkingReplayAliasesLocked(now)
+		claudeThinkingReplayLastAliasPurge = now
+	}
 	claudeThinkingReplayUpsertAliasLocked(key, sessionKey, firstUserHash, now)
 	enforceClaudeThinkingReplayAliasLimitsLocked()
 }
@@ -424,10 +438,18 @@ func claudeThinkingReplayUpsertAliasLocked(key, sessionKey, firstUserHash string
 	}
 	list = append(list, claudeThinkingReplayAliasEntry{sessionKey: sessionKey, firstUserHash: firstUserHash, timestamp: now})
 	if len(list) > ClaudeThinkingReplayCacheMaxAliasesPerKey {
-		claudeThinkingReplayAliasBytes -= len(list[0].sessionKey) + len(list[0].firstUserHash)
-		list = list[1:]
+		oldest := 0
+		for i := 1; i < len(list); i++ {
+			if list[i].timestamp.Before(list[oldest].timestamp) {
+				oldest = i
+			}
+		}
+		claudeThinkingReplayAliasBytes -= len(list[oldest].sessionKey) + len(list[oldest].firstUserHash)
+		list = append(list[:oldest], list[oldest+1:]...)
+		claudeThinkingReplayAliasCount--
 	}
 	claudeThinkingReplayAliases[key] = list
+	claudeThinkingReplayAliasCount++
 	claudeThinkingReplayAliasBytes += len(key) + len(sessionKey) + len(firstUserHash)
 }
 
@@ -492,6 +514,7 @@ func purgeExpiredClaudeThinkingReplayAliasesLocked(now time.Time) {
 				kept = append(kept, entry)
 			} else {
 				claudeThinkingReplayAliasBytes -= len(key) + len(entry.sessionKey) + len(entry.firstUserHash)
+				claudeThinkingReplayAliasCount--
 			}
 		}
 		if len(kept) == 0 {
@@ -503,11 +526,7 @@ func purgeExpiredClaudeThinkingReplayAliasesLocked(now time.Time) {
 }
 
 func enforceClaudeThinkingReplayAliasLimitsLocked() {
-	total := 0
-	for _, list := range claudeThinkingReplayAliases {
-		total += len(list)
-	}
-	for total > ClaudeThinkingReplayCacheMaxAliases {
+	for claudeThinkingReplayAliasCount > ClaudeThinkingReplayCacheMaxAliases || claudeThinkingReplayAliasBytes > ClaudeThinkingReplayCacheMaxAliasBytes {
 		type candidate struct {
 			key       string
 			index     int
@@ -529,9 +548,6 @@ func enforceClaudeThinkingReplayAliasLimitsLocked() {
 		if batch > len(candidates) {
 			batch = len(candidates)
 		}
-		if batch > total-ClaudeThinkingReplayCacheMaxAliases {
-			batch = total - ClaudeThinkingReplayCacheMaxAliases
-		}
 		for i := 0; i < batch; i++ {
 			c := candidates[i]
 			list := claudeThinkingReplayAliases[c.key]
@@ -543,7 +559,7 @@ func enforceClaudeThinkingReplayAliasLimitsLocked() {
 				} else {
 					claudeThinkingReplayAliases[c.key] = list
 				}
-				total--
+				claudeThinkingReplayAliasCount--
 			}
 		}
 	}

--- a/internal/cache/claude_thinking_replay_cache.go
+++ b/internal/cache/claude_thinking_replay_cache.go
@@ -42,6 +42,16 @@ const (
 	// aliases kept in the local fallback map.
 	ClaudeThinkingReplayCacheMaxAliases = 102400
 
+	// ClaudeThinkingReplayCacheMaxAliasesPerKey bounds how many distinct
+	// conversation scopes a single message can map to in the local alias map.
+	ClaudeThinkingReplayCacheMaxAliasesPerKey = 8
+
+	// ClaudeThinkingReplayCacheMaxAliasesPerCredential bounds how many distinct
+	// alias keys a single credential/model can create in Home KV. Keep small so
+	// the per-credential index value does not exceed the underlying KV entry
+	// size limit.
+	ClaudeThinkingReplayCacheMaxAliasesPerCredential = 256
+
 	claudeThinkingReplayCacheMaxSerializedBytes = ClaudeThinkingReplayCacheMaxBytesPerSession + 1024
 )
 
@@ -67,17 +77,28 @@ var (
 	claudeThinkingReplayTotalBytes int
 
 	claudeThinkingReplayAliasMu sync.RWMutex
-	// claudeThinkingReplayAliases maps a per-model message hash to the
-	// conversation-scoped session key that first saw it. This lets sessionless
-	// clients compact history without orphaning the replay cache: the first
-	// remaining message in a truncated request can resolve the original scope.
-	claudeThinkingReplayAliases    = make(map[string]claudeThinkingReplayAliasEntry)
+	// claudeThinkingReplayAliases maps a per-model message hash to a list of
+	// conversation-scoped session keys that have contained that message. The list
+	// lets two sessionless conversations share a visible message without
+	// overwriting each other; Resolve scores candidates by how many request
+	// messages resolve to the same session and breaks ties by recency.
+	claudeThinkingReplayAliases    = make(map[string][]claudeThinkingReplayAliasEntry)
 	claudeThinkingReplayAliasBytes int
 )
 
 type claudeThinkingReplayAliasEntry struct {
-	sessionKey string
-	timestamp  time.Time
+	sessionKey    string
+	firstUserHash string
+	timestamp     time.Time
+}
+
+// ClaudeThinkingReplayAliasMessage pairs a message hash with the weight it
+// should receive during alias resolution. User messages typically receive a
+// higher weight because they are a stronger conversation anchor than
+// an echoed assistant turn.
+type ClaudeThinkingReplayAliasMessage struct {
+	Hash   string
+	Weight int
 }
 
 var currentClaudeThinkingReplayKVClient = func() (kimiThinkingReplayKVClient, bool, error) {
@@ -300,16 +321,17 @@ func ClearClaudeThinkingReplayCache() {
 	claudeThinkingReplayMu.Unlock()
 
 	claudeThinkingReplayAliasMu.Lock()
-	claudeThinkingReplayAliases = make(map[string]claudeThinkingReplayAliasEntry)
+	claudeThinkingReplayAliases = make(map[string][]claudeThinkingReplayAliasEntry)
 	claudeThinkingReplayAliasBytes = 0
 	claudeThinkingReplayAliasMu.Unlock()
 }
 
 // RegisterClaudeThinkingReplayAlias records that a request message belongs to a
-// specific conversation scope. Compacted requests can later resolve the same
-// scope through one of their remaining messages. In Home KV mode the alias is
-// stored as a separate KV entry so different instances can resolve it.
-func RegisterClaudeThinkingReplayAlias(ctx context.Context, modelFamily, sessionKey, messageHash string) {
+// conversation scope. Two different conversations can share the same visible
+// message, so the alias is a list of (session, timestamp) pairs rather than a
+// single mapping. In Home KV mode the alias is stored as a separate KV entry
+// with a per-credential index that enforces a cap and evicts oldest aliases.
+func RegisterClaudeThinkingReplayAlias(ctx context.Context, modelFamily, sessionKey, messageHash, firstUserHash string) {
 	if modelFamily == "" || sessionKey == "" || messageHash == "" {
 		return
 	}
@@ -321,7 +343,7 @@ func RegisterClaudeThinkingReplayAlias(ctx context.Context, modelFamily, session
 		if errClient != nil {
 			return
 		}
-		_, _ = client.KVSet(ctx, claudeThinkingReplayAliasKVKey(modelFamily, messageHash), []byte(sessionKey), homekv.KVSetOptions{EX: ClaudeThinkingReplayCacheTTL})
+		registerClaudeThinkingReplayAliasHome(ctx, client, modelFamily, sessionKey, messageHash, firstUserHash)
 		return
 	}
 
@@ -330,20 +352,17 @@ func RegisterClaudeThinkingReplayAlias(ctx context.Context, modelFamily, session
 	defer claudeThinkingReplayAliasMu.Unlock()
 	now := time.Now()
 	purgeExpiredClaudeThinkingReplayAliasesLocked(now)
+	claudeThinkingReplayUpsertAliasLocked(key, sessionKey, firstUserHash, now)
 	enforceClaudeThinkingReplayAliasLimitsLocked()
-	old, ok := claudeThinkingReplayAliases[key]
-	if ok {
-		claudeThinkingReplayAliasBytes -= len(key) + len(old.sessionKey)
-	}
-	claudeThinkingReplayAliases[key] = claudeThinkingReplayAliasEntry{sessionKey: sessionKey, timestamp: now}
-	claudeThinkingReplayAliasBytes += len(key) + len(sessionKey)
 }
 
 // ResolveClaudeThinkingReplaySessionKey looks for an existing conversation scope
-// that any of the provided message hashes belongs to. This is used by the
-// sessionless fallback when messages.0 has changed due to compaction.
-func ResolveClaudeThinkingReplaySessionKey(ctx context.Context, modelFamily string, messageHashes []string) (string, bool) {
-	if modelFamily == "" || len(messageHashes) == 0 {
+// that the request messages belong to. It scores each candidate session by the
+// weighted count of request messages that point to it and breaks ties by
+// recency, so shared messages do not resolve the wrong conversation when
+// multiple messages remain after compaction.
+func ResolveClaudeThinkingReplaySessionKey(ctx context.Context, modelFamily string, messages []ClaudeThinkingReplayAliasMessage, requestFirstUserHash string) (string, bool) {
+	if modelFamily == "" || len(messages) == 0 {
 		return "", false
 	}
 	if ctx == nil {
@@ -354,34 +373,12 @@ func ResolveClaudeThinkingReplaySessionKey(ctx context.Context, modelFamily stri
 		if errClient != nil {
 			return "", false
 		}
-		for _, h := range messageHashes {
-			raw, found, err := client.KVGet(ctx, claudeThinkingReplayAliasKVKey(modelFamily, h))
-			if err != nil || !found {
-				continue
-			}
-			sessionKey := string(raw)
-			if sessionKey != "" {
-				return sessionKey, true
-			}
-		}
-		return "", false
+		return resolveClaudeThinkingReplayAliasHome(ctx, client, modelFamily, messages, requestFirstUserHash)
 	}
 
 	claudeThinkingReplayAliasMu.RLock()
 	defer claudeThinkingReplayAliasMu.RUnlock()
-	now := time.Now()
-	for _, h := range messageHashes {
-		key := claudeThinkingReplayAliasKey(modelFamily, h)
-		entry, ok := claudeThinkingReplayAliases[key]
-		if !ok {
-			continue
-		}
-		if now.Sub(entry.timestamp) > ClaudeThinkingReplayCacheTTL {
-			continue
-		}
-		return entry.sessionKey, true
-	}
-	return "", false
+	return claudeThinkingReplayResolveBestAliasLocked(modelFamily, messages, requestFirstUserHash, time.Now())
 }
 
 func claudeThinkingReplayAliasKey(modelFamily, messageHash string) string {
@@ -392,24 +389,107 @@ func claudeThinkingReplayAliasKVKey(modelFamily, messageHash string) string {
 	return "cpa:claude:thinking-replay-alias:" + homekv.HashKeyPart(strings.TrimSpace(modelFamily)) + ":" + homekv.HashKeyPart(strings.TrimSpace(messageHash))
 }
 
+func claudeThinkingReplayAliasIndexKVKey(modelFamily string) string {
+	return "cpa:claude:thinking-replay-alias-index:" + homekv.HashKeyPart(strings.TrimSpace(modelFamily))
+}
+
+func claudeThinkingReplayUpsertAliasLocked(key, sessionKey, firstUserHash string, now time.Time) {
+	list := claudeThinkingReplayAliases[key]
+	for i := range list {
+		if list[i].sessionKey == sessionKey {
+			claudeThinkingReplayAliasBytes -= len(list[i].sessionKey) + len(list[i].firstUserHash)
+			list[i].timestamp = now
+			list[i].firstUserHash = firstUserHash
+			claudeThinkingReplayAliasBytes += len(sessionKey) + len(firstUserHash)
+			claudeThinkingReplayAliases[key] = list
+			return
+		}
+	}
+	list = append(list, claudeThinkingReplayAliasEntry{sessionKey: sessionKey, firstUserHash: firstUserHash, timestamp: now})
+	if len(list) > ClaudeThinkingReplayCacheMaxAliasesPerKey {
+		claudeThinkingReplayAliasBytes -= len(list[0].sessionKey) + len(list[0].firstUserHash)
+		list = list[1:]
+	}
+	claudeThinkingReplayAliases[key] = list
+	claudeThinkingReplayAliasBytes += len(key) + len(sessionKey) + len(firstUserHash)
+}
+
+func claudeThinkingReplayResolveBestAliasLocked(modelFamily string, messages []ClaudeThinkingReplayAliasMessage, requestFirstUserHash string, now time.Time) (string, bool) {
+	type candidate struct {
+		score  int
+		latest time.Time
+	}
+	const firstUserMatchBonus = 2
+	scores := make(map[string]candidate)
+	for _, m := range messages {
+		key := claudeThinkingReplayAliasKey(modelFamily, m.Hash)
+		list, ok := claudeThinkingReplayAliases[key]
+		if !ok {
+			continue
+		}
+		for _, entry := range list {
+			if now.Sub(entry.timestamp) > ClaudeThinkingReplayCacheTTL {
+				continue
+			}
+			c := scores[entry.sessionKey]
+			c.score += m.Weight
+			if requestFirstUserHash != "" && entry.firstUserHash == requestFirstUserHash {
+				c.score += firstUserMatchBonus
+			}
+			if entry.timestamp.After(c.latest) {
+				c.latest = entry.timestamp
+			}
+			scores[entry.sessionKey] = c
+		}
+	}
+	var best string
+	var bestCand candidate
+	for session, c := range scores {
+		if c.score > bestCand.score || (c.score == bestCand.score && c.latest.After(bestCand.latest)) {
+			best = session
+			bestCand = c
+		}
+	}
+	return best, best != ""
+}
+
 func purgeExpiredClaudeThinkingReplayAliasesLocked(now time.Time) {
-	for key, entry := range claudeThinkingReplayAliases {
-		if now.Sub(entry.timestamp) > ClaudeThinkingReplayCacheTTL {
-			claudeThinkingReplayAliasBytes -= len(key) + len(entry.sessionKey)
+	for key, list := range claudeThinkingReplayAliases {
+		kept := list[:0]
+		for _, entry := range list {
+			if now.Sub(entry.timestamp) <= ClaudeThinkingReplayCacheTTL {
+				kept = append(kept, entry)
+			} else {
+				claudeThinkingReplayAliasBytes -= len(key) + len(entry.sessionKey) + len(entry.firstUserHash)
+			}
+		}
+		if len(kept) == 0 {
 			delete(claudeThinkingReplayAliases, key)
+		} else {
+			claudeThinkingReplayAliases[key] = kept
 		}
 	}
 }
 
 func enforceClaudeThinkingReplayAliasLimitsLocked() {
-	for len(claudeThinkingReplayAliases) > ClaudeThinkingReplayCacheMaxAliases {
+	total := 0
+	for _, list := range claudeThinkingReplayAliases {
+		total += len(list)
+	}
+	for total > ClaudeThinkingReplayCacheMaxAliases {
 		type candidate struct {
 			key       string
+			index     int
 			timestamp time.Time
 		}
-		candidates := make([]candidate, 0, len(claudeThinkingReplayAliases))
-		for key, entry := range claudeThinkingReplayAliases {
-			candidates = append(candidates, candidate{key: key, timestamp: entry.timestamp})
+		var candidates []candidate
+		for key, list := range claudeThinkingReplayAliases {
+			for i, entry := range list {
+				candidates = append(candidates, candidate{key: key, index: i, timestamp: entry.timestamp})
+			}
+		}
+		if len(candidates) == 0 {
+			break
 		}
 		sort.Slice(candidates, func(i, j int) bool {
 			return candidates[i].timestamp.Before(candidates[j].timestamp)
@@ -418,12 +498,208 @@ func enforceClaudeThinkingReplayAliasLimitsLocked() {
 		if batch > len(candidates) {
 			batch = len(candidates)
 		}
+		if batch > total-ClaudeThinkingReplayCacheMaxAliases {
+			batch = total - ClaudeThinkingReplayCacheMaxAliases
+		}
 		for i := 0; i < batch; i++ {
-			entry := claudeThinkingReplayAliases[candidates[i].key]
-			claudeThinkingReplayAliasBytes -= len(candidates[i].key) + len(entry.sessionKey)
-			delete(claudeThinkingReplayAliases, candidates[i].key)
+			c := candidates[i]
+			list := claudeThinkingReplayAliases[c.key]
+			if c.index < len(list) {
+				claudeThinkingReplayAliasBytes -= len(c.key) + len(list[c.index].sessionKey) + len(list[c.index].firstUserHash)
+				list = append(list[:c.index], list[c.index+1:]...)
+				if len(list) == 0 {
+					delete(claudeThinkingReplayAliases, c.key)
+				} else {
+					claudeThinkingReplayAliases[c.key] = list
+				}
+				total--
+			}
 		}
 	}
+}
+
+// claudeThinkingReplayAliasIndexRecord and claudeThinkingReplayAliasIndex are
+// used to cap Home KV aliases per credential. The index lists all alias keys
+// created by that credential so the oldest can be evicted.
+type claudeThinkingReplayAliasIndexRecord struct {
+	AliasKey  string    `json:"alias_key"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+type claudeThinkingReplayAliasIndex struct {
+	Aliases []claudeThinkingReplayAliasIndexRecord `json:"aliases"`
+}
+
+type claudeThinkingReplayAliasHomeValue struct {
+	Sessions []claudeThinkingReplayAliasHomeSession `json:"sessions"`
+}
+
+type claudeThinkingReplayAliasHomeSession struct {
+	SessionKey    string    `json:"session_key"`
+	FirstUserHash string    `json:"first_user_hash"`
+	Timestamp     time.Time `json:"timestamp"`
+}
+
+func registerClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThinkingReplayKVClient, modelFamily, sessionKey, messageHash, firstUserHash string) {
+	aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHash)
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+	now := time.Now()
+
+	for attempt := 0; attempt < 4; attempt++ {
+		indexRaw, indexFound, errIndex := client.KVGet(ctx, indexKey)
+		if errIndex != nil {
+			log.Warnf("claude thinking replay alias index read failed: %v", errIndex)
+			return
+		}
+		index, ok := decodeClaudeThinkingReplayAliasIndex(indexRaw)
+		if !ok {
+			index = claudeThinkingReplayAliasIndex{}
+		}
+		index.Aliases = purgeExpiredClaudeThinkingReplayAliasIndex(index.Aliases, now)
+		index.Aliases = claudeThinkingReplayAliasIndexUpsert(index.Aliases, aliasKey, now)
+		if len(index.Aliases) > ClaudeThinkingReplayCacheMaxAliasesPerCredential {
+			sort.Slice(index.Aliases, func(i, j int) bool {
+				return index.Aliases[i].Timestamp.Before(index.Aliases[j].Timestamp)
+			})
+			for len(index.Aliases) > ClaudeThinkingReplayCacheMaxAliasesPerCredential {
+				oldest := index.Aliases[0]
+				index.Aliases = index.Aliases[1:]
+				if _, errDel := client.KVDel(ctx, oldest.AliasKey); errDel != nil {
+					log.Warnf("claude thinking replay alias eviction failed: %v", errDel)
+				}
+			}
+		}
+		indexBytes, errMarshal := json.Marshal(index)
+		if errMarshal != nil {
+			log.Warnf("claude thinking replay alias index marshal failed: %v", errMarshal)
+			return
+		}
+		swapped, errSwap := client.KVCompareAndSwap(ctx, indexKey, indexRaw, indexFound, indexBytes, ClaudeThinkingReplayCacheTTL)
+		if errSwap != nil {
+			log.Warnf("claude thinking replay alias index cas failed: %v", errSwap)
+			return
+		}
+		if swapped {
+			break
+		}
+		if attempt == 3 {
+			log.Warnf("claude thinking replay alias index cas exhausted after %d attempts", attempt+1)
+			return
+		}
+	}
+
+	var value claudeThinkingReplayAliasHomeValue
+	raw, found, errGet := client.KVGet(ctx, aliasKey)
+	if errGet != nil {
+		log.Warnf("claude thinking replay alias read failed: %v", errGet)
+		return
+	}
+	if found {
+		if err := json.Unmarshal(raw, &value); err != nil {
+			log.Warnf("claude thinking replay alias unmarshal failed: %v", errGet)
+			value = claudeThinkingReplayAliasHomeValue{}
+		}
+	}
+	value.Sessions = claudeThinkingReplayAliasHomeValueUpsert(value.Sessions, sessionKey, firstUserHash, now)
+	if len(value.Sessions) > ClaudeThinkingReplayCacheMaxAliasesPerKey {
+		sort.Slice(value.Sessions, func(i, j int) bool {
+			return value.Sessions[i].Timestamp.Before(value.Sessions[j].Timestamp)
+		})
+		value.Sessions = value.Sessions[len(value.Sessions)-ClaudeThinkingReplayCacheMaxAliasesPerKey:]
+	}
+	raw, errMarshal := json.Marshal(value)
+	if errMarshal != nil {
+		log.Warnf("claude thinking replay alias marshal failed: %v", errMarshal)
+		return
+	}
+	if _, errSet := client.KVSet(ctx, aliasKey, raw, homekv.KVSetOptions{EX: ClaudeThinkingReplayCacheTTL}); errSet != nil {
+		log.Warnf("claude thinking replay alias set failed: %v", errSet)
+	}
+}
+
+func resolveClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThinkingReplayKVClient, modelFamily string, messages []ClaudeThinkingReplayAliasMessage, requestFirstUserHash string) (string, bool) {
+	type candidate struct {
+		score  int
+		latest time.Time
+	}
+	const firstUserMatchBonus = 2
+	scores := make(map[string]candidate)
+	now := time.Now()
+	for _, m := range messages {
+		raw, found, err := client.KVGet(ctx, claudeThinkingReplayAliasKVKey(modelFamily, m.Hash))
+		if err != nil || !found {
+			continue
+		}
+		var value claudeThinkingReplayAliasHomeValue
+		if err := json.Unmarshal(raw, &value); err != nil {
+			continue
+		}
+		for _, s := range value.Sessions {
+			if now.Sub(s.Timestamp) > ClaudeThinkingReplayCacheTTL {
+				continue
+			}
+			c := scores[s.SessionKey]
+			c.score += m.Weight
+			if requestFirstUserHash != "" && s.FirstUserHash == requestFirstUserHash {
+				c.score += firstUserMatchBonus
+			}
+			if s.Timestamp.After(c.latest) {
+				c.latest = s.Timestamp
+			}
+			scores[s.SessionKey] = c
+		}
+	}
+	var best string
+	var bestCand candidate
+	for session, c := range scores {
+		if c.score > bestCand.score || (c.score == bestCand.score && c.latest.After(bestCand.latest)) {
+			best = session
+			bestCand = c
+		}
+	}
+	return best, best != ""
+}
+
+func decodeClaudeThinkingReplayAliasIndex(raw []byte) (claudeThinkingReplayAliasIndex, bool) {
+	if len(raw) == 0 {
+		return claudeThinkingReplayAliasIndex{}, true
+	}
+	var index claudeThinkingReplayAliasIndex
+	if err := json.Unmarshal(raw, &index); err != nil {
+		return claudeThinkingReplayAliasIndex{}, false
+	}
+	return index, true
+}
+
+func purgeExpiredClaudeThinkingReplayAliasIndex(records []claudeThinkingReplayAliasIndexRecord, now time.Time) []claudeThinkingReplayAliasIndexRecord {
+	kept := records[:0]
+	for _, r := range records {
+		if now.Sub(r.Timestamp) <= ClaudeThinkingReplayCacheTTL {
+			kept = append(kept, r)
+		}
+	}
+	return kept
+}
+
+func claudeThinkingReplayAliasIndexUpsert(records []claudeThinkingReplayAliasIndexRecord, aliasKey string, now time.Time) []claudeThinkingReplayAliasIndexRecord {
+	for i := range records {
+		if records[i].AliasKey == aliasKey {
+			records[i].Timestamp = now
+			return records
+		}
+	}
+	return append(records, claudeThinkingReplayAliasIndexRecord{AliasKey: aliasKey, Timestamp: now})
+}
+
+func claudeThinkingReplayAliasHomeValueUpsert(sessions []claudeThinkingReplayAliasHomeSession, sessionKey, firstUserHash string, now time.Time) []claudeThinkingReplayAliasHomeSession {
+	for i := range sessions {
+		if sessions[i].SessionKey == sessionKey {
+			sessions[i].Timestamp = now
+			sessions[i].FirstUserHash = firstUserHash
+			return sessions
+		}
+	}
+	return append(sessions, claudeThinkingReplayAliasHomeSession{SessionKey: sessionKey, FirstUserHash: firstUserHash, Timestamp: now})
 }
 
 func readOrReserveClaudeThinkingReplayHomeValue(ctx context.Context, client kimiThinkingReplayKVClient, key string) ([]byte, error) {

--- a/internal/cache/claude_thinking_replay_cache.go
+++ b/internal/cache/claude_thinking_replay_cache.go
@@ -609,6 +609,9 @@ func registerClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThink
 		swapped, errSwap := client.KVCompareAndSwap(ctx, aliasKey, raw, found, newRaw, ClaudeThinkingReplayCacheTTL)
 		if errSwap != nil {
 			log.Warnf("claude thinking replay alias cas failed: %v", errSwap)
+			// The command may have been applied before the error was returned.
+			// Roll back if the alias value still matches the attempted raw.
+			rollBackClaudeThinkingReplayAliasHome(ctx, client, aliasKey, indexKey, newRaw)
 			return
 		}
 		if swapped {

--- a/internal/cache/claude_thinking_replay_cache.go
+++ b/internal/cache/claude_thinking_replay_cache.go
@@ -61,6 +61,13 @@ var (
 	claudeThinkingReplayMu         sync.Mutex
 	claudeThinkingReplayEntries    = make(map[string]claudeThinkingReplayEntry)
 	claudeThinkingReplayTotalBytes int
+
+	claudeThinkingReplayAliasMu sync.RWMutex
+	// claudeThinkingReplayAliases maps a per-model message hash to the
+	// conversation-scoped session key that first saw it. This lets sessionless
+	// clients compact history without orphaning the replay cache: the first
+	// remaining message in a truncated request can resolve the original scope.
+	claudeThinkingReplayAliases = make(map[string]string)
 )
 
 var currentClaudeThinkingReplayKVClient = func() (kimiThinkingReplayKVClient, bool, error) {
@@ -274,12 +281,51 @@ func DeleteClaudeThinkingReplayRequired(ctx context.Context, modelFamily, sessio
 	return nil
 }
 
-// ClearClaudeThinkingReplayCache clears only Claude replay state.
+// ClearClaudeThinkingReplayCache clears only Claude replay state and its
+// message-to-scope aliases.
 func ClearClaudeThinkingReplayCache() {
 	claudeThinkingReplayMu.Lock()
 	claudeThinkingReplayEntries = make(map[string]claudeThinkingReplayEntry)
 	claudeThinkingReplayTotalBytes = 0
 	claudeThinkingReplayMu.Unlock()
+
+	claudeThinkingReplayAliasMu.Lock()
+	claudeThinkingReplayAliases = make(map[string]string)
+	claudeThinkingReplayAliasMu.Unlock()
+}
+
+// RegisterClaudeThinkingReplayAlias records that a request message belongs to a
+// specific conversation scope. Compacted requests can later resolve the same
+// scope through one of their remaining messages.
+func RegisterClaudeThinkingReplayAlias(modelFamily, sessionKey, messageHash string) {
+	if modelFamily == "" || sessionKey == "" || messageHash == "" {
+		return
+	}
+	key := claudeThinkingReplayAliasKey(modelFamily, messageHash)
+	claudeThinkingReplayAliasMu.Lock()
+	defer claudeThinkingReplayAliasMu.Unlock()
+	claudeThinkingReplayAliases[key] = sessionKey
+}
+
+// ResolveClaudeThinkingReplaySessionKey looks for an existing conversation scope
+// that any of the provided message hashes belongs to. This is used by the
+// sessionless fallback when messages.0 has changed due to compaction.
+func ResolveClaudeThinkingReplaySessionKey(modelFamily string, messageHashes []string) (string, bool) {
+	if modelFamily == "" || len(messageHashes) == 0 {
+		return "", false
+	}
+	claudeThinkingReplayAliasMu.RLock()
+	defer claudeThinkingReplayAliasMu.RUnlock()
+	for _, h := range messageHashes {
+		if sessionKey, ok := claudeThinkingReplayAliases[claudeThinkingReplayAliasKey(modelFamily, h)]; ok {
+			return sessionKey, true
+		}
+	}
+	return "", false
+}
+
+func claudeThinkingReplayAliasKey(modelFamily, messageHash string) string {
+	return strings.Join([]string{modelFamily, messageHash}, "\x00")
 }
 
 func readOrReserveClaudeThinkingReplayHomeValue(ctx context.Context, client kimiThinkingReplayKVClient, key string) ([]byte, error) {

--- a/internal/cache/claude_thinking_replay_cache.go
+++ b/internal/cache/claude_thinking_replay_cache.go
@@ -555,17 +555,29 @@ func enforceClaudeThinkingReplayAliasLimitsLocked() {
 		for i := 0; i < batch; i++ {
 			c := candidates[i]
 			list := claudeThinkingReplayAliases[c.key]
-			if c.index < len(list) {
-				claudeThinkingReplayAliasBytes -= len(list[c.index].sessionKey) + len(list[c.index].firstUserHash)
-				list = append(list[:c.index], list[c.index+1:]...)
-				if len(list) == 0 {
-					claudeThinkingReplayAliasBytes -= len(c.key)
-					delete(claudeThinkingReplayAliases, c.key)
-				} else {
-					claudeThinkingReplayAliases[c.key] = list
-				}
-				claudeThinkingReplayAliasCount--
+			if c.index >= len(list) {
+				continue
 			}
+			sessionKey := list[c.index].sessionKey
+			found := -1
+			for j, e := range list {
+				if e.sessionKey == sessionKey {
+					found = j
+					break
+				}
+			}
+			if found < 0 {
+				continue
+			}
+			claudeThinkingReplayAliasBytes -= len(list[found].sessionKey) + len(list[found].firstUserHash)
+			list = append(list[:found], list[found+1:]...)
+			if len(list) == 0 {
+				claudeThinkingReplayAliasBytes -= len(c.key)
+				delete(claudeThinkingReplayAliases, c.key)
+			} else {
+				claudeThinkingReplayAliases[c.key] = list
+			}
+			claudeThinkingReplayAliasCount--
 		}
 	}
 }

--- a/internal/cache/claude_thinking_replay_cache.go
+++ b/internal/cache/claude_thinking_replay_cache.go
@@ -437,6 +437,11 @@ func claudeThinkingReplayUpsertAliasLocked(key, sessionKey, firstUserHash string
 		}
 	}
 	list = append(list, claudeThinkingReplayAliasEntry{sessionKey: sessionKey, firstUserHash: firstUserHash, timestamp: now})
+	if len(list) == 1 {
+		claudeThinkingReplayAliasBytes += len(key)
+	}
+	claudeThinkingReplayAliasCount++
+	claudeThinkingReplayAliasBytes += len(sessionKey) + len(firstUserHash)
 	if len(list) > ClaudeThinkingReplayCacheMaxAliasesPerKey {
 		oldest := 0
 		for i := 1; i < len(list); i++ {
@@ -449,8 +454,6 @@ func claudeThinkingReplayUpsertAliasLocked(key, sessionKey, firstUserHash string
 		claudeThinkingReplayAliasCount--
 	}
 	claudeThinkingReplayAliases[key] = list
-	claudeThinkingReplayAliasCount++
-	claudeThinkingReplayAliasBytes += len(key) + len(sessionKey) + len(firstUserHash)
 }
 
 func claudeThinkingReplayResolveBestAliasLocked(modelFamily string, messages []ClaudeThinkingReplayAliasMessage, requestFirstUserHash string, now time.Time) (string, bool) {
@@ -513,11 +516,12 @@ func purgeExpiredClaudeThinkingReplayAliasesLocked(now time.Time) {
 			if now.Sub(entry.timestamp) <= ClaudeThinkingReplayCacheTTL {
 				kept = append(kept, entry)
 			} else {
-				claudeThinkingReplayAliasBytes -= len(key) + len(entry.sessionKey) + len(entry.firstUserHash)
+				claudeThinkingReplayAliasBytes -= len(entry.sessionKey) + len(entry.firstUserHash)
 				claudeThinkingReplayAliasCount--
 			}
 		}
 		if len(kept) == 0 {
+			claudeThinkingReplayAliasBytes -= len(key)
 			delete(claudeThinkingReplayAliases, key)
 		} else {
 			claudeThinkingReplayAliases[key] = kept
@@ -552,9 +556,10 @@ func enforceClaudeThinkingReplayAliasLimitsLocked() {
 			c := candidates[i]
 			list := claudeThinkingReplayAliases[c.key]
 			if c.index < len(list) {
-				claudeThinkingReplayAliasBytes -= len(c.key) + len(list[c.index].sessionKey) + len(list[c.index].firstUserHash)
+				claudeThinkingReplayAliasBytes -= len(list[c.index].sessionKey) + len(list[c.index].firstUserHash)
 				list = append(list[:c.index], list[c.index+1:]...)
 				if len(list) == 0 {
+					claudeThinkingReplayAliasBytes -= len(c.key)
 					delete(claudeThinkingReplayAliases, c.key)
 				} else {
 					claudeThinkingReplayAliases[c.key] = list

--- a/internal/cache/claude_thinking_replay_cache.go
+++ b/internal/cache/claude_thinking_replay_cache.go
@@ -580,6 +580,7 @@ func registerClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThink
 	// Multiple sessionless conversations can register the same message hash
 	// concurrently, so an unconditional KVSet would let the last writer discard
 	// the others.
+	var committedAliasRaw []byte
 	for attempt := 0; attempt < 4; attempt++ {
 		var value claudeThinkingReplayAliasHomeValue
 		raw, found, errGet := client.KVGet(ctx, aliasKey)
@@ -611,6 +612,7 @@ func registerClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThink
 			return
 		}
 		if swapped {
+			committedAliasRaw = newRaw
 			break
 		}
 		if attempt == 3 {
@@ -620,10 +622,13 @@ func registerClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThink
 	}
 
 	// Maintain the per-credential index so old aliases can be evicted.
+	var evicted []string
+	indexUpdated := false
 	for attempt := 0; attempt < 4; attempt++ {
 		indexRaw, indexFound, errIndex := client.KVGet(ctx, indexKey)
 		if errIndex != nil {
 			log.Warnf("claude thinking replay alias index read failed: %v", errIndex)
+			rollBackClaudeThinkingReplayAliasHome(ctx, client, aliasKey, indexKey, committedAliasRaw)
 			return
 		}
 		index, ok := decodeClaudeThinkingReplayAliasIndex(indexRaw)
@@ -632,7 +637,7 @@ func registerClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThink
 		}
 		index.Aliases = purgeExpiredClaudeThinkingReplayAliasIndex(index.Aliases, now)
 		index.Aliases = claudeThinkingReplayAliasIndexUpsert(index.Aliases, aliasKey, now)
-		var evicted []string
+		evicted = evicted[:0]
 		if len(index.Aliases) > ClaudeThinkingReplayCacheMaxAliasesPerCredential {
 			sort.Slice(index.Aliases, func(i, j int) bool {
 				return index.Aliases[i].Timestamp.Before(index.Aliases[j].Timestamp)
@@ -645,29 +650,82 @@ func registerClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThink
 		indexBytes, errMarshal := json.Marshal(index)
 		if errMarshal != nil {
 			log.Warnf("claude thinking replay alias index marshal failed: %v", errMarshal)
+			rollBackClaudeThinkingReplayAliasHome(ctx, client, aliasKey, indexKey, committedAliasRaw)
 			return
 		}
 		swapped, errSwap := client.KVCompareAndSwap(ctx, indexKey, indexRaw, indexFound, indexBytes, ClaudeThinkingReplayCacheTTL)
 		if errSwap != nil {
 			log.Warnf("claude thinking replay alias index cas failed: %v", errSwap)
+			rollBackClaudeThinkingReplayAliasHome(ctx, client, aliasKey, indexKey, committedAliasRaw)
 			return
 		}
 		if swapped {
-			// Only delete evicted alias values after the index CAS succeeds.
-			// A concurrent worker may have refreshed an alias between our read
-			// and the CAS; deleting before the CAS could erase a still-indexed
-			// alias and break compacted continuations.
-			for _, key := range evicted {
-				if _, errDel := client.KVDel(ctx, key); errDel != nil {
-					log.Warnf("claude thinking replay alias eviction failed: %v", errDel)
-				}
-			}
+			indexUpdated = true
 			break
 		}
 		if attempt == 3 {
 			log.Warnf("claude thinking replay alias index cas exhausted after %d attempts", attempt+1)
+			rollBackClaudeThinkingReplayAliasHome(ctx, client, aliasKey, indexKey, committedAliasRaw)
 			return
 		}
+	}
+
+	if !indexUpdated {
+		// Defensive: should have rolled back above, but ensure no half-registered state.
+		rollBackClaudeThinkingReplayAliasHome(ctx, client, aliasKey, indexKey, committedAliasRaw)
+		return
+	}
+
+	// Only delete evicted alias values after the index CAS succeeds and a fresh
+	// read confirms the alias is still absent from the index. A concurrent
+	// worker may have re-registered an evicted alias after our CAS.
+	currentIndexRaw, _, errCurrentIndex := client.KVGet(ctx, indexKey)
+	if errCurrentIndex != nil {
+		log.Warnf("claude thinking replay alias index re-read failed: %v", errCurrentIndex)
+		return
+	}
+	currentIndex, _ := decodeClaudeThinkingReplayAliasIndex(currentIndexRaw)
+	present := make(map[string]struct{}, len(currentIndex.Aliases))
+	for _, a := range currentIndex.Aliases {
+		present[a.AliasKey] = struct{}{}
+	}
+	for _, key := range evicted {
+		if _, ok := present[key]; ok {
+			continue
+		}
+		if _, errDel := client.KVDel(ctx, key); errDel != nil {
+			log.Warnf("claude thinking replay alias eviction failed: %v", errDel)
+		}
+	}
+}
+
+// rollBackClaudeThinkingReplayAliasHome removes an alias value that was
+// committed but could not be added to the index, so it does not become an
+// unindexed, uncapped KV entry. The rollback only deletes the value when no
+// other worker has modified it and the alias is not currently indexed.
+func rollBackClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThinkingReplayKVClient, aliasKey, indexKey string, committedAliasRaw []byte) {
+	if len(committedAliasRaw) == 0 {
+		return
+	}
+	currentRaw, found, errCurrent := client.KVGet(ctx, aliasKey)
+	if errCurrent != nil || !found {
+		return
+	}
+	if !bytes.Equal(currentRaw, committedAliasRaw) {
+		return
+	}
+	indexRaw, _, errIndex := client.KVGet(ctx, indexKey)
+	if errIndex != nil {
+		return
+	}
+	index, _ := decodeClaudeThinkingReplayAliasIndex(indexRaw)
+	for _, a := range index.Aliases {
+		if a.AliasKey == aliasKey {
+			return
+		}
+	}
+	if _, errDel := client.KVDel(ctx, aliasKey); errDel != nil {
+		log.Warnf("claude thinking replay alias rollback failed: %v", errDel)
 	}
 }
 

--- a/internal/cache/claude_thinking_replay_cache.go
+++ b/internal/cache/claude_thinking_replay_cache.go
@@ -389,8 +389,25 @@ func claudeThinkingReplayAliasKVKey(modelFamily, messageHash string) string {
 	return "cpa:claude:thinking-replay-alias:" + homekv.HashKeyPart(strings.TrimSpace(modelFamily)) + ":" + homekv.HashKeyPart(strings.TrimSpace(messageHash))
 }
 
+// claudeThinkingReplayCredentialHash extracts the stable credential hash embedded
+// in a modelFamily string ("claude:<hash>:<baseModel>"). The alias index is keyed
+// by credential so the per-credential cap applies across all model names a caller
+// may use.
+func claudeThinkingReplayCredentialHash(modelFamily string) string {
+	const prefix = "claude:"
+	if !strings.HasPrefix(modelFamily, prefix) {
+		return modelFamily
+	}
+	rest := modelFamily[len(prefix):]
+	if i := strings.IndexByte(rest, ':'); i > 0 {
+		return rest[:i]
+	}
+	return modelFamily
+}
+
 func claudeThinkingReplayAliasIndexKVKey(modelFamily string) string {
-	return "cpa:claude:thinking-replay-alias-index:" + homekv.HashKeyPart(strings.TrimSpace(modelFamily))
+	credentialHash := claudeThinkingReplayCredentialHash(modelFamily)
+	return "cpa:claude:thinking-replay-alias-index:" + homekv.HashKeyPart(strings.TrimSpace(credentialHash))
 }
 
 func claudeThinkingReplayUpsertAliasLocked(key, sessionKey, firstUserHash string, now time.Time) {
@@ -615,16 +632,14 @@ func registerClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThink
 		}
 		index.Aliases = purgeExpiredClaudeThinkingReplayAliasIndex(index.Aliases, now)
 		index.Aliases = claudeThinkingReplayAliasIndexUpsert(index.Aliases, aliasKey, now)
+		var evicted []string
 		if len(index.Aliases) > ClaudeThinkingReplayCacheMaxAliasesPerCredential {
 			sort.Slice(index.Aliases, func(i, j int) bool {
 				return index.Aliases[i].Timestamp.Before(index.Aliases[j].Timestamp)
 			})
 			for len(index.Aliases) > ClaudeThinkingReplayCacheMaxAliasesPerCredential {
-				oldest := index.Aliases[0]
+				evicted = append(evicted, index.Aliases[0].AliasKey)
 				index.Aliases = index.Aliases[1:]
-				if _, errDel := client.KVDel(ctx, oldest.AliasKey); errDel != nil {
-					log.Warnf("claude thinking replay alias eviction failed: %v", errDel)
-				}
 			}
 		}
 		indexBytes, errMarshal := json.Marshal(index)
@@ -638,6 +653,15 @@ func registerClaudeThinkingReplayAliasHome(ctx context.Context, client kimiThink
 			return
 		}
 		if swapped {
+			// Only delete evicted alias values after the index CAS succeeds.
+			// A concurrent worker may have refreshed an alias between our read
+			// and the CAS; deleting before the CAS could erase a still-indexed
+			// alias and break compacted continuations.
+			for _, key := range evicted {
+				if _, errDel := client.KVDel(ctx, key); errDel != nil {
+					log.Warnf("claude thinking replay alias eviction failed: %v", errDel)
+				}
+			}
 			break
 		}
 		if attempt == 3 {

--- a/internal/cache/claude_thinking_replay_cache_test.go
+++ b/internal/cache/claude_thinking_replay_cache_test.go
@@ -538,6 +538,53 @@ func TestClaudeThinkingReplayAliasHomeEvictionSkipsReaddedAlias(t *testing.T) {
 	}
 }
 
+func TestClaudeThinkingReplayAliasHomeRechecksEvictedAliasValue(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+
+	client := newFakeClaudeThinkingReplayKVClient()
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	max := ClaudeThinkingReplayCacheMaxAliasesPerCredential
+	now := time.Now()
+	var index claudeThinkingReplayAliasIndex
+	for i := 0; i < max; i++ {
+		aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHashFor(i))
+		index.Aliases = append(index.Aliases, claudeThinkingReplayAliasIndexRecord{
+			AliasKey:  aliasKey,
+			Timestamp: now.Add(-time.Duration(max-i) * time.Second),
+		})
+		value, _ := json.Marshal(claudeThinkingReplayAliasHomeValue{
+			Sessions: []claudeThinkingReplayAliasHomeSession{
+				{SessionKey: "session", FirstUserHash: "first", Timestamp: now},
+			},
+		})
+		client.values[aliasKey] = value
+	}
+	evictedAlias := index.Aliases[0].AliasKey
+	indexBytes, _ := json.Marshal(index)
+	client.values[indexKey] = indexBytes
+
+	// Simulate a concurrent worker refreshing the evicted alias value after the
+	// index record was established but before the eviction pass.
+	refreshed, _ := json.Marshal(claudeThinkingReplayAliasHomeValue{
+		Sessions: []claudeThinkingReplayAliasHomeSession{
+			{SessionKey: "session", FirstUserHash: "first", Timestamp: now.Add(time.Minute)},
+		},
+	})
+	client.values[evictedAlias] = refreshed
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session", messageHashFor(max), "first")
+
+	if _, ok := client.values[evictedAlias]; !ok {
+		t.Fatalf("evicted alias %q was deleted despite a repopulated value", evictedAlias)
+	}
+}
+
 // indexGetFailingClaudeThinkingReplayKVClient fails KVGet for the index key.
 // This verifies rollback does not depend on an index read succeeding.
 type indexGetFailingClaudeThinkingReplayKVClient struct {

--- a/internal/cache/claude_thinking_replay_cache_test.go
+++ b/internal/cache/claude_thinking_replay_cache_test.go
@@ -436,6 +436,107 @@ func TestClaudeThinkingReplayAliasHomeEvictionIsAtomicWithIndexCAS(t *testing.T)
 	}
 }
 
+func TestClaudeThinkingReplayAliasHomeRollbackOnIndexFailure(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+	messageHash := "new-msg"
+	aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHash)
+
+	base := newFakeClaudeThinkingReplayKVClient()
+	client := &failingIndexClaudeThinkingReplayKVClient{
+		fakeClaudeThinkingReplayKVClient: base,
+		indexKey:                         indexKey,
+	}
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session", messageHash, "first")
+
+	if _, ok := client.values[aliasKey]; ok {
+		t.Fatalf("alias %q was committed but not indexed; expected rollback", aliasKey)
+	}
+}
+
+// readdEvictedClaudeThinkingReplayKVClient simulates a concurrent worker that
+// re-registers the evicted alias between the successful index CAS and the
+// eviction re-read. The re-read should see the alias back in the index and skip
+// deletion.
+type readdEvictedClaudeThinkingReplayKVClient struct {
+	*fakeClaudeThinkingReplayKVClient
+	indexKey string
+	evicted  string
+	swapped  bool
+}
+
+func (c *readdEvictedClaudeThinkingReplayKVClient) KVGet(ctx context.Context, key string) ([]byte, bool, error) {
+	if key == c.indexKey && c.swapped {
+		idx, ok := decodeClaudeThinkingReplayAliasIndex(c.values[c.indexKey])
+		if !ok {
+			idx = claudeThinkingReplayAliasIndex{}
+		}
+		idx.Aliases = append(idx.Aliases, claudeThinkingReplayAliasIndexRecord{
+			AliasKey:  c.evicted,
+			Timestamp: time.Now(),
+		})
+		raw, _ := json.Marshal(idx)
+		return raw, true, nil
+	}
+	return c.fakeClaudeThinkingReplayKVClient.KVGet(ctx, key)
+}
+
+func (c *readdEvictedClaudeThinkingReplayKVClient) KVCompareAndSwap(ctx context.Context, key string, expected []byte, expectedExists bool, newValue []byte, ttl time.Duration) (bool, error) {
+	swapped, err := c.fakeClaudeThinkingReplayKVClient.KVCompareAndSwap(ctx, key, expected, expectedExists, newValue, ttl)
+	if err == nil && swapped && key == c.indexKey {
+		c.swapped = true
+	}
+	return swapped, err
+}
+
+func TestClaudeThinkingReplayAliasHomeEvictionSkipsReaddedAlias(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+
+	base := newFakeClaudeThinkingReplayKVClient()
+	client := &readdEvictedClaudeThinkingReplayKVClient{
+		fakeClaudeThinkingReplayKVClient: base,
+		indexKey:                         indexKey,
+	}
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	max := ClaudeThinkingReplayCacheMaxAliasesPerCredential
+	now := time.Now()
+	var index claudeThinkingReplayAliasIndex
+	for i := 0; i < max; i++ {
+		aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHashFor(i))
+		index.Aliases = append(index.Aliases, claudeThinkingReplayAliasIndexRecord{
+			AliasKey:  aliasKey,
+			Timestamp: now.Add(-time.Duration(max-i) * time.Second),
+		})
+		value, _ := json.Marshal(claudeThinkingReplayAliasHomeValue{
+			Sessions: []claudeThinkingReplayAliasHomeSession{
+				{SessionKey: "session", FirstUserHash: "first", Timestamp: now},
+			},
+		})
+		client.values[aliasKey] = value
+	}
+	client.evicted = index.Aliases[0].AliasKey
+	indexBytes, _ := json.Marshal(index)
+	client.values[indexKey] = indexBytes
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session", messageHashFor(max), "first")
+
+	if _, ok := client.values[client.evicted]; !ok {
+		t.Fatalf("evicted alias %q was deleted while re-added to index", client.evicted)
+	}
+}
+
 func messageHashFor(i int) string {
 	const chars = "abcdefghijklmnopqrstuvwxyz"
 	s := make([]byte, 0, 8)

--- a/internal/cache/claude_thinking_replay_cache_test.go
+++ b/internal/cache/claude_thinking_replay_cache_test.go
@@ -1,89 +1,210 @@
 package cache
 
 import (
-	"bytes"
 	"context"
 	"testing"
+	"time"
+
+	homekv "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 )
 
-func useFakeClaudeThinkingReplayKVClient(t *testing.T, client *fakeKimiThinkingReplayKVClient) {
+type fakeClaudeThinkingReplayKVClient struct {
+	values  map[string][]byte
+	sets    int
+	dels    int
+	getErr  error
+	setErr  error
+	delErr  error
+	swapErr error
+}
+
+func newFakeClaudeThinkingReplayKVClient() *fakeClaudeThinkingReplayKVClient {
+	return &fakeClaudeThinkingReplayKVClient{values: make(map[string][]byte)}
+}
+
+func (c *fakeClaudeThinkingReplayKVClient) KVGet(_ context.Context, key string) ([]byte, bool, error) {
+	if c.getErr != nil {
+		return nil, false, c.getErr
+	}
+	v, ok := c.values[key]
+	return append([]byte(nil), v...), ok, nil
+}
+
+func (c *fakeClaudeThinkingReplayKVClient) KVSet(_ context.Context, key string, value []byte, _ homekv.KVSetOptions) (bool, error) {
+	if c.setErr != nil {
+		return false, c.setErr
+	}
+	c.values[key] = append([]byte(nil), value...)
+	c.sets++
+	return true, nil
+}
+
+func (c *fakeClaudeThinkingReplayKVClient) KVDel(_ context.Context, keys ...string) (int64, error) {
+	if c.delErr != nil {
+		return 0, c.delErr
+	}
+	var n int64
+	for _, k := range keys {
+		if _, ok := c.values[k]; ok {
+			delete(c.values, k)
+			n++
+		}
+	}
+	c.dels += int(n)
+	return n, nil
+}
+
+func (c *fakeClaudeThinkingReplayKVClient) KVCompareAndSwap(_ context.Context, key string, expected []byte, _ bool, newValue []byte, _ time.Duration) (bool, error) {
+	if c.swapErr != nil {
+		return false, c.swapErr
+	}
+	current, ok := c.values[key]
+	if !ok && expected == nil {
+		c.values[key] = append([]byte(nil), newValue...)
+		c.sets++
+		return true, nil
+	}
+	if ok && string(current) == string(expected) {
+		c.values[key] = append([]byte(nil), newValue...)
+		c.sets++
+		return true, nil
+	}
+	return false, nil
+}
+
+func (c *fakeClaudeThinkingReplayKVClient) KVExpire(context.Context, string, time.Duration) (bool, error) {
+	return true, nil
+}
+
+func useFakeClaudeThinkingReplayKVClient(t *testing.T, client *fakeClaudeThinkingReplayKVClient, homeMode bool) {
 	t.Helper()
-	previous := currentClaudeThinkingReplayKVClient
+	prev := currentClaudeThinkingReplayKVClient
 	currentClaudeThinkingReplayKVClient = func() (kimiThinkingReplayKVClient, bool, error) {
-		return client, true, nil
+		return client, homeMode, nil
 	}
 	t.Cleanup(func() {
-		currentClaudeThinkingReplayKVClient = previous
+		currentClaudeThinkingReplayKVClient = prev
+		ClearClaudeThinkingReplayCache()
 	})
 }
 
-func TestClaudeThinkingReplayAppendsAssistantTurns(t *testing.T) {
-	client := newFakeKimiThinkingReplayKVClient()
-	useFakeClaudeThinkingReplayKVClient(t, client)
+func TestResolveClaudeThinkingReplayAliasScoresByWeightAndFirstUser(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
 
-	const modelFamily = "claude:auth:model"
-	const sessionKey = "execution:multi-turn"
-	first := []byte(`[{"type":"thinking","thinking":"first","signature":"sig-1"},{"type":"tool_use","id":"toolu-1","name":"Read","input":{"path":"one"}}]`)
-	second := []byte(`[{"type":"thinking","thinking":"second","signature":"sig-2"},{"type":"tool_use","id":"toolu-2","name":"Read","input":{"path":"two"}}]`)
+	ctx := context.Background()
+	const modelFamily = "claude:test"
 
-	if !CacheClaudeThinkingReplayBestEffort(context.Background(), modelFamily, sessionKey, first) {
-		t.Fatal("failed to seed first Claude replay turn")
-	}
-	_, snapshot, found, errGet := GetClaudeThinkingReplayWithSnapshotRequired(context.Background(), modelFamily, sessionKey)
-	if errGet != nil || !found {
-		t.Fatalf("initial Claude replay read = found %v, error %v", found, errGet)
-	}
-	replaced, errReplace := ReplaceClaudeThinkingReplayIfUnchanged(context.Background(), modelFamily, sessionKey, snapshot, second)
-	if errReplace != nil || !replaced {
-		t.Fatalf("append Claude replay turn = replaced %v, error %v", replaced, errReplace)
+	firstA := "firstA"
+	firstB := "firstB"
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionA", "msg1", firstA)
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionA", "msg2", firstA)
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionB", "msg1", firstB)
+
+	// A request with first user A and messages [msg1, msg2] should resolve to A.
+	msgs := []ClaudeThinkingReplayAliasMessage{{Hash: "msg1", Weight: 1}, {Hash: "msg2", Weight: 2}}
+	if s, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, firstA); !ok || s != "sessionA" {
+		t.Fatalf("resolve first A: got %q, want sessionA", s)
 	}
 
-	contents, found, errGet := GetClaudeThinkingReplayRequired(context.Background(), modelFamily, sessionKey)
-	if errGet != nil || !found || len(contents) != 2 {
-		t.Fatalf("Claude replay contents = %d, found %v, error %v; want two turns", len(contents), found, errGet)
-	}
-	if !bytes.Equal(contents[0], first) || !bytes.Equal(contents[1], second) {
-		t.Fatalf("Claude replay contents lost ordering: got %s / %s", contents[0], contents[1])
+	// Same messages with first user B should resolve to B, even though msg2
+	// only belongs to A; msg1 is shared, but the first-user bonus for B tips
+	// the scales.
+	msgs = []ClaudeThinkingReplayAliasMessage{{Hash: "msg1", Weight: 1}}
+	if s, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, firstB); !ok || s != "sessionB" {
+		t.Fatalf("resolve first B: got %q, want sessionB", s)
 	}
 }
 
-func TestClaudeThinkingReplayClearDoesNotClearKimiState(t *testing.T) {
-	previousClaudeClient := currentClaudeThinkingReplayKVClient
-	previousKimiClient := currentKimiThinkingReplayKVClient
-	currentClaudeThinkingReplayKVClient = func() (kimiThinkingReplayKVClient, bool, error) {
-		return nil, false, nil
-	}
-	currentKimiThinkingReplayKVClient = func() (kimiThinkingReplayKVClient, bool, error) {
-		return nil, false, nil
-	}
-	t.Cleanup(func() {
-		currentClaudeThinkingReplayKVClient = previousClaudeClient
-		currentKimiThinkingReplayKVClient = previousKimiClient
-	})
+func TestResolveClaudeThinkingReplayAliasIgnoresExpiredEntries(t *testing.T) {
 	ClearClaudeThinkingReplayCache()
-	ClearKimiThinkingReplayCache()
-	t.Cleanup(ClearClaudeThinkingReplayCache)
-	t.Cleanup(ClearKimiThinkingReplayCache)
+	defer ClearClaudeThinkingReplayCache()
 
-	const modelFamily = "shared-model"
-	const sessionKey = "execution:shared-session"
-	kimiContent := []byte(`[{"type":"thinking","signature":"kimi"}]`)
-	claudeContent := []byte(`[{"type":"thinking","signature":"claude"}]`)
-	if !CacheKimiThinkingReplayBestEffort(context.Background(), modelFamily, sessionKey, kimiContent) {
-		t.Fatal("failed to seed Kimi replay state")
-	}
-	if !CacheClaudeThinkingReplayBestEffort(context.Background(), modelFamily, sessionKey, claudeContent) {
-		t.Fatal("failed to seed Claude replay state")
-	}
+	ctx := context.Background()
+	const modelFamily = "claude:test"
 
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionA", "msg1", "firstA")
+
+	// Expire the alias by advancing time.
+	claudeThinkingReplayAliasMu.Lock()
+	for key, list := range claudeThinkingReplayAliases {
+		for i := range list {
+			list[i].timestamp = time.Now().Add(-2 * ClaudeThinkingReplayCacheTTL)
+		}
+		claudeThinkingReplayAliases[key] = list
+	}
+	claudeThinkingReplayAliasMu.Unlock()
+
+	msgs := []ClaudeThinkingReplayAliasMessage{{Hash: "msg1", Weight: 1}}
+	if _, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, "firstA"); ok {
+		t.Fatal("expected no resolve for expired alias")
+	}
+}
+
+func TestClaudeThinkingReplayAliasHomeCappedPerCredential(t *testing.T) {
 	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
 
-	gotKimi, foundKimi, errKimi := GetKimiThinkingReplayRequired(context.Background(), modelFamily, sessionKey)
-	if errKimi != nil || !foundKimi || !bytes.Equal(gotKimi, kimiContent) {
-		t.Fatalf("Kimi replay after Claude clear = %s, found %v, error %v; want preserved state", gotKimi, foundKimi, errKimi)
+	client := newFakeClaudeThinkingReplayKVClient()
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+
+	// Register more than the per-credential cap and ensure the oldest keys
+	// are evicted from the index.
+	max := ClaudeThinkingReplayCacheMaxAliasesPerCredential
+	for i := 0; i < max+10; i++ {
+		RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session", messageHashFor(i), "first")
 	}
-	gotClaude, foundClaude, errClaude := GetClaudeThinkingReplayRequired(context.Background(), modelFamily, sessionKey)
-	if errClaude != nil || foundClaude || len(gotClaude) != 0 {
-		t.Fatalf("Claude replay after Claude clear = %d turns, found %v, error %v; want cleared state", len(gotClaude), foundClaude, errClaude)
+
+	// The number of stored alias values should not exceed the cap.
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+	index, _ := decodeClaudeThinkingReplayAliasIndex(client.values[indexKey])
+	if len(index.Aliases) > max {
+		t.Fatalf("credential alias cap exceeded: %d > %d", len(index.Aliases), max)
 	}
+
+	// The oldest entries should have been deleted.
+	live := 0
+	for k := range client.values {
+		if k != indexKey {
+			live++
+		}
+	}
+	if live > max+1 { // +1 for the index key itself
+		t.Fatalf("too many live alias keys: %d", live)
+	}
+}
+
+func TestClaudeThinkingReplayAliasHomeMultiSessionResolve(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	client := newFakeClaudeThinkingReplayKVClient()
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionA", "msg1", "firstA")
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionA", "msg2", "firstA")
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionB", "msg1", "firstB")
+
+	msgs := []ClaudeThinkingReplayAliasMessage{{Hash: "msg1", Weight: 1}, {Hash: "msg2", Weight: 2}}
+	if s, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, "firstA"); !ok || s != "sessionA" {
+		t.Fatalf("home resolve: got %q, want sessionA", s)
+	}
+}
+
+func messageHashFor(i int) string {
+	const chars = "abcdefghijklmnopqrstuvwxyz"
+	s := make([]byte, 0, 8)
+	v := i
+	for j := 0; j < 8; j++ {
+		s = append(s, chars[v%26])
+		v /= 26
+	}
+	return string(s)
 }

--- a/internal/cache/claude_thinking_replay_cache_test.go
+++ b/internal/cache/claude_thinking_replay_cache_test.go
@@ -329,6 +329,113 @@ func TestResolveClaudeThinkingReplayAliasHomeRejectsTies(t *testing.T) {
 	}
 }
 
+func TestClaudeThinkingReplayAliasHomeCappedAcrossModelsPerCredential(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	client := newFakeClaudeThinkingReplayKVClient()
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	ctx := context.Background()
+	const credentialHash = "deadbeef"
+	modelA := "claude:" + credentialHash + ":modelA"
+	modelB := "claude:" + credentialHash + ":modelB"
+
+	// Both model families should map to the same credential-scoped index.
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelA)
+	if indexKey != claudeThinkingReplayAliasIndexKVKey(modelB) {
+		t.Fatalf("index key not shared across models for same credential: %q vs %q", indexKey, claudeThinkingReplayAliasIndexKVKey(modelB))
+	}
+
+	max := ClaudeThinkingReplayCacheMaxAliasesPerCredential
+	for i := 0; i < max+10; i++ {
+		mf := modelA
+		if i%2 == 1 {
+			mf = modelB
+		}
+		RegisterClaudeThinkingReplayAlias(ctx, mf, "session", messageHashFor(i), "first")
+	}
+
+	index, _ := decodeClaudeThinkingReplayAliasIndex(client.values[indexKey])
+	if len(index.Aliases) > max {
+		t.Fatalf("credential alias cap exceeded across models: %d > %d", len(index.Aliases), max)
+	}
+
+	live := 0
+	for k := range client.values {
+		if k != indexKey {
+			live++
+		}
+	}
+	if live > max+1 {
+		t.Fatalf("too many live alias keys across models: %d", live)
+	}
+}
+
+// failingIndexClaudeThinkingReplayKVClient fails every KVCompareAndSwap on the
+// index key, simulating a stale read that makes the index CAS lose. It verifies
+// that evicted alias values are NOT deleted before a successful index CAS.
+type failingIndexClaudeThinkingReplayKVClient struct {
+	*fakeClaudeThinkingReplayKVClient
+	indexKey string
+	mu       sync.Mutex
+}
+
+func (c *failingIndexClaudeThinkingReplayKVClient) KVCompareAndSwap(ctx context.Context, key string, expected []byte, expectedExists bool, newValue []byte, ttl time.Duration) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if key == c.indexKey {
+		return false, nil
+	}
+	return c.fakeClaudeThinkingReplayKVClient.KVCompareAndSwap(ctx, key, expected, expectedExists, newValue, ttl)
+}
+
+func TestClaudeThinkingReplayAliasHomeEvictionIsAtomicWithIndexCAS(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+
+	base := newFakeClaudeThinkingReplayKVClient()
+	client := &failingIndexClaudeThinkingReplayKVClient{
+		fakeClaudeThinkingReplayKVClient: base,
+		indexKey:                         indexKey,
+	}
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	// Pre-populate the index to the cap and create the matching alias values.
+	max := ClaudeThinkingReplayCacheMaxAliasesPerCredential
+	var index claudeThinkingReplayAliasIndex
+	now := time.Now()
+	for i := 0; i < max; i++ {
+		aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHashFor(i))
+		index.Aliases = append(index.Aliases, claudeThinkingReplayAliasIndexRecord{
+			AliasKey:  aliasKey,
+			Timestamp: now.Add(-time.Duration(max-i) * time.Second),
+		})
+		value, _ := json.Marshal(claudeThinkingReplayAliasHomeValue{
+			Sessions: []claudeThinkingReplayAliasHomeSession{
+				{SessionKey: "session", FirstUserHash: "first", Timestamp: now},
+			},
+		})
+		client.values[aliasKey] = value
+	}
+	indexBytes, _ := json.Marshal(index)
+	client.values[indexKey] = indexBytes
+
+	oldestAliasKey := index.Aliases[0].AliasKey
+
+	// The next registration will try to evict the oldest, but the index CAS is
+	// forced to fail. The evicted alias value must NOT be deleted.
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session", messageHashFor(max), "first")
+
+	if _, ok := client.values[oldestAliasKey]; !ok {
+		t.Fatalf("oldest alias %q deleted before successful index CAS", oldestAliasKey)
+	}
+}
+
 func messageHashFor(i int) string {
 	const chars = "abcdefghijklmnopqrstuvwxyz"
 	s := make([]byte, 0, 8)

--- a/internal/cache/claude_thinking_replay_cache_test.go
+++ b/internal/cache/claude_thinking_replay_cache_test.go
@@ -623,6 +623,47 @@ func TestClaudeThinkingReplayAliasHomeRollbackConditionalOnCommittedValue(t *tes
 	}
 }
 
+// erroredAliasCASClaudeThinkingReplayKVClient simulates an alias CAS that
+// returns an error after the value was already applied, leaving a partial
+// registration that must be rolled back.
+type erroredAliasCASClaudeThinkingReplayKVClient struct {
+	*fakeClaudeThinkingReplayKVClient
+	aliasKey string
+	errored  bool
+}
+
+func (c *erroredAliasCASClaudeThinkingReplayKVClient) KVCompareAndSwap(ctx context.Context, key string, expected []byte, expectedExists bool, newValue []byte, ttl time.Duration) (bool, error) {
+	if key == c.aliasKey && !c.errored {
+		c.errored = true
+		c.values[key] = append([]byte(nil), newValue...)
+		return false, fmt.Errorf("simulated alias CAS error")
+	}
+	return c.fakeClaudeThinkingReplayKVClient.KVCompareAndSwap(ctx, key, expected, expectedExists, newValue, ttl)
+}
+
+func TestClaudeThinkingReplayAliasHomeRollBackOnFailedRegistration(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	messageHash := "new-msg"
+	aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHash)
+
+	base := newFakeClaudeThinkingReplayKVClient()
+	client := &erroredAliasCASClaudeThinkingReplayKVClient{
+		fakeClaudeThinkingReplayKVClient: base,
+		aliasKey:                         aliasKey,
+	}
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session", messageHash, "first")
+
+	if _, ok := client.values[aliasKey]; ok {
+		t.Fatalf("alias %q was left after a failed CAS; expected rollback", aliasKey)
+	}
+}
+
 func messageHashFor(i int) string {
 	const chars = "abcdefghijklmnopqrstuvwxyz"
 	s := make([]byte, 0, 8)

--- a/internal/cache/claude_thinking_replay_cache_test.go
+++ b/internal/cache/claude_thinking_replay_cache_test.go
@@ -664,6 +664,59 @@ func TestClaudeThinkingReplayAliasHomeRollBackOnFailedRegistration(t *testing.T)
 	}
 }
 
+func TestClaudeThinkingReplayAliasEnforcesByteLimitAndLRU(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	ctx := context.Background()
+
+	// The byte limit is large; construct an alias with a very long modelFamily
+	// to push the aggregate size over the cap.
+	large := make([]byte, ClaudeThinkingReplayCacheMaxAliasBytes)
+	for i := range large {
+		large[i] = 'x'
+	}
+	modelFamily := "claude:" + string(large) + ":model"
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session-a", "msg", "first")
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session-b", "msg2", "first")
+
+	if claudeThinkingReplayAliasBytes > ClaudeThinkingReplayCacheMaxAliasBytes {
+		t.Fatalf("alias bytes %d still over the %d cap after enforcement", claudeThinkingReplayAliasBytes, ClaudeThinkingReplayCacheMaxAliasBytes)
+	}
+}
+
+func TestClaudeThinkingReplayAliasPerKeyEvictsOldestByTimestamp(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	ctx := context.Background()
+
+	modelFamily := "claude:cred:model"
+	messageHash := "shared-msg"
+
+	// Fill the per-key list with 8 sessions, each with a distinct timestamp.
+	for i := 0; i < ClaudeThinkingReplayCacheMaxAliasesPerKey; i++ {
+		useFakeClaudeThinkingReplayKVClient(t, newFakeClaudeThinkingReplayKVClient(), false)
+		RegisterClaudeThinkingReplayAlias(ctx, modelFamily, fmt.Sprintf("session-%d", i), messageHash, "first")
+	}
+
+	// Refresh the oldest one (session-0) so it becomes newest.
+	useFakeClaudeThinkingReplayKVClient(t, newFakeClaudeThinkingReplayKVClient(), false)
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session-0", messageHash, "first")
+
+	// Add one more. The oldest remaining by timestamp should be session-1.
+	useFakeClaudeThinkingReplayKVClient(t, newFakeClaudeThinkingReplayKVClient(), false)
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session-9", messageHash, "first")
+
+	key := claudeThinkingReplayAliasKey(modelFamily, messageHash)
+	list := claudeThinkingReplayAliases[key]
+	for _, e := range list {
+		if e.sessionKey == "session-1" {
+			t.Fatalf("session-1 should have been evicted as oldest after session-0 refresh")
+		}
+	}
+	if len(list) != ClaudeThinkingReplayCacheMaxAliasesPerKey {
+		t.Fatalf("per-key list len = %d, want %d", len(list), ClaudeThinkingReplayCacheMaxAliasesPerKey)
+	}
+}
+
 func messageHashFor(i int) string {
 	const chars = "abcdefghijklmnopqrstuvwxyz"
 	s := make([]byte, 0, 8)

--- a/internal/cache/claude_thinking_replay_cache_test.go
+++ b/internal/cache/claude_thinking_replay_cache_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -534,6 +535,44 @@ func TestClaudeThinkingReplayAliasHomeEvictionSkipsReaddedAlias(t *testing.T) {
 
 	if _, ok := client.values[client.evicted]; !ok {
 		t.Fatalf("evicted alias %q was deleted while re-added to index", client.evicted)
+	}
+}
+
+// indexGetFailingClaudeThinkingReplayKVClient fails KVGet for the index key.
+// This verifies rollback does not depend on an index read succeeding.
+type indexGetFailingClaudeThinkingReplayKVClient struct {
+	*fakeClaudeThinkingReplayKVClient
+	indexKey string
+}
+
+func (c *indexGetFailingClaudeThinkingReplayKVClient) KVGet(ctx context.Context, key string) ([]byte, bool, error) {
+	if key == c.indexKey {
+		return nil, false, fmt.Errorf("simulated index read failure")
+	}
+	return c.fakeClaudeThinkingReplayKVClient.KVGet(ctx, key)
+}
+
+func TestClaudeThinkingReplayAliasHomeRollbackConditionalOnCommittedValue(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+	messageHash := "new-msg"
+	aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHash)
+
+	base := newFakeClaudeThinkingReplayKVClient()
+	client := &indexGetFailingClaudeThinkingReplayKVClient{
+		fakeClaudeThinkingReplayKVClient: base,
+		indexKey:                         indexKey,
+	}
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session", messageHash, "first")
+
+	if _, ok := client.values[aliasKey]; ok {
+		t.Fatalf("alias %q was committed but not indexed; expected rollback conditional on committed value", aliasKey)
 	}
 }
 

--- a/internal/cache/claude_thinking_replay_cache_test.go
+++ b/internal/cache/claude_thinking_replay_cache_test.go
@@ -2,6 +2,9 @@ package cache
 
 import (
 	"context"
+	"encoding/json"
+	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -76,7 +79,7 @@ func (c *fakeClaudeThinkingReplayKVClient) KVExpire(context.Context, string, tim
 	return true, nil
 }
 
-func useFakeClaudeThinkingReplayKVClient(t *testing.T, client *fakeClaudeThinkingReplayKVClient, homeMode bool) {
+func useFakeClaudeThinkingReplayKVClient(t *testing.T, client kimiThinkingReplayKVClient, homeMode bool) {
 	t.Helper()
 	prev := currentClaudeThinkingReplayKVClient
 	currentClaudeThinkingReplayKVClient = func() (kimiThinkingReplayKVClient, bool, error) {
@@ -195,6 +198,134 @@ func TestClaudeThinkingReplayAliasHomeMultiSessionResolve(t *testing.T) {
 	msgs := []ClaudeThinkingReplayAliasMessage{{Hash: "msg1", Weight: 1}, {Hash: "msg2", Weight: 2}}
 	if s, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, "firstA"); !ok || s != "sessionA" {
 		t.Fatalf("home resolve: got %q, want sessionA", s)
+	}
+}
+
+// raceyClaudeThinkingReplayKVClient is a test client that fails the first
+// KVCompareAndSwap on a specific alias key and injects a new value, simulating
+// a concurrent writer. This verifies that the alias update retries and merges
+// instead of overwriting the injected session.
+type raceyClaudeThinkingReplayKVClient struct {
+	*fakeClaudeThinkingReplayKVClient
+	aliasKey string
+	injected []byte
+	attempts int
+	mu       sync.Mutex
+}
+
+func (c *raceyClaudeThinkingReplayKVClient) KVCompareAndSwap(ctx context.Context, key string, expected []byte, expectedExists bool, newValue []byte, ttl time.Duration) (bool, error) {
+	if key == c.aliasKey {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if c.attempts == 0 {
+			c.attempts++
+			c.values[key] = append([]byte(nil), c.injected...)
+			return false, nil
+		}
+		c.values[key] = append([]byte(nil), newValue...)
+		return true, nil
+	}
+	return c.fakeClaudeThinkingReplayKVClient.KVCompareAndSwap(ctx, key, expected, expectedExists, newValue, ttl)
+}
+
+func TestClaudeThinkingReplayAliasHomeAtomicListUpdates(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+	aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, "msg")
+
+	aValue, _ := json.Marshal(claudeThinkingReplayAliasHomeValue{
+		Sessions: []claudeThinkingReplayAliasHomeSession{
+			{SessionKey: "sessionA", FirstUserHash: "firstA", Timestamp: time.Now()},
+		},
+	})
+	abValue, _ := json.Marshal(claudeThinkingReplayAliasHomeValue{
+		Sessions: []claudeThinkingReplayAliasHomeSession{
+			{SessionKey: "sessionA", FirstUserHash: "firstA", Timestamp: time.Now()},
+			{SessionKey: "sessionB", FirstUserHash: "firstB", Timestamp: time.Now()},
+		},
+	})
+
+	base := newFakeClaudeThinkingReplayKVClient()
+	base.values[aliasKey] = aValue
+	client := &raceyClaudeThinkingReplayKVClient{
+		fakeClaudeThinkingReplayKVClient: base,
+		aliasKey:                         aliasKey,
+		injected:                         abValue,
+	}
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	// Register session C. The first CAS sees the initial value A; the racey
+	// client simulates a concurrent writer changing it to A+B and returns
+	// false. The function must retry, read A+B, append C, and CAS successfully.
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionC", "msg", "firstC")
+
+	raw, ok := client.values[aliasKey]
+	if !ok {
+		t.Fatal("alias value not found")
+	}
+	var value claudeThinkingReplayAliasHomeValue
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatalf("unmarshal alias value: %v", err)
+	}
+	got := make(map[string]string)
+	for _, s := range value.Sessions {
+		got[s.SessionKey] = s.FirstUserHash
+	}
+	want := map[string]string{
+		"sessionA": "firstA",
+		"sessionB": "firstB",
+		"sessionC": "firstC",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("alias sessions = %v, want %v", got, want)
+	}
+}
+
+func TestResolveClaudeThinkingReplayAliasRejectsTies(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionA", "msg", "firstA")
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionB", "msg", "firstB")
+
+	// Without a first-user bonus the two sessions are tied; refuse the match.
+	msgs := []ClaudeThinkingReplayAliasMessage{{Hash: "msg", Weight: 1}}
+	if _, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, ""); ok {
+		t.Fatal("expected no resolve for ambiguous tie")
+	}
+
+	// With a matching first-user hash one session uniquely wins.
+	if s, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, "firstA"); !ok || s != "sessionA" {
+		t.Fatalf("resolve with first-user bonus: got %q ok=%v, want sessionA", s, ok)
+	}
+}
+
+func TestResolveClaudeThinkingReplayAliasHomeRejectsTies(t *testing.T) {
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	client := newFakeClaudeThinkingReplayKVClient()
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	ctx := context.Background()
+	const modelFamily = "claude:test"
+
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionA", "msg", "firstA")
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "sessionB", "msg", "firstB")
+
+	msgs := []ClaudeThinkingReplayAliasMessage{{Hash: "msg", Weight: 1}}
+	if _, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, ""); ok {
+		t.Fatal("expected no resolve for home ambiguous tie")
+	}
+
+	if s, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, "firstA"); !ok || s != "sessionA" {
+		t.Fatalf("home resolve with first-user bonus: got %q ok=%v, want sessionA", s, ok)
 	}
 }
 

--- a/internal/cache/replay_alias_doctrine_test.go
+++ b/internal/cache/replay_alias_doctrine_test.go
@@ -1,0 +1,271 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// requireReplayAliasSupport skips the test when the Plus #209 replay-alias
+// behavior is not active (e.g. running on a branch without the alias registry).
+func requireReplayAliasSupport(t *testing.T) {
+	t.Helper()
+	ClearClaudeThinkingReplayCache()
+	ctx := context.Background()
+	const modelFamily = "claude:probe:model"
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "probe-session", "probe-msg", "probe-first")
+	msgs := []ClaudeThinkingReplayAliasMessage{{Hash: "probe-msg", Weight: 1}}
+	if _, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, msgs, "probe-first"); !ok {
+		t.Skip("Plus #209 not on main: replay alias resolution not implemented")
+	}
+}
+
+// TestReplayAliasDoctrineCompactionStableScopes verifies that a follow-up request
+// whose history has been compacted (first user message removed) still resolves to
+// the same conversation scope because later messages alias back to it.
+// Rule (a) from airouters-11 / Plus #209 / stock #5150.
+func TestReplayAliasDoctrineCompactionStableScopes(t *testing.T) {
+	requireReplayAliasSupport(t)
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:cred:model"
+	const session = "compaction-session"
+	const firstUser = "first-user-hash"
+
+	fullTurn := []ClaudeThinkingReplayAliasMessage{
+		{Hash: messageHashFor(0), Weight: 2}, // first user
+		{Hash: messageHashFor(1), Weight: 1}, // assistant
+		{Hash: messageHashFor(2), Weight: 2}, // user
+	}
+	for _, m := range fullTurn {
+		RegisterClaudeThinkingReplayAlias(ctx, modelFamily, session, m.Hash, firstUser)
+	}
+
+	// Compacted history: first user message is gone, assistant + last user remain.
+	compacted := []ClaudeThinkingReplayAliasMessage{
+		{Hash: messageHashFor(1), Weight: 1},
+		{Hash: messageHashFor(2), Weight: 2},
+	}
+	got, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, compacted, firstUser)
+	if !ok {
+		t.Skip("Plus #209 not on main: compacted history cannot resolve original scope")
+	}
+	if got != session {
+		t.Fatalf("compacted resolve = %q, want %q", got, session)
+	}
+}
+
+// TestReplayAliasDoctrineHomeKVAliasCapPerCredential verifies that flooding one
+// credential with aliases does not evict another credential's aliases from Home KV.
+// Rule (b) from airouters-11 / Plus #209 / stock #5150.
+func TestReplayAliasDoctrineHomeKVAliasCapPerCredential(t *testing.T) {
+	requireReplayAliasSupport(t)
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	client := newFakeClaudeThinkingReplayKVClient()
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	ctx := context.Background()
+	const credA = "claude:credA:model"
+	const credB = "claude:credB:model"
+
+	max := ClaudeThinkingReplayCacheMaxAliasesPerCredential
+
+	// Flood credential A to and past the per-credential cap.
+	for i := 0; i < max+10; i++ {
+		RegisterClaudeThinkingReplayAlias(ctx, credA, fmt.Sprintf("session-a-%d", i), messageHashFor(i), "first-a")
+	}
+
+	// Register a single alias for credential B.
+	const bHash = "b-only-msg"
+	RegisterClaudeThinkingReplayAlias(ctx, credB, "session-b", bHash, "first-b")
+
+	// Credential B must still resolve, proving A's flood did not exhaust B's index.
+	msgsB := []ClaudeThinkingReplayAliasMessage{{Hash: bHash, Weight: 1}}
+	if got, ok := ResolveClaudeThinkingReplaySessionKey(ctx, credB, msgsB, "first-b"); !ok || got != "session-b" {
+		t.Fatalf("credential B resolve = %q ok=%v; want session-b after credential A flood", got, ok)
+	}
+
+	// Credential A's newest aliases must still be resolvable; oldest are evicted.
+	newestA := messageHashFor(max + 9)
+	msgsA := []ClaudeThinkingReplayAliasMessage{{Hash: newestA, Weight: 1}}
+	if got, ok := ResolveClaudeThinkingReplaySessionKey(ctx, credA, msgsA, "first-a"); !ok || got != fmt.Sprintf("session-a-%d", max+9) {
+		t.Fatalf("credential A newest resolve = %q ok=%v; want session-a-%d", got, ok, max+9)
+	}
+
+	// Credential A's index must be at or under the cap.
+	indexA, _ := decodeClaudeThinkingReplayAliasIndex(client.values[claudeThinkingReplayAliasIndexKVKey(credA)])
+	if len(indexA.Aliases) > max {
+		t.Fatalf("credential A index exceeded per-credential cap: %d > %d", len(indexA.Aliases), max)
+	}
+
+	// Credential B's index must be independent and contain the one alias.
+	indexB, _ := decodeClaudeThinkingReplayAliasIndex(client.values[claudeThinkingReplayAliasIndexKVKey(credB)])
+	if len(indexB.Aliases) != 1 {
+		t.Fatalf("credential B index length = %d, want 1", len(indexB.Aliases))
+	}
+}
+
+// TestReplayAliasDoctrineAtomicEvictionWithIndexUpdate verifies that an alias
+// value is rolled back when its index update fails, and that no alias value is
+// deleted before the index has been updated and re-read successfully.
+// Rule (c) from airouters-11 / Plus #209 / stock #5150.
+func TestReplayAliasDoctrineAtomicEvictionWithIndexUpdate(t *testing.T) {
+	requireReplayAliasSupport(t)
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:cred:model"
+	indexKey := claudeThinkingReplayAliasIndexKVKey(modelFamily)
+
+	base := newFakeClaudeThinkingReplayKVClient()
+
+	// Pre-fill the index to cap and create matching alias values.
+	max := ClaudeThinkingReplayCacheMaxAliasesPerCredential
+	now := time.Now()
+	var index claudeThinkingReplayAliasIndex
+	for i := 0; i < max; i++ {
+		aliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHashFor(i))
+		index.Aliases = append(index.Aliases, claudeThinkingReplayAliasIndexRecord{
+			AliasKey:  aliasKey,
+			Timestamp: now.Add(-time.Duration(max-i) * time.Second),
+		})
+		value, _ := json.Marshal(claudeThinkingReplayAliasHomeValue{
+			Sessions: []claudeThinkingReplayAliasHomeSession{
+				{SessionKey: "session", FirstUserHash: "first", Timestamp: now},
+			},
+		})
+		base.values[aliasKey] = value
+	}
+	indexBytes, _ := json.Marshal(index)
+	base.values[indexKey] = indexBytes
+
+	failingClient := &failingIndexClaudeThinkingReplayKVClient{
+		fakeClaudeThinkingReplayKVClient: base,
+		indexKey:                         indexKey,
+	}
+	useFakeClaudeThinkingReplayKVClient(t, failingClient, true)
+
+	oldestAliasKey := index.Aliases[0].AliasKey
+
+	// This registration attempts to evict the oldest alias, but the index CAS
+	// fails every time, so neither the new alias value nor the evicted deletion
+	// should be observable.
+	RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session", messageHashFor(max), "first")
+
+	if _, ok := base.values[oldestAliasKey]; !ok {
+		t.Fatalf("evicted alias %q deleted before index CAS succeeded", oldestAliasKey)
+	}
+
+	// The new alias value must not be left unindexed.
+	newAliasKey := claudeThinkingReplayAliasKVKey(modelFamily, messageHashFor(max))
+	if _, ok := base.values[newAliasKey]; ok {
+		t.Fatalf("unindexed alias value %q left behind after failed index CAS", newAliasKey)
+	}
+
+}
+
+// TestReplayAliasDoctrineIdenticalConversationsIdenticalScopes verifies that two
+// identical conversation openings resolve to the same replay scope.
+// Rule (d) from airouters-11 / Plus #209 / stock #5150.
+func TestReplayAliasDoctrineIdenticalConversationsIdenticalScopes(t *testing.T) {
+	requireReplayAliasSupport(t)
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:cred:model"
+	const firstUser = "shared-first-user"
+
+	conversation := []ClaudeThinkingReplayAliasMessage{
+		{Hash: messageHashFor(1), Weight: 2},
+		{Hash: messageHashFor(2), Weight: 1},
+		{Hash: messageHashFor(3), Weight: 2},
+	}
+
+	for _, m := range conversation {
+		RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "identical-session", m.Hash, firstUser)
+	}
+
+	got, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, conversation, firstUser)
+	if !ok {
+		t.Skip("Plus #209 not on main: identical conversation cannot resolve shared scope")
+	}
+	if got != "identical-session" {
+		t.Fatalf("identical conversation resolve = %q, want identical-session", got)
+	}
+}
+
+// TestReplayAliasDoctrineDistinctConversationsNeverCollapse verifies that two
+// conversations sharing the same visible messages but with different first-user
+// context never collapse into a single scope.
+// Rule (d) from airouters-11 / Plus #209 / stock #5150.
+func TestReplayAliasDoctrineDistinctConversationsNeverCollapse(t *testing.T) {
+	requireReplayAliasSupport(t)
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	ctx := context.Background()
+	const modelFamily = "claude:cred:model"
+
+	shared := []ClaudeThinkingReplayAliasMessage{
+		{Hash: messageHashFor(1), Weight: 2},
+		{Hash: messageHashFor(2), Weight: 1},
+	}
+
+	for _, m := range shared {
+		RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session-a", m.Hash, "first-a")
+		RegisterClaudeThinkingReplayAlias(ctx, modelFamily, "session-b", m.Hash, "first-b")
+	}
+
+	// Without first-user context the two sessions tie; resolve must refuse.
+	if _, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, shared, ""); ok {
+		t.Fatal("distinct conversations with identical messages collapsed without first-user context")
+	}
+
+	// With first-user context, each resolves to its own scope.
+	if got, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, shared, "first-a"); !ok || got != "session-a" {
+		t.Fatalf("first-a resolve = %q ok=%v; want session-a", got, ok)
+	}
+	if got, ok := ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, shared, "first-b"); !ok || got != "session-b" {
+		t.Fatalf("first-b resolve = %q ok=%v; want session-b", got, ok)
+	}
+}
+
+// TestReplayAliasDoctrineHomeKVCrossCredentialIsolation is a stricter version of
+// the per-credential cap: a distinct credential should not even share an index.
+func TestReplayAliasDoctrineHomeKVCrossCredentialIsolation(t *testing.T) {
+	requireReplayAliasSupport(t)
+	ClearClaudeThinkingReplayCache()
+	defer ClearClaudeThinkingReplayCache()
+
+	client := newFakeClaudeThinkingReplayKVClient()
+	useFakeClaudeThinkingReplayKVClient(t, client, true)
+
+	ctx := context.Background()
+	const mfA = "claude:credA:model"
+	const mfB = "claude:credB:model"
+
+	if keyA, keyB := claudeThinkingReplayAliasIndexKVKey(mfA), claudeThinkingReplayAliasIndexKVKey(mfB); keyA == keyB {
+		t.Fatalf("different credentials share the same index key: %q", keyA)
+	}
+
+	// Register the same visible message under two different credentials.
+	RegisterClaudeThinkingReplayAlias(ctx, mfA, "session-a", "shared-msg", "first-a")
+	RegisterClaudeThinkingReplayAlias(ctx, mfB, "session-b", "shared-msg", "first-b")
+
+	// Each credential resolves to its own session.
+	msgs := []ClaudeThinkingReplayAliasMessage{{Hash: "shared-msg", Weight: 1}}
+	if got, ok := ResolveClaudeThinkingReplaySessionKey(ctx, mfA, msgs, "first-a"); !ok || got != "session-a" {
+		t.Fatalf("credential A resolve = %q ok=%v; want session-a", got, ok)
+	}
+	if got, ok := ResolveClaudeThinkingReplaySessionKey(ctx, mfB, msgs, "first-b"); !ok || got != "session-b" {
+		t.Fatalf("credential B resolve = %q ok=%v; want session-b", got, ok)
+	}
+}

--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -91,7 +91,9 @@ func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (cloakMode string, strictMo
 }
 
 // injectFakeUserID generates and injects a fake user ID into the request metadata.
-// When useCache is false, a new user ID is generated for every call.
+// The user ID is derived deterministically from the auth credential and session
+// so the same credential always produces the same upstream metadata, preserving
+// prompt-cache prefix stability.
 func injectFakeUserID(ctx context.Context, payload []byte, apiKey string, useCache bool) ([]byte, error) {
 	generateID := func() (string, error) {
 		if useCache {

--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -1247,20 +1247,40 @@ func countCacheControls(payload []byte) int {
 
 // stripCacheControls removes Anthropic-only prompt-caching fields before a
 // delegated Claude-format request is sent to a provider that does not support
-// them, such as Kimi.
+// them, such as Kimi. It only targets protocol-level cache_control markers on
+// system/tool/message blocks and nested content blocks (e.g. tool_result
+// content); arbitrary JSON like tool input_schema properties named
+// "cache_control" are left untouched.
 func stripCacheControls(payload []byte) []byte {
 	result := payload
+	for i := range gjson.GetBytes(result, "system").Array() {
+		result, _ = sjson.DeleteBytes(result, fmt.Sprintf("system.%d.cache_control", i))
+		result = stripContentCacheControls(result, fmt.Sprintf("system.%d.content", i))
+	}
 	for i := range gjson.GetBytes(result, "tools").Array() {
 		result, _ = sjson.DeleteBytes(result, fmt.Sprintf("tools.%d.cache_control", i))
 	}
-	for i := range gjson.GetBytes(result, "system").Array() {
-		result, _ = sjson.DeleteBytes(result, fmt.Sprintf("system.%d.cache_control", i))
+	for i := range gjson.GetBytes(result, "messages").Array() {
+		result, _ = sjson.DeleteBytes(result, fmt.Sprintf("messages.%d.cache_control", i))
+		result = stripContentCacheControls(result, fmt.Sprintf("messages.%d.content", i))
 	}
-	for messageIndex, message := range gjson.GetBytes(result, "messages").Array() {
-		result, _ = sjson.DeleteBytes(result, fmt.Sprintf("messages.%d.cache_control", messageIndex))
-		for contentIndex := range message.Get("content").Array() {
-			result, _ = sjson.DeleteBytes(result, fmt.Sprintf("messages.%d.content.%d.cache_control", messageIndex, contentIndex))
-		}
+	return result
+}
+
+// stripContentCacheControls removes cache_control from each block in a content
+// array and recurses into nested content arrays (e.g. a tool_result whose
+// content is an array of text/image blocks). It does not walk into siblings of
+// content such as tool_use input or tool input_schema.
+func stripContentCacheControls(payload []byte, contentPath string) []byte {
+	result := payload
+	arr := gjson.GetBytes(result, contentPath)
+	if !arr.IsArray() {
+		return result
+	}
+	for i := range arr.Array() {
+		itemPath := fmt.Sprintf("%s.%d", contentPath, i)
+		result, _ = sjson.DeleteBytes(result, fmt.Sprintf("%s.cache_control", itemPath))
+		result = stripContentCacheControls(result, fmt.Sprintf("%s.content", itemPath))
 	}
 	return result
 }

--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -91,17 +91,19 @@ func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (cloakMode string, strictMo
 }
 
 // injectFakeUserID generates and injects a fake user ID into the request metadata.
-// When useCache is false, a new user ID is generated for every call.
-func injectFakeUserID(ctx context.Context, payload []byte, apiKey string, useCache bool) ([]byte, error) {
+// When useCache is true, the user ID is cached and stable per credential.
+// When useCache is false, the device_id is fresh per request while the session_id
+// stays stable, preserving header/body session alignment.
+func injectFakeUserID(ctx context.Context, payload []byte, auth *cliproxyauth.Auth, apiKey string, useCache bool) ([]byte, error) {
 	generateID := func() (string, error) {
-		if useCache {
-			return helps.CachedUserIDRequired(ctx, apiKey)
-		}
-		sessionID, errSessionID := helps.CachedSessionIDRequired(ctx, apiKey)
+		sessionID, errSessionID := helps.CachedSessionIDRequired(ctx, apiKey, auth)
 		if errSessionID != nil {
 			return "", errSessionID
 		}
-		return helps.GenerateFakeUserIDWithSessionID(sessionID), nil
+		if useCache {
+			return helps.CachedUserIDRequired(ctx, apiKey, auth)
+		}
+		return helps.GenerateRandomFakeUserIDForSession(sessionID), nil
 	}
 
 	metadata := gjson.GetBytes(payload, "metadata")
@@ -1033,7 +1035,7 @@ func applyCloaking(
 	// Other non-OAuth cloaking keeps the legacy per-request fake user_id.
 	if !policy.ProfileClaudeCodeCLI {
 		var errFakeUserID error
-		payload, errFakeUserID = injectFakeUserID(ctx, payload, apiKey, settings.cacheUserID)
+		payload, errFakeUserID = injectFakeUserID(ctx, payload, auth, apiKey, settings.cacheUserID)
 		if errFakeUserID != nil {
 			return nil, false, errFakeUserID
 		}

--- a/internal/runtime/executor/claude_executor_cloaking.go
+++ b/internal/runtime/executor/claude_executor_cloaking.go
@@ -91,19 +91,19 @@ func getCloakConfigFromAuth(auth *cliproxyauth.Auth) (cloakMode string, strictMo
 }
 
 // injectFakeUserID generates and injects a fake user ID into the request metadata.
-// The user ID is derived deterministically from the auth credential and session
-// so the same credential always produces the same upstream metadata, preserving
-// prompt-cache prefix stability.
+// When useCache is true, the user ID is cached and stable per credential.
+// When useCache is false, the device_id is fresh per request while the session_id
+// stays stable, preserving header/body session alignment.
 func injectFakeUserID(ctx context.Context, payload []byte, apiKey string, useCache bool) ([]byte, error) {
 	generateID := func() (string, error) {
-		if useCache {
-			return helps.CachedUserIDRequired(ctx, apiKey)
-		}
 		sessionID, errSessionID := helps.CachedSessionIDRequired(ctx, apiKey)
 		if errSessionID != nil {
 			return "", errSessionID
 		}
-		return helps.GenerateFakeUserIDWithSessionID(sessionID), nil
+		if useCache {
+			return helps.CachedUserIDRequired(ctx, apiKey)
+		}
+		return helps.GenerateRandomFakeUserIDForSession(sessionID), nil
 	}
 
 	metadata := gjson.GetBytes(payload, "metadata")

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -40,8 +40,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("claude")
 	var replayScope claudeThinkingReplayScope
+	var replayContents [][]byte
 	if claudeThinkingReplayEnabled(auth, req, opts) {
-		req, replayScope = prepareClaudeThinkingReplayRequest(ctx, auth, req, opts)
+		replayScope, replayContents, _ = prepareClaudeThinkingReplayRequest(ctx, auth, req, opts)
 	}
 	defer func() {
 		if err != nil && replayScope.replayApplied && shouldClearKimiThinkingReplayAfterError(err) {
@@ -168,12 +169,15 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	extraBetas, body = extractAndRemoveBetas(body)
 	bodyForTranslation := body
 	bodyForUpstream := body
+	bodyForUpstream = sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, bodyForUpstream, baseModel, helps.APIKeyModelIsCompat(req))
+	if len(replayContents) > 0 && replayScope.valid() {
+		bodyForUpstream, replayScope.replayApplied = restoreClaudeThinkingReplayContents(bodyForUpstream, replayContents)
+	}
 	var oauthToolNamesReverseMap map[string]string
 	if fp.MCPAlias && cloaked {
 		mcpAliases := resolveClaudeMCPAliasOptions(ctx)
 		bodyForUpstream, oauthToolNamesReverseMap = prepareClaudeOAuthToolNamesForUpstream(bodyForUpstream, mcpAliases)
 	}
-	bodyForUpstream = sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, bodyForUpstream, baseModel, helps.APIKeyModelIsCompat(req))
 	if fp.ApplyCLIIdentity {
 		bodyForUpstream, err = applyClaudeCLIIdentity(bodyForUpstream, auth, apiKey, url, claudeSessionID, fp.SynthesizeIdentity)
 		if err != nil {

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -94,7 +94,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	// If cloaking obfuscated the upstream body, cached assistant content must be
 	// obfuscated with the same words before the replay match/restore runs.
 	_, cloakSettings := resolveClaudeWirePolicy(e.cfg, auth, apiKey, confirmedClaudeCode)
-	if len(cloakSettings.sensitiveWords) > 0 && len(replayContents) > 0 {
+	if cloaked && len(cloakSettings.sensitiveWords) > 0 && len(replayContents) > 0 {
 		replayContents = obfuscateClaudeThinkingReplayContents(replayContents, cloakSettings.sensitiveWords)
 	}
 	systemPlacementState := captureClaudeCodeSystemPlacement(bodyBeforeCloaking, body, cloaked)

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -40,9 +40,8 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("claude")
 	var replayScope claudeThinkingReplayScope
-	var replayContents [][]byte
 	if claudeThinkingReplayEnabled(auth, req, opts) {
-		replayScope, replayContents, _ = prepareClaudeThinkingReplayRequest(ctx, auth, req, opts)
+		req, replayScope = prepareClaudeThinkingReplayRequest(ctx, auth, req, opts)
 	}
 	defer func() {
 		if err != nil && replayScope.replayApplied && shouldClearKimiThinkingReplayAfterError(err) {
@@ -175,9 +174,6 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		bodyForUpstream, oauthToolNamesReverseMap = prepareClaudeOAuthToolNamesForUpstream(bodyForUpstream, mcpAliases)
 	}
 	bodyForUpstream = sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, bodyForUpstream, baseModel, helps.APIKeyModelIsCompat(req))
-	if len(replayContents) > 0 && replayScope.valid() {
-		bodyForUpstream, replayScope.replayApplied = restoreClaudeThinkingReplayContents(bodyForUpstream, replayContents)
-	}
 	if fp.ApplyCLIIdentity {
 		bodyForUpstream, err = applyClaudeCLIIdentity(bodyForUpstream, auth, apiKey, url, claudeSessionID, fp.SynthesizeIdentity)
 		if err != nil {

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -91,6 +91,12 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if err != nil {
 		return resp, err
 	}
+	// If cloaking obfuscated the upstream body, cached assistant content must be
+	// obfuscated with the same words before the replay match/restore runs.
+	_, cloakSettings := resolveClaudeWirePolicy(e.cfg, auth, apiKey, confirmedClaudeCode)
+	if len(cloakSettings.sensitiveWords) > 0 && len(replayContents) > 0 {
+		replayContents = obfuscateClaudeThinkingReplayContents(replayContents, cloakSettings.sensitiveWords)
+	}
 	systemPlacementState := captureClaudeCodeSystemPlacement(bodyBeforeCloaking, body, cloaked)
 	// Only the Messages endpoint on Anthropic itself was captured; count_tokens
 	// keeps its own shape and other gateways never see this field.

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -40,8 +40,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("claude")
 	var replayScope claudeThinkingReplayScope
+	var replayContents [][]byte
 	if claudeThinkingReplayEnabled(auth, req, opts) {
-		req, replayScope = prepareClaudeThinkingReplayRequest(ctx, auth, req, opts)
+		replayScope, replayContents, _ = prepareClaudeThinkingReplayRequest(ctx, auth, req, opts)
 	}
 	defer func() {
 		if err != nil && replayScope.replayApplied && shouldClearKimiThinkingReplayAfterError(err) {
@@ -116,17 +117,42 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body = reconcileClaudeCodeContextManagement(body, contextManagementState)
 	body = normalizeClaudeSamplingForUpstream(body, confirmedClaudeCode)
 
-	if e.cacheControlDisabled {
-		body = stripCacheControls(body)
-	} else {
+	// Default cache_control for translated entrypoints (Responses/Chat/Gemini) and other
+	// non-native callers. Confirmed native Claude Code owns its marker placement and must
+	// not be rewritten. Cloaked requests always run section-independent ensure so cloaking's
+	// first-user marker cannot suppress system/latest-user breakpoints.
+	// cloaked and confirmedClaudeCode are mutually exclusive: resolveClaudeWirePolicy
+	// forces Cloak off for a confirmed native client.
+	// Embedders that disable cache_control (e.g. Kimi reusing the Claude path) must
+	// skip all cache-control placement entirely.
+	if !e.cacheControlDisabled {
 		cpaOwnsCacheControl := shouldEnsureCacheControl(body, cloaked, confirmedClaudeCode)
 		if cpaOwnsCacheControl {
 			body = ensureCacheControl(body)
 		}
+
+		// Enforce Anthropic's cache_control block limit (max 4 breakpoints per request).
+		// Cloaking and ensureCacheControl may push the total over 4 when the client
+		// already sends multiple cache_control blocks.
 		body = enforceCacheControlLimit(body, 4)
+
+		// Native selects the 1h cache pool only for OAuth credentials and pairs it with
+		// extended-cache-ttl-2025-04-11, which claudeCodeCLIBetas emits on exactly the
+		// same credential condition. Upgrading after placement is settled mirrors the
+		// native ttl helper.
+		//
+		// This runs only while CPA owns placement, and it then owns the ttl of every
+		// breakpoint it can reach: a marker carrying no ttl is the wire default, not an
+		// opt-in to 5m, so a cloaked caller's bare {"type":"ephemeral"} is upgraded too.
+		// Only a ttl the caller wrote out explicitly survives, because
+		// upgradeClaudeCacheControlTTL skips any block that already has one.
+		// claude-code-cli fingerprint profiles emit extended-cache-ttl and must use the same 1h pool.
 		if cpaOwnsCacheControl && fp.ProfileClaudeCodeCLI {
 			body = upgradeClaudeCacheControlTTL(body, claudeCacheControlTTL1h)
 		}
+
+		// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
+		// A 1h-TTL block must not appear after a 5m-TTL block in evaluation order (tools→system→messages).
 		body = normalizeCacheControlTTL(body)
 	}
 	// Payload rules and other request processing may rewrite stream. Keep the
@@ -149,6 +175,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		bodyForUpstream, oauthToolNamesReverseMap = prepareClaudeOAuthToolNamesForUpstream(bodyForUpstream, mcpAliases)
 	}
 	bodyForUpstream = sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, bodyForUpstream, baseModel, helps.APIKeyModelIsCompat(req))
+	if len(replayContents) > 0 && replayScope.valid() {
+		bodyForUpstream, replayScope.replayApplied = restoreClaudeThinkingReplayContents(bodyForUpstream, replayContents)
+	}
 	if fp.ApplyCLIIdentity {
 		bodyForUpstream, err = applyClaudeCLIIdentity(bodyForUpstream, auth, apiKey, url, claudeSessionID, fp.SynthesizeIdentity)
 		if err != nil {

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -874,7 +874,7 @@ func applyClaudeHeadersWithNativeProfile(
 		r.Header.Set("X-Claude-Code-Session-Id", sessionID)
 	} else {
 		var errSessionID error
-		sessionID, errSessionID = helps.CachedSessionIDRequired(r.Context(), apiKey)
+		sessionID, errSessionID = helps.CachedSessionIDRequired(r.Context(), apiKey, auth)
 		if errSessionID != nil {
 			return errSessionID
 		}

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -50,6 +50,10 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	if claudeThinkingReplayEnabled(auth, req, opts) {
 		replayScope, replayContents, _ = prepareClaudeThinkingReplayRequest(ctx, auth, req, opts)
 	}
+	var replayAccum *kimiThinkingReplayStreamAccumulator
+	if replayScope.valid() && responseFormat != to {
+		replayAccum = newKimiThinkingReplayStreamAccumulator()
+	}
 	defer func() {
 		if err != nil && replayScope.replayApplied && shouldClearKimiThinkingReplayAfterError(err) {
 			clearClaudeThinkingReplayContent(ctx, replayScope)
@@ -384,6 +388,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			observeClaudeStreamLine(line, &upstreamMessageID, &upstreamCompleted)
+			if replayAccum != nil {
+				replayAccum.observe(line)
+			}
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 			if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
 				reporter.Publish(ctx, detail)
@@ -433,6 +440,11 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		}
 		if upstreamCompleted {
 			commitClaudeDiagnostics(diagnosticsState, upstreamMessageID)
+		}
+		if replayAccum != nil && upstreamCompleted {
+			if content, completed := replayAccum.content(); completed {
+				cacheClaudeThinkingReplayContent(ctx, replayScope, content)
+			}
 		}
 	}()
 	result := &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -388,9 +388,6 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			observeClaudeStreamLine(line, &upstreamMessageID, &upstreamCompleted)
-			if replayAccum != nil {
-				replayAccum.observe(line)
-			}
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 			if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
 				reporter.Publish(ctx, detail)
@@ -401,6 +398,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				return
 			}
 			line = e.restoreResponseModel(restoredLine, req.Model)
+			if replayAccum != nil {
+				replayAccum.observe(line)
+			}
 			chunks := sdktranslator.TranslateStream(
 				ctx,
 				to,

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -46,8 +46,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("claude")
 	var replayScope claudeThinkingReplayScope
+	var replayContents [][]byte
 	if claudeThinkingReplayEnabled(auth, req, opts) {
-		req, replayScope = prepareClaudeThinkingReplayRequest(ctx, auth, req, opts)
+		replayScope, replayContents, _ = prepareClaudeThinkingReplayRequest(ctx, auth, req, opts)
 	}
 	defer func() {
 		if err != nil && replayScope.replayApplied && shouldClearKimiThinkingReplayAfterError(err) {
@@ -119,19 +120,42 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body = reconcileClaudeCodeContextManagement(body, contextManagementState)
 	body = normalizeClaudeSamplingForUpstream(body, confirmedClaudeCode)
 
-	if e.cacheControlDisabled {
-		body = stripCacheControls(body)
-	} else {
+	// Default cache_control for translated entrypoints (Responses/Chat/Gemini) and other
+	// non-native callers. Confirmed native Claude Code owns its marker placement and must
+	// not be rewritten. Cloaked requests always run section-independent ensure so cloaking's
+	// first-user marker cannot suppress system/latest-user breakpoints.
+	// cloaked and confirmedClaudeCode are mutually exclusive: resolveClaudeWirePolicy
+	// forces Cloak off for a confirmed native client.
+	// Embedders that disable cache_control (e.g. Kimi reusing the Claude path) must
+	// skip all cache-control placement entirely.
+	if !e.cacheControlDisabled {
 		cpaOwnsCacheControl := shouldEnsureCacheControl(body, cloaked, confirmedClaudeCode)
 		if cpaOwnsCacheControl {
 			body = ensureCacheControl(body)
 		}
+
+		// Enforce Anthropic's cache_control block limit (max 4 breakpoints per request).
 		body = enforceCacheControlLimit(body, 4)
+
+		// Native selects the 1h cache pool only for OAuth credentials and pairs it with
+		// extended-cache-ttl-2025-04-11, which claudeCodeCLIBetas emits on exactly the
+		// same credential condition. Upgrading after placement is settled mirrors the
+		// native ttl helper.
+		//
+		// This runs only while CPA owns placement, and it then owns the ttl of every
+		// breakpoint it can reach: a marker carrying no ttl is the wire default, not an
+		// opt-in to 5m, so a cloaked caller's bare {"type":"ephemeral"} is upgraded too.
+		// Only a ttl the caller wrote out explicitly survives, because
+		// upgradeClaudeCacheControlTTL skips any block that already has one.
+		// claude-code-cli fingerprint profiles emit extended-cache-ttl and must use the same 1h pool.
 		if cpaOwnsCacheControl && fp.ProfileClaudeCodeCLI {
 			body = upgradeClaudeCacheControlTTL(body, claudeCacheControlTTL1h)
 		}
+
+		// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
 		body = normalizeCacheControlTTL(body)
 	}
+
 	// Extract betas from body and convert to header
 	var extraBetas []string
 	extraBetas, body = extractAndRemoveBetas(body)
@@ -143,6 +167,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		bodyForUpstream, oauthToolNamesReverseMap = prepareClaudeOAuthToolNamesForUpstream(bodyForUpstream, mcpAliases)
 	}
 	bodyForUpstream = sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, bodyForUpstream, baseModel, helps.APIKeyModelIsCompat(req))
+	if len(replayContents) > 0 && replayScope.valid() {
+		bodyForUpstream, replayScope.replayApplied = restoreClaudeThinkingReplayContents(bodyForUpstream, replayContents)
+	}
 	if fp.ApplyCLIIdentity {
 		bodyForUpstream, err = applyClaudeCLIIdentity(bodyForUpstream, auth, apiKey, url, claudeSessionID, fp.SynthesizeIdentity)
 		if err != nil {

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -46,9 +46,8 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("claude")
 	var replayScope claudeThinkingReplayScope
-	var replayContents [][]byte
 	if claudeThinkingReplayEnabled(auth, req, opts) {
-		replayScope, replayContents, _ = prepareClaudeThinkingReplayRequest(ctx, auth, req, opts)
+		req, replayScope = prepareClaudeThinkingReplayRequest(ctx, auth, req, opts)
 	}
 	defer func() {
 		if err != nil && replayScope.replayApplied && shouldClearKimiThinkingReplayAfterError(err) {
@@ -167,9 +166,6 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		bodyForUpstream, oauthToolNamesReverseMap = prepareClaudeOAuthToolNamesForUpstream(bodyForUpstream, mcpAliases)
 	}
 	bodyForUpstream = sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, bodyForUpstream, baseModel, helps.APIKeyModelIsCompat(req))
-	if len(replayContents) > 0 && replayScope.valid() {
-		bodyForUpstream, replayScope.replayApplied = restoreClaudeThinkingReplayContents(bodyForUpstream, replayContents)
-	}
 	if fp.ApplyCLIIdentity {
 		bodyForUpstream, err = applyClaudeCLIIdentity(bodyForUpstream, auth, apiKey, url, claudeSessionID, fp.SynthesizeIdentity)
 		if err != nil {

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -46,8 +46,9 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("claude")
 	var replayScope claudeThinkingReplayScope
+	var replayContents [][]byte
 	if claudeThinkingReplayEnabled(auth, req, opts) {
-		req, replayScope = prepareClaudeThinkingReplayRequest(ctx, auth, req, opts)
+		replayScope, replayContents, _ = prepareClaudeThinkingReplayRequest(ctx, auth, req, opts)
 	}
 	defer func() {
 		if err != nil && replayScope.replayApplied && shouldClearKimiThinkingReplayAfterError(err) {
@@ -160,12 +161,15 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	extraBetas, body = extractAndRemoveBetas(body)
 	bodyForTranslation := body
 	bodyForUpstream := body
+	bodyForUpstream = sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, bodyForUpstream, baseModel, helps.APIKeyModelIsCompat(req))
+	if len(replayContents) > 0 && replayScope.valid() {
+		bodyForUpstream, replayScope.replayApplied = restoreClaudeThinkingReplayContents(bodyForUpstream, replayContents)
+	}
 	var oauthToolNamesReverseMap map[string]string
 	if fp.MCPAlias && cloaked {
 		mcpAliases := resolveClaudeMCPAliasOptions(ctx)
 		bodyForUpstream, oauthToolNamesReverseMap = prepareClaudeOAuthToolNamesForUpstream(bodyForUpstream, mcpAliases)
 	}
-	bodyForUpstream = sanitizeClaudeMessagesForClaudeUpstreamWithDebug(ctx, bodyForUpstream, baseModel, helps.APIKeyModelIsCompat(req))
 	if fp.ApplyCLIIdentity {
 		bodyForUpstream, err = applyClaudeCLIIdentity(bodyForUpstream, auth, apiKey, url, claudeSessionID, fp.SynthesizeIdentity)
 		if err != nil {

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -97,7 +97,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	// If cloaking obfuscated the upstream body, cached assistant content must be
 	// obfuscated with the same words before the replay match/restore runs.
 	_, cloakSettings := resolveClaudeWirePolicy(e.cfg, auth, apiKey, confirmedClaudeCode)
-	if len(cloakSettings.sensitiveWords) > 0 && len(replayContents) > 0 {
+	if cloaked && len(cloakSettings.sensitiveWords) > 0 && len(replayContents) > 0 {
 		replayContents = obfuscateClaudeThinkingReplayContents(replayContents, cloakSettings.sensitiveWords)
 	}
 	systemPlacementState := captureClaudeCodeSystemPlacement(bodyBeforeCloaking, body, cloaked)

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -94,6 +94,12 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	if err != nil {
 		return nil, err
 	}
+	// If cloaking obfuscated the upstream body, cached assistant content must be
+	// obfuscated with the same words before the replay match/restore runs.
+	_, cloakSettings := resolveClaudeWirePolicy(e.cfg, auth, apiKey, confirmedClaudeCode)
+	if len(cloakSettings.sensitiveWords) > 0 && len(replayContents) > 0 {
+		replayContents = obfuscateClaudeThinkingReplayContents(replayContents, cloakSettings.sensitiveWords)
+	}
 	systemPlacementState := captureClaudeCodeSystemPlacement(bodyBeforeCloaking, body, cloaked)
 	// Only the Messages endpoint on Anthropic itself was captured; count_tokens
 	// keeps its own shape and other gateways never see this field.

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -6455,7 +6455,11 @@ func TestClaudeExecutor_CacheTTLIsPairedWithExtendedCacheTTLBeta(t *testing.T) {
 
 func TestApplyCloaking_DeterministicUserID(t *testing.T) {
 	cfg := &config.Config{}
-	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-123", "cloak_mode": "always"}}
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":             "key-123",
+		"cloak_mode":          "always",
+		"cloak_cache_user_id": "true",
+	}}
 	payload := []byte(`{"model":"claude-opus-5","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`)
 
 	first, cloaked, err := applyCloaking(context.Background(), cfg, auth, payload, "key-123", false, false)
@@ -6480,11 +6484,15 @@ func TestApplyCloaking_DeterministicUserID(t *testing.T) {
 		t.Fatal("metadata.user_id is empty")
 	}
 	if userID1 != userID2 {
-		t.Fatalf("same conversation produced different metadata.user_id: %q vs %q", userID1, userID2)
+		t.Fatalf("cache-user-id:true must produce a stable user_id, got %q vs %q", userID1, userID2)
 	}
 
 	// Different credentials must produce different user IDs.
-	auth2 := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-456", "cloak_mode": "always"}}
+	auth2 := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":             "key-456",
+		"cloak_mode":          "always",
+		"cloak_cache_user_id": "true",
+	}}
 	third, _, _ := applyCloaking(context.Background(), cfg, auth2, payload, "key-456", false, false)
 	userID3 := gjson.GetBytes(third, "metadata.user_id").String()
 	if userID1 == userID3 {
@@ -6500,5 +6508,99 @@ func TestApplyCloaking_DeterministicUserID(t *testing.T) {
 	}
 	if got := gjson.GetBytes(fourth, "metadata.user_id").String(); got != callerUserID {
 		t.Fatalf("caller-supplied metadata.user_id not preserved, got %q want %q", got, callerUserID)
+	}
+}
+
+func TestApplyCloaking_NonCachedUserIDIsRandom(t *testing.T) {
+	cfg := &config.Config{}
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":    "key-123",
+		"cloak_mode": "always",
+	}}
+	payload := []byte(`{"model":"claude-opus-5","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`)
+
+	first, cloaked, err := applyCloaking(context.Background(), cfg, auth, payload, "key-123", false, false)
+	if err != nil {
+		t.Fatalf("applyCloaking() error = %v", err)
+	}
+	if !cloaked {
+		t.Fatal("applyCloaking() cloaked = false, want true")
+	}
+
+	second, cloaked2, err2 := applyCloaking(context.Background(), cfg, auth, payload, "key-123", false, false)
+	if err2 != nil {
+		t.Fatalf("applyCloaking() second error = %v", err2)
+	}
+	if !cloaked2 {
+		t.Fatal("applyCloaking() second cloaked = false, want true")
+	}
+
+	userID1 := gjson.GetBytes(first, "metadata.user_id").String()
+	userID2 := gjson.GetBytes(second, "metadata.user_id").String()
+	if userID1 == "" || userID2 == "" {
+		t.Fatalf("metadata.user_id is empty: %q, %q", userID1, userID2)
+	}
+
+	deviceID1 := gjson.Get(userID1, "device_id").String()
+	deviceID2 := gjson.Get(userID2, "device_id").String()
+	if deviceID1 == deviceID2 {
+		t.Fatalf("cache-user-id:false must produce a fresh device_id per call, got %q", deviceID1)
+	}
+
+	sessionID1 := gjson.Get(userID1, "session_id").String()
+	sessionID2 := gjson.Get(userID2, "session_id").String()
+	if sessionID1 == "" || sessionID1 != sessionID2 {
+		t.Fatalf("cache-user-id:false must keep the stable session_id, got %q vs %q", sessionID1, sessionID2)
+	}
+}
+
+func TestInjectFakeUserID_CacheEnabledIsDeterministic(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
+	first, errFirst := injectFakeUserID(context.Background(), payload, "key-cache-enabled", true)
+	if errFirst != nil {
+		t.Fatalf("first injectFakeUserID error: %v", errFirst)
+	}
+	second, errSecond := injectFakeUserID(context.Background(), payload, "key-cache-enabled", true)
+	if errSecond != nil {
+		t.Fatalf("second injectFakeUserID error: %v", errSecond)
+	}
+
+	firstID := gjson.GetBytes(first, "metadata.user_id").String()
+	secondID := gjson.GetBytes(second, "metadata.user_id").String()
+	if firstID == "" || secondID == "" {
+		t.Fatalf("user_id not injected: first=%q second=%q", firstID, secondID)
+	}
+	if firstID != secondID {
+		t.Fatalf("cache-user-id:true must produce a stable user_id, got %q and %q", firstID, secondID)
+	}
+}
+
+func TestInjectFakeUserID_CacheDisabledIsRandomPerRequest(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
+	first, errFirst := injectFakeUserID(context.Background(), payload, "key-cache-disabled", false)
+	if errFirst != nil {
+		t.Fatalf("first injectFakeUserID error: %v", errFirst)
+	}
+	second, errSecond := injectFakeUserID(context.Background(), payload, "key-cache-disabled", false)
+	if errSecond != nil {
+		t.Fatalf("second injectFakeUserID error: %v", errSecond)
+	}
+
+	firstID := gjson.GetBytes(first, "metadata.user_id").String()
+	secondID := gjson.GetBytes(second, "metadata.user_id").String()
+	if firstID == "" || secondID == "" {
+		t.Fatalf("user_id not injected: first=%q second=%q", firstID, secondID)
+	}
+
+	firstDevice := gjson.Get(firstID, "device_id").String()
+	secondDevice := gjson.Get(secondID, "device_id").String()
+	if firstDevice == secondDevice {
+		t.Fatalf("cache-user-id:false must produce a fresh device_id per request, got %q", firstDevice)
+	}
+
+	firstSession := gjson.Get(firstID, "session_id").String()
+	secondSession := gjson.Get(secondID, "session_id").String()
+	if firstSession == "" || firstSession != secondSession {
+		t.Fatalf("cache-user-id:false must keep the stable session_id, got %q vs %q", firstSession, secondSession)
 	}
 }

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -6452,3 +6452,53 @@ func TestClaudeExecutor_CacheTTLIsPairedWithExtendedCacheTTLBeta(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyCloaking_DeterministicUserID(t *testing.T) {
+	cfg := &config.Config{}
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-123", "cloak_mode": "always"}}
+	payload := []byte(`{"model":"claude-opus-5","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`)
+
+	first, cloaked, err := applyCloaking(context.Background(), cfg, auth, payload, "key-123", false, false)
+	if err != nil {
+		t.Fatalf("applyCloaking() error = %v", err)
+	}
+	if !cloaked {
+		t.Fatal("applyCloaking() cloaked = false, want true")
+	}
+
+	second, cloaked2, err2 := applyCloaking(context.Background(), cfg, auth, payload, "key-123", false, false)
+	if err2 != nil {
+		t.Fatalf("applyCloaking() second error = %v", err2)
+	}
+	if !cloaked2 {
+		t.Fatal("applyCloaking() second cloaked = false, want true")
+	}
+
+	userID1 := gjson.GetBytes(first, "metadata.user_id").String()
+	userID2 := gjson.GetBytes(second, "metadata.user_id").String()
+	if userID1 == "" {
+		t.Fatal("metadata.user_id is empty")
+	}
+	if userID1 != userID2 {
+		t.Fatalf("same conversation produced different metadata.user_id: %q vs %q", userID1, userID2)
+	}
+
+	// Different credentials must produce different user IDs.
+	auth2 := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-456", "cloak_mode": "always"}}
+	third, _, _ := applyCloaking(context.Background(), cfg, auth2, payload, "key-456", false, false)
+	userID3 := gjson.GetBytes(third, "metadata.user_id").String()
+	if userID1 == userID3 {
+		t.Fatalf("different api keys produced same metadata.user_id: %q", userID1)
+	}
+
+	// Caller-supplied metadata.user_id is preserved.
+	callerUserID := `{"device_id":"0000000000000000000000000000000000000000000000000000000000000000","session_id":"11111111-2222-4333-8444-555555555555"}`
+	payloadWithUser, _ := sjson.SetBytes(payload, "metadata.user_id", callerUserID)
+	fourth, _, err4 := applyCloaking(context.Background(), cfg, auth, payloadWithUser, "key-123", false, false)
+	if err4 != nil {
+		t.Fatalf("applyCloaking() caller user_id error = %v", err4)
+	}
+	if got := gjson.GetBytes(fourth, "metadata.user_id").String(); got != callerUserID {
+		t.Fatalf("caller-supplied metadata.user_id not preserved, got %q want %q", got, callerUserID)
+	}
+}

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -6452,3 +6452,140 @@ func TestClaudeExecutor_CacheTTLIsPairedWithExtendedCacheTTLBeta(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyCloaking_DeterministicUserID(t *testing.T) {
+	cfg := &config.Config{}
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-123", "cloak_mode": "always", "cloak_cache_user_id": "true"}}
+	payload := []byte(`{"model":"claude-opus-5","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`)
+
+	first, cloaked, err := applyCloaking(context.Background(), cfg, auth, payload, "key-123", false, false)
+	if err != nil {
+		t.Fatalf("applyCloaking() error = %v", err)
+	}
+	if !cloaked {
+		t.Fatal("applyCloaking() cloaked = false, want true")
+	}
+
+	second, cloaked2, err2 := applyCloaking(context.Background(), cfg, auth, payload, "key-123", false, false)
+	if err2 != nil {
+		t.Fatalf("applyCloaking() second error = %v", err2)
+	}
+	if !cloaked2 {
+		t.Fatal("applyCloaking() second cloaked = false, want true")
+	}
+
+	userID1 := gjson.GetBytes(first, "metadata.user_id").String()
+	userID2 := gjson.GetBytes(second, "metadata.user_id").String()
+	if userID1 == "" {
+		t.Fatal("metadata.user_id is empty")
+	}
+	if userID1 != userID2 {
+		t.Fatalf("same conversation produced different metadata.user_id: %q vs %q", userID1, userID2)
+	}
+
+	// Different credentials must produce different user IDs.
+	auth2 := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-456", "cloak_mode": "always", "cloak_cache_user_id": "true"}}
+	third, _, _ := applyCloaking(context.Background(), cfg, auth2, payload, "key-456", false, false)
+	userID3 := gjson.GetBytes(third, "metadata.user_id").String()
+	if userID1 == userID3 {
+		t.Fatalf("different api keys produced same metadata.user_id: %q", userID1)
+	}
+
+	// Caller-supplied metadata.user_id is preserved.
+	callerUserID := `{"device_id":"0000000000000000000000000000000000000000000000000000000000000000","session_id":"11111111-2222-4333-8444-555555555555"}`
+	payloadWithUser, _ := sjson.SetBytes(payload, "metadata.user_id", callerUserID)
+	fourth, _, err4 := applyCloaking(context.Background(), cfg, auth, payloadWithUser, "key-123", false, false)
+	if err4 != nil {
+		t.Fatalf("applyCloaking() caller user_id error = %v", err4)
+	}
+	if got := gjson.GetBytes(fourth, "metadata.user_id").String(); got != callerUserID {
+		t.Fatalf("caller-supplied metadata.user_id not preserved, got %q want %q", got, callerUserID)
+	}
+}
+
+func TestApplyCloaking_NonCachedUserIDIsRandom(t *testing.T) {
+	cfg := &config.Config{}
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-123", "cloak_mode": "always"}}
+	payload := []byte(`{"model":"claude-opus-5","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`)
+
+	first, cloaked, err := applyCloaking(context.Background(), cfg, auth, payload, "key-123", false, false)
+	if err != nil {
+		t.Fatalf("applyCloaking() error = %v", err)
+	}
+	if !cloaked {
+		t.Fatal("applyCloaking() cloaked = false, want true")
+	}
+
+	second, cloaked2, err2 := applyCloaking(context.Background(), cfg, auth, payload, "key-123", false, false)
+	if err2 != nil {
+		t.Fatalf("applyCloaking() second error = %v", err2)
+	}
+	if !cloaked2 {
+		t.Fatal("applyCloaking() second cloaked = false, want true")
+	}
+
+	userID1 := gjson.GetBytes(first, "metadata.user_id").String()
+	userID2 := gjson.GetBytes(second, "metadata.user_id").String()
+	if userID1 == "" || userID2 == "" {
+		t.Fatal("metadata.user_id is empty")
+	}
+	if !helps.IsValidUserID(userID1) || !helps.IsValidUserID(userID2) {
+		t.Fatalf("metadata.user_id is not valid: %q, %q", userID1, userID2)
+	}
+	if userID1 == userID2 {
+		t.Fatalf("cache-user-id:false produced the same metadata.user_id on two calls: %q", userID1)
+	}
+}
+
+func TestInjectFakeUserID_CacheEnabledIsDeterministic(t *testing.T) {
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-cache-enabled"}}
+	payload := []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
+	first, errFirst := injectFakeUserID(context.Background(), payload, auth, "key-cache-enabled", true)
+	if errFirst != nil {
+		t.Fatalf("first injectFakeUserID error: %v", errFirst)
+	}
+	second, errSecond := injectFakeUserID(context.Background(), payload, auth, "key-cache-enabled", true)
+	if errSecond != nil {
+		t.Fatalf("second injectFakeUserID error: %v", errSecond)
+	}
+
+	firstID := gjson.GetBytes(first, "metadata.user_id").String()
+	secondID := gjson.GetBytes(second, "metadata.user_id").String()
+	if firstID == "" || secondID == "" {
+		t.Fatalf("user_id not injected: first=%q second=%q", firstID, secondID)
+	}
+	if firstID != secondID {
+		t.Fatalf("cache-user-id:true must produce a stable user_id, got %q and %q", firstID, secondID)
+	}
+}
+
+func TestInjectFakeUserID_CacheDisabledIsRandomPerRequest(t *testing.T) {
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-cache-disabled"}}
+	payload := []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
+	first, errFirst := injectFakeUserID(context.Background(), payload, auth, "key-cache-disabled", false)
+	if errFirst != nil {
+		t.Fatalf("first injectFakeUserID error: %v", errFirst)
+	}
+	second, errSecond := injectFakeUserID(context.Background(), payload, auth, "key-cache-disabled", false)
+	if errSecond != nil {
+		t.Fatalf("second injectFakeUserID error: %v", errSecond)
+	}
+
+	firstID := gjson.GetBytes(first, "metadata.user_id").String()
+	secondID := gjson.GetBytes(second, "metadata.user_id").String()
+	if firstID == "" || secondID == "" {
+		t.Fatalf("user_id not injected: first=%q second=%q", firstID, secondID)
+	}
+
+	firstDevice := gjson.Get(firstID, "device_id").String()
+	secondDevice := gjson.Get(secondID, "device_id").String()
+	if firstDevice == secondDevice {
+		t.Fatalf("cache-user-id:false must produce a fresh device_id per request, got %q", firstDevice)
+	}
+
+	firstSession := gjson.Get(firstID, "session_id").String()
+	secondSession := gjson.Get(secondID, "session_id").String()
+	if firstSession == "" || firstSession != secondSession {
+		t.Fatalf("cache-user-id:false must keep the stable session_id, got %q vs %q", firstSession, secondSession)
+	}
+}

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -6452,3 +6452,49 @@ func TestClaudeExecutor_CacheTTLIsPairedWithExtendedCacheTTLBeta(t *testing.T) {
 		})
 	}
 }
+
+func TestStripCacheControls(t *testing.T) {
+	payload := []byte(`{"model":"claude-opus-4","system":[{"type":"text","text":"sys","cache_control":{"type":"ephemeral"}}],"tools":[{"name":"t","cache_control":{"type":"ephemeral"},"input_schema":{"type":"object","properties":{"cache_control":{"type":"string"}}}}],"messages":[{"role":"user","content":[{"type":"text","text":"hi","cache_control":{"type":"ephemeral"}}],"cache_control":{"type":"ephemeral"}}]}`)
+	got := stripCacheControls(payload)
+
+	for _, path := range []string{
+		"system.0.cache_control",
+		"tools.0.cache_control",
+		"messages.0.cache_control",
+		"messages.0.content.0.cache_control",
+	} {
+		if gjson.GetBytes(got, path).Exists() {
+			t.Fatalf("cache_control still present at %q: %s", path, got)
+		}
+	}
+	// cache_control inside a tool input_schema is data, not an Anthropic marker.
+	if gjson.GetBytes(got, "tools.0.input_schema.properties.cache_control.type").String() != "string" {
+		t.Fatalf("tool input_schema property cache_control should be preserved, got %s", got)
+	}
+	if gjson.GetBytes(got, "system.0.text").String() != "sys" {
+		t.Fatalf("system text not preserved, got %s", got)
+	}
+	if gjson.GetBytes(got, "messages.0.content.0.text").String() != "hi" {
+		t.Fatalf("message content not preserved, got %s", got)
+	}
+}
+
+func TestStripCacheControls_NestedToolResultContent(t *testing.T) {
+	payload := []byte(`{"model":"claude-opus-4","messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_1","content":[{"type":"text","text":"result","cache_control":{"type":"ephemeral"}}],"cache_control":{"type":"ephemeral"}}]}]}`)
+	got := stripCacheControls(payload)
+
+	for _, path := range []string{
+		"messages.0.content.0.cache_control",
+		"messages.0.content.0.content.0.cache_control",
+	} {
+		if gjson.GetBytes(got, path).Exists() {
+			t.Fatalf("cache_control still present at %q: %s", path, got)
+		}
+	}
+	if gjson.GetBytes(got, "messages.0.content.0.tool_use_id").String() != "tu_1" {
+		t.Fatalf("tool_use_id not preserved, got %s", got)
+	}
+	if gjson.GetBytes(got, "messages.0.content.0.content.0.text").String() != "result" {
+		t.Fatalf("nested tool_result content not preserved, got %s", got)
+	}
+}

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -9,6 +9,7 @@ import (
 
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -91,7 +92,41 @@ func prepareClaudeThinkingReplayRequest(ctx context.Context, auth *cliproxyauth.
 	if !found {
 		return scope, nil, false
 	}
-	return scope, contents, true
+	// Normalize cached tool_use parts to match the shape the sanitizer will apply
+	// to the upstream body, so an echo'd tool_use with provenance fields does not
+	// fail the canonical comparison.
+	normalized := make([][]byte, len(contents))
+	for i, content := range contents {
+		normalized[i] = claudeThinkingReplayNormalizeCachedContent(content)
+	}
+	return scope, normalized, true
+}
+
+// claudeThinkingReplayNormalizeCachedContent strips tool-use signature/provenance
+// fields from a cached assistant content array. This lets the replay match compare
+// the same normalized shape the upstream sanitizer produces, while the restored
+// content still carries the trusted thinking signature.
+func claudeThinkingReplayNormalizeCachedContent(content []byte) []byte {
+	root := gjson.ParseBytes(content)
+	if !root.IsArray() {
+		return content
+	}
+	parts := root.Array()
+	outParts := make([]string, len(parts))
+	modified := false
+	for i, part := range parts {
+		if strings.TrimSpace(part.Get("type").String()) == "tool_use" {
+			updated, changed := signature.StripClaudeToolUseSignatureFields(part)
+			outParts[i] = updated
+			modified = modified || changed
+			continue
+		}
+		outParts[i] = part.Raw
+	}
+	if !modified {
+		return content
+	}
+	return []byte("[" + strings.Join(outParts, ",") + "]")
 }
 
 // stripClaudeThinkingReplayProvenanceMarkers removes any client-supplied

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
@@ -42,16 +44,30 @@ func claudeThinkingReplayEnabled(auth *cliproxyauth.Auth, req cliproxyexecutor.R
 // conversations through the same credential cannot see each other's cached
 // signatures.
 func claudeThinkingReplayScopeFromRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) claudeThinkingReplayScope {
+	modelFamily := claudeThinkingReplayModelFamily(auth, req.Model)
+	callerHash := claudeThinkingReplayCallerHash(auth, req, opts)
 	sessionKey := codexReasoningReplaySessionKey(ctx, sdktranslator.FormatClaude, req, opts, req.Payload)
+	fallback := false
 	if sessionKey != "" {
 		sessionKey = xaiReasoningReplayIsolateSessionKey(ctx, sessionKey)
 	}
 	if sessionKey == "" {
 		sessionKey = helps.ClaudeThinkingReplayConversationSessionKey(auth, req, opts)
+		fallback = true
+	}
+	// When the sessionless fallback key is based on messages.0, a compacted
+	// history can change the key and orphan cached turns. Try to resolve the
+	// original conversation scope through any remaining message.
+	if fallback && sessionKey != "" {
+		if resolved, ok := internalcache.ResolveClaudeThinkingReplaySessionKey(modelFamily, claudeThinkingReplayMessageHashes(modelFamily, callerHash, req.Payload)); ok {
+			sessionKey = resolved
+		}
 	}
 	return claudeThinkingReplayScope{
-		modelFamily: claudeThinkingReplayModelFamily(auth, req.Model),
+		modelFamily: modelFamily,
 		sessionKey:  sessionKey,
+		fallbackKey: fallback,
+		callerHash:  callerHash,
 	}
 }
 
@@ -121,6 +137,15 @@ func prepareClaudeThinkingReplayRequest(ctx context.Context, auth *cliproxyauth.
 	if errGet != nil {
 		log.Warnf("claude compatible thinking replay cache read failed: %v", errGet)
 		return scope, nil, false
+	}
+	// Register the messages in this payload as aliases for this conversation
+	// scope, so later compacted requests can resolve the same scope even when
+	// messages.0 has changed. This is done even when the cache is empty so the
+	// first request in a conversation can be rediscovered after compaction.
+	if scope.fallbackKey {
+		for _, h := range claudeThinkingReplayMessageHashes(scope.modelFamily, scope.callerHash, req.Payload) {
+			internalcache.RegisterClaudeThinkingReplayAlias(scope.modelFamily, scope.sessionKey, h)
+		}
 	}
 	if !found {
 		return scope, nil, false
@@ -296,6 +321,120 @@ func claudeThinkingReplayFindStartIndex(firstContent gjson.Result, cachedContent
 	return 0
 }
 
+// claudeThinkingReplayMessageHashes returns a stable hash for each user and
+// assistant message in the payload. These hashes are used to resolve and
+// register conversation-scope aliases when a sessionless client compacts
+// history so messages.0 no longer matches the original key.
+func claudeThinkingReplayMessageHashes(modelFamily, callerHash string, payload []byte) []string {
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.IsArray() {
+		return nil
+	}
+	var hashes []string
+	for _, msg := range messages.Array() {
+		role := strings.ToLower(strings.TrimSpace(msg.Get("role").String()))
+		if role != "user" && role != "assistant" {
+			continue
+		}
+		var h string
+		if role == "assistant" {
+			h = claudeThinkingReplayAssistantMessageHash(modelFamily, callerHash, []byte(msg.Get("content").Raw))
+		} else {
+			h = claudeThinkingReplayUserMessageHash(modelFamily, callerHash, msg)
+		}
+		if h != "" {
+			hashes = append(hashes, h)
+		}
+	}
+	return hashes
+}
+
+func claudeThinkingReplayUserMessageHash(modelFamily, callerHash string, msg gjson.Result) string {
+	role := strings.TrimSpace(msg.Get("role").String())
+	content := msg.Get("content")
+	if role == "" {
+		return ""
+	}
+	m := map[string]json.RawMessage{
+		"role":    json.RawMessage(`"` + role + `"`),
+		"content": json.RawMessage(content.Raw),
+	}
+	raw, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	canon, ok := kimiCanonicalJSON(raw)
+	if !ok {
+		return ""
+	}
+	return claudeThinkingReplayHash(modelFamily, callerHash, canon)
+}
+
+func claudeThinkingReplayAssistantMessageHash(modelFamily, callerHash string, content []byte) string {
+	parts, ok := kimiNonThinkingContentParts(gjson.ParseBytes(content))
+	if !ok || len(parts) == 0 {
+		return ""
+	}
+	partsJSON, err := json.Marshal(parts)
+	if err != nil {
+		return ""
+	}
+	m := map[string]json.RawMessage{
+		"role":    json.RawMessage(`"assistant"`),
+		"content": json.RawMessage(partsJSON),
+	}
+	raw, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	canon, ok := kimiCanonicalJSON(raw)
+	if !ok {
+		return ""
+	}
+	return claudeThinkingReplayHash(modelFamily, callerHash, canon)
+}
+
+func claudeThinkingReplayHash(modelFamily, callerHash string, canon []byte) string {
+	h := sha256.New()
+	h.Write([]byte(modelFamily))
+	h.Write([]byte{0})
+	h.Write([]byte(callerHash))
+	h.Write([]byte{0})
+	h.Write(canon)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func claudeThinkingReplayCallerHash(auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) string {
+	h := sha256.New()
+	if auth != nil {
+		if id := strings.TrimSpace(auth.ID); id != "" {
+			h.Write([]byte(id))
+		} else if apiKey, _ := claudeCreds(auth); apiKey != "" {
+			h.Write([]byte(apiKey))
+		}
+	}
+	h.Write([]byte(metadataString(opts.Metadata, cliproxyexecutor.CallerScopeMetadataKey)))
+	h.Write([]byte(metadataString(req.Metadata, cliproxyexecutor.CallerScopeMetadataKey)))
+	h.Write([]byte(metadataString(opts.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey)))
+	h.Write([]byte(metadataString(req.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey)))
+	h.Write([]byte(headerFirstValue(opts.Headers, "User-Agent")))
+	h.Write([]byte(headerFirstValue(opts.Headers, "X-App")))
+	h.Write([]byte(headerFirstValue(opts.Headers, "X-Codex-Client-Id")))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func headerFirstValue(headers http.Header, key string) string {
+	if headers == nil {
+		return ""
+	}
+	for k, vv := range headers {
+		if strings.EqualFold(k, key) && len(vv) > 0 {
+			return vv[0]
+		}
+	}
+	return ""
+}
+
 func cacheClaudeThinkingReplayResponse(ctx context.Context, scope claudeThinkingReplayScope, response []byte) {
 	content := gjson.GetBytes(response, "content")
 	if content.IsArray() {
@@ -319,6 +458,14 @@ func cacheClaudeThinkingReplayContent(ctx context.Context, scope claudeThinkingR
 	if kimiThinkingReplayContentIsReplayable(content) {
 		if _, errReplace := internalcache.ReplaceClaudeThinkingReplayIfUnchanged(ctx, scope.modelFamily, scope.sessionKey, scope.snapshot, content); errReplace != nil {
 			log.Warnf("claude compatible thinking replay cache replace failed: %v", errReplace)
+		}
+		// Register the client-visible assistant shape as an alias so a later
+		// compacted request that leads with this assistant can resolve the
+		// original conversation scope.
+		if scope.fallbackKey {
+			if h := claudeThinkingReplayAssistantMessageHash(scope.modelFamily, scope.callerHash, content); h != "" {
+				internalcache.RegisterClaudeThinkingReplayAlias(scope.modelFamily, scope.sessionKey, h)
+			}
 		}
 	}
 }

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"strings"
 
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
@@ -67,63 +68,64 @@ func claudeThinkingReplayModelFamily(auth *cliproxyauth.Auth, model string) stri
 	return "claude:" + hex.EncodeToString(sum[:8]) + ":" + baseModel
 }
 
-// prepareClaudeThinkingReplayRequest restores cached assistant content into
-// req.Payload before translation and sanitization. Each restored thinking part
-// carries an internal _cliproxy_replay_provenance marker so the compat
-// sanitizer can preserve trusted replay signatures while still rejecting
-// unprovenanced client-provided signatures.
-func prepareClaudeThinkingReplayRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Request, claudeThinkingReplayScope) {
+// prepareClaudeThinkingReplayRequest loads cached assistant content for this
+// request and strips any client-supplied _cliproxy_replay_provenance markers
+// from req.Payload. The actual restore is applied to bodyForUpstream after
+// signature sanitization and before MCP tool-name remapping, so cache-provenanced
+// signatures bypass the sanitizer while matching against the caller-facing body.
+func prepareClaudeThinkingReplayRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (claudeThinkingReplayScope, [][]byte, bool) {
 	scope := claudeThinkingReplayScopeFromRequest(ctx, auth, req, opts)
 	if !scope.valid() {
-		return req, scope
+		return scope, nil, false
 	}
+
+	req.Payload = stripClaudeThinkingReplayProvenanceMarkers(req.Payload)
+
 	contents, snapshot, found, errGet := internalcache.GetClaudeThinkingReplayWithSnapshotRequired(ctx, scope.modelFamily, scope.sessionKey)
 	scope.snapshot = snapshot
 	scope.cacheReady = errGet == nil
 	if errGet != nil {
 		log.Warnf("claude compatible thinking replay cache read failed: %v", errGet)
-		return req, scope
+		return scope, nil, false
 	}
 	if !found {
-		return req, scope
+		return scope, nil, false
 	}
-	markedContents := make([][]byte, len(contents))
-	for i, content := range contents {
-		markedContents[i] = claudeThinkingReplayMarkProvenance(content)
-	}
-	updated, restored := restoreClaudeThinkingReplayContents(req.Payload, markedContents)
-	if restored {
-		req.Payload = updated
-		scope.replayApplied = true
-	}
-	return req, scope
+	return scope, contents, true
 }
 
-// claudeThinkingReplayMarkProvenance adds a transient _cliproxy_replay_provenance
-// marker to each thinking part in a cached assistant content array. The
-// sanitizer uses the marker to preserve trusted replay signatures and removes
-// it before the body is sent upstream.
-func claudeThinkingReplayMarkProvenance(content []byte) []byte {
-	root := gjson.ParseBytes(content)
+// stripClaudeThinkingReplayProvenanceMarkers removes any client-supplied
+// _cliproxy_replay_provenance fields from thinking blocks in the request payload
+// before the sanitizer runs. The marker is internal-only.
+func stripClaudeThinkingReplayProvenanceMarkers(payload []byte) []byte {
+	root := gjson.GetBytes(payload, "messages")
 	if !root.IsArray() {
-		return content
+		return payload
 	}
-	parts := root.Array()
+	updated := payload
 	modified := false
-	outParts := make([]string, len(parts))
-	for i, part := range parts {
-		if strings.TrimSpace(part.Get("type").String()) == "thinking" {
-			updated, _ := sjson.Set(part.Raw, "_cliproxy_replay_provenance", true)
-			outParts[i] = updated
+	for i, message := range root.Array() {
+		content := message.Get("content")
+		if !content.IsArray() {
+			continue
+		}
+		for j, part := range content.Array() {
+			if strings.TrimSpace(part.Get("type").String()) != "thinking" {
+				continue
+			}
+			if !part.Get("_cliproxy_replay_provenance").Exists() {
+				continue
+			}
+			path := fmt.Sprintf("messages.%d.content.%d._cliproxy_replay_provenance", i, j)
+			out, _ := sjson.DeleteBytes(updated, path)
+			updated = out
 			modified = true
-		} else {
-			outParts[i] = part.Raw
 		}
 	}
 	if !modified {
-		return content
+		return payload
 	}
-	return []byte("[" + strings.Join(outParts, ",") + "]")
+	return updated
 }
 
 func restoreClaudeThinkingReplayContents(body []byte, cachedContents [][]byte) ([]byte, bool) {

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -48,6 +48,7 @@ func claudeThinkingReplayEnabled(auth *cliproxyauth.Auth, req cliproxyexecutor.R
 func claudeThinkingReplayScopeFromRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) claudeThinkingReplayScope {
 	modelFamily := claudeThinkingReplayModelFamily(auth, req.Model)
 	callerHash := claudeThinkingReplayCallerHash(auth, req, opts)
+	firstUserHash := claudeThinkingReplayFirstUserHash(modelFamily, callerHash, req.Payload)
 	sessionKey := codexReasoningReplaySessionKey(ctx, sdktranslator.FormatClaude, req, opts, req.Payload)
 	fallback := false
 	if sessionKey != "" {
@@ -58,18 +59,21 @@ func claudeThinkingReplayScopeFromRequest(ctx context.Context, auth *cliproxyaut
 		fallback = true
 	}
 	// When the sessionless fallback key is based on messages.0, a compacted
-	// history can change the key and orphan cached turns. Try to resolve the
-	// original conversation scope through any remaining message.
+	// history can change the key and orphan caches. Resolve the original
+	// conversation scope through any remaining message, weighting user
+	// messages and conversation-first-user context more strongly.
 	if fallback && sessionKey != "" {
-		if resolved, ok := internalcache.ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, claudeThinkingReplayMessageHashes(modelFamily, callerHash, req.Payload)); ok {
+		resolvedMessages := claudeThinkingReplayMessageHashes(modelFamily, callerHash, req.Payload)
+		if resolved, ok := internalcache.ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, resolvedMessages, firstUserHash); ok {
 			sessionKey = resolved
 		}
 	}
 	return claudeThinkingReplayScope{
-		modelFamily: modelFamily,
-		sessionKey:  sessionKey,
-		fallbackKey: fallback,
-		callerHash:  callerHash,
+		modelFamily:   modelFamily,
+		sessionKey:    sessionKey,
+		fallbackKey:   fallback,
+		callerHash:    callerHash,
+		firstUserHash: firstUserHash,
 	}
 }
 
@@ -145,8 +149,8 @@ func prepareClaudeThinkingReplayRequest(ctx context.Context, auth *cliproxyauth.
 	// messages.0 has changed. This is done even when the cache is empty so the
 	// first request in a conversation can be rediscovered after compaction.
 	if scope.fallbackKey {
-		for _, h := range claudeThinkingReplayMessageHashes(scope.modelFamily, scope.callerHash, req.Payload) {
-			internalcache.RegisterClaudeThinkingReplayAlias(ctx, scope.modelFamily, scope.sessionKey, h)
+		for _, m := range claudeThinkingReplayMessageHashes(scope.modelFamily, scope.callerHash, req.Payload) {
+			internalcache.RegisterClaudeThinkingReplayAlias(ctx, scope.modelFamily, scope.sessionKey, m.Hash, scope.firstUserHash)
 		}
 	}
 	if !found {
@@ -323,16 +327,16 @@ func claudeThinkingReplayFindStartIndex(firstContent gjson.Result, cachedContent
 	return 0
 }
 
-// claudeThinkingReplayMessageHashes returns a stable hash for each user and
-// assistant message in the payload. These hashes are used to resolve and
-// register conversation-scope aliases when a sessionless client compacts
-// history so messages.0 no longer matches the original key.
-func claudeThinkingReplayMessageHashes(modelFamily, callerHash string, payload []byte) []string {
+// claudeThinkingReplayMessageHashes returns a stable weighted hash for each
+// user and assistant message in the payload. User messages receive a higher
+// weight because they are the strongest conversation anchor; an echoed
+// assistant can be shared across conversations and is a weaker signal.
+func claudeThinkingReplayMessageHashes(modelFamily, callerHash string, payload []byte) []internalcache.ClaudeThinkingReplayAliasMessage {
 	messages := gjson.GetBytes(payload, "messages")
 	if !messages.IsArray() {
 		return nil
 	}
-	var hashes []string
+	var out []internalcache.ClaudeThinkingReplayAliasMessage
 	for _, msg := range messages.Array() {
 		role := strings.ToLower(strings.TrimSpace(msg.Get("role").String()))
 		if role != "user" && role != "assistant" {
@@ -344,11 +348,16 @@ func claudeThinkingReplayMessageHashes(modelFamily, callerHash string, payload [
 		} else {
 			h = claudeThinkingReplayUserMessageHash(modelFamily, callerHash, msg)
 		}
-		if h != "" {
-			hashes = append(hashes, h)
+		if h == "" {
+			continue
 		}
+		weight := 2
+		if role == "assistant" {
+			weight = 1
+		}
+		out = append(out, internalcache.ClaudeThinkingReplayAliasMessage{Hash: h, Weight: weight})
 	}
-	return hashes
+	return out
 }
 
 func claudeThinkingReplayUserMessageHash(modelFamily, callerHash string, msg gjson.Result) string {
@@ -404,6 +413,22 @@ func claudeThinkingReplayHash(modelFamily, callerHash string, canon []byte) stri
 	h.Write([]byte{0})
 	h.Write(canon)
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+func claudeThinkingReplayFirstUserHash(modelFamily, callerHash string, payload []byte) string {
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.IsArray() {
+		return ""
+	}
+	for _, msg := range messages.Array() {
+		if strings.ToLower(strings.TrimSpace(msg.Get("role").String())) != "user" {
+			continue
+		}
+		if h := claudeThinkingReplayUserMessageHash(modelFamily, callerHash, msg); h != "" {
+			return h
+		}
+	}
+	return ""
 }
 
 func claudeThinkingReplayCallerHash(auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) string {
@@ -479,7 +504,7 @@ func cacheClaudeThinkingReplayContent(ctx context.Context, scope claudeThinkingR
 		// original conversation scope.
 		if scope.fallbackKey {
 			if h := claudeThinkingReplayAssistantMessageHash(scope.modelFamily, scope.callerHash, content); h != "" {
-				internalcache.RegisterClaudeThinkingReplayAlias(ctx, scope.modelFamily, scope.sessionKey, h)
+				internalcache.RegisterClaudeThinkingReplayAlias(ctx, scope.modelFamily, scope.sessionKey, h, scope.firstUserHash)
 			}
 		}
 	}

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -66,27 +66,26 @@ func claudeThinkingReplayModelFamily(auth *cliproxyauth.Auth, model string) stri
 	return "claude:" + hex.EncodeToString(sum[:8]) + ":" + baseModel
 }
 
-func prepareClaudeThinkingReplayRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Request, claudeThinkingReplayScope) {
+// prepareClaudeThinkingReplayRequest loads cached assistant content for this
+// request. It does not modify req: the restore is intentionally applied to the
+// already-sanitized upstream body so cache-provenanced signatures are not
+// cleared by the compat sanitizer.
+func prepareClaudeThinkingReplayRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (claudeThinkingReplayScope, [][]byte, bool) {
 	scope := claudeThinkingReplayScopeFromRequest(ctx, auth, req, opts)
 	if !scope.valid() {
-		return req, scope
+		return scope, nil, false
 	}
 	contents, snapshot, found, errGet := internalcache.GetClaudeThinkingReplayWithSnapshotRequired(ctx, scope.modelFamily, scope.sessionKey)
 	scope.snapshot = snapshot
 	scope.cacheReady = errGet == nil
 	if errGet != nil {
 		log.Warnf("claude compatible thinking replay cache read failed: %v", errGet)
-		return req, scope
+		return scope, nil, false
 	}
 	if !found {
-		return req, scope
+		return scope, nil, false
 	}
-	updated, restored := restoreClaudeThinkingReplayContents(req.Payload, contents)
-	if restored {
-		req.Payload = updated
-		scope.replayApplied = true
-	}
-	return req, scope
+	return scope, contents, true
 }
 
 func restoreClaudeThinkingReplayContents(body []byte, cachedContents [][]byte) ([]byte, bool) {

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -3,9 +3,11 @@ package executor
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"hash"
 	"net/http"
 	"strings"
 
@@ -59,7 +61,7 @@ func claudeThinkingReplayScopeFromRequest(ctx context.Context, auth *cliproxyaut
 	// history can change the key and orphan cached turns. Try to resolve the
 	// original conversation scope through any remaining message.
 	if fallback && sessionKey != "" {
-		if resolved, ok := internalcache.ResolveClaudeThinkingReplaySessionKey(modelFamily, claudeThinkingReplayMessageHashes(modelFamily, callerHash, req.Payload)); ok {
+		if resolved, ok := internalcache.ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, claudeThinkingReplayMessageHashes(modelFamily, callerHash, req.Payload)); ok {
 			sessionKey = resolved
 		}
 	}
@@ -144,7 +146,7 @@ func prepareClaudeThinkingReplayRequest(ctx context.Context, auth *cliproxyauth.
 	// first request in a conversation can be rediscovered after compaction.
 	if scope.fallbackKey {
 		for _, h := range claudeThinkingReplayMessageHashes(scope.modelFamily, scope.callerHash, req.Payload) {
-			internalcache.RegisterClaudeThinkingReplayAlias(scope.modelFamily, scope.sessionKey, h)
+			internalcache.RegisterClaudeThinkingReplayAlias(ctx, scope.modelFamily, scope.sessionKey, h)
 		}
 	}
 	if !found {
@@ -406,21 +408,34 @@ func claudeThinkingReplayHash(modelFamily, callerHash string, canon []byte) stri
 
 func claudeThinkingReplayCallerHash(auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) string {
 	h := sha256.New()
+	var identity string
 	if auth != nil {
 		if id := strings.TrimSpace(auth.ID); id != "" {
-			h.Write([]byte(id))
+			identity = id
 		} else if apiKey, _ := claudeCreds(auth); apiKey != "" {
-			h.Write([]byte(apiKey))
+			identity = apiKey
 		}
 	}
-	h.Write([]byte(metadataString(opts.Metadata, cliproxyexecutor.CallerScopeMetadataKey)))
-	h.Write([]byte(metadataString(req.Metadata, cliproxyexecutor.CallerScopeMetadataKey)))
-	h.Write([]byte(metadataString(opts.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey)))
-	h.Write([]byte(metadataString(req.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey)))
-	h.Write([]byte(headerFirstValue(opts.Headers, "User-Agent")))
-	h.Write([]byte(headerFirstValue(opts.Headers, "X-App")))
-	h.Write([]byte(headerFirstValue(opts.Headers, "X-Codex-Client-Id")))
+	claudeThinkingReplayHashString(h, identity)
+	claudeThinkingReplayHashString(h, metadataString(opts.Metadata, cliproxyexecutor.CallerScopeMetadataKey))
+	claudeThinkingReplayHashString(h, metadataString(req.Metadata, cliproxyexecutor.CallerScopeMetadataKey))
+	claudeThinkingReplayHashString(h, metadataString(opts.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey))
+	claudeThinkingReplayHashString(h, metadataString(req.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey))
+	claudeThinkingReplayHashString(h, headerFirstValue(opts.Headers, "User-Agent"))
+	claudeThinkingReplayHashString(h, headerFirstValue(opts.Headers, "X-App"))
+	claudeThinkingReplayHashString(h, headerFirstValue(opts.Headers, "X-Codex-Client-Id"))
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+func claudeThinkingReplayHashString(h hash.Hash, s string) {
+	claudeThinkingReplayHashBytes(h, []byte(s))
+}
+
+func claudeThinkingReplayHashBytes(h hash.Hash, b []byte) {
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(b)))
+	h.Write(length[:])
+	h.Write(b)
 }
 
 func headerFirstValue(headers http.Header, key string) string {
@@ -464,7 +479,7 @@ func cacheClaudeThinkingReplayContent(ctx context.Context, scope claudeThinkingR
 		// original conversation scope.
 		if scope.fallbackKey {
 			if h := claudeThinkingReplayAssistantMessageHash(scope.modelFamily, scope.callerHash, content); h != "" {
-				internalcache.RegisterClaudeThinkingReplayAlias(scope.modelFamily, scope.sessionKey, h)
+				internalcache.RegisterClaudeThinkingReplayAlias(ctx, scope.modelFamily, scope.sessionKey, h)
 			}
 		}
 	}

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -14,6 +14,7 @@ import (
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 // claudeThinkingReplayScope reuses the bounded replay state shape shared with Kimi.
@@ -66,26 +67,63 @@ func claudeThinkingReplayModelFamily(auth *cliproxyauth.Auth, model string) stri
 	return "claude:" + hex.EncodeToString(sum[:8]) + ":" + baseModel
 }
 
-// prepareClaudeThinkingReplayRequest loads cached assistant content for this
-// request. It does not modify req: the restore is intentionally applied to the
-// already-sanitized upstream body so cache-provenanced signatures are not
-// cleared by the compat sanitizer.
-func prepareClaudeThinkingReplayRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (claudeThinkingReplayScope, [][]byte, bool) {
+// prepareClaudeThinkingReplayRequest restores cached assistant content into
+// req.Payload before translation and sanitization. Each restored thinking part
+// carries an internal _cliproxy_replay_provenance marker so the compat
+// sanitizer can preserve trusted replay signatures while still rejecting
+// unprovenanced client-provided signatures.
+func prepareClaudeThinkingReplayRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Request, claudeThinkingReplayScope) {
 	scope := claudeThinkingReplayScopeFromRequest(ctx, auth, req, opts)
 	if !scope.valid() {
-		return scope, nil, false
+		return req, scope
 	}
 	contents, snapshot, found, errGet := internalcache.GetClaudeThinkingReplayWithSnapshotRequired(ctx, scope.modelFamily, scope.sessionKey)
 	scope.snapshot = snapshot
 	scope.cacheReady = errGet == nil
 	if errGet != nil {
 		log.Warnf("claude compatible thinking replay cache read failed: %v", errGet)
-		return scope, nil, false
+		return req, scope
 	}
 	if !found {
-		return scope, nil, false
+		return req, scope
 	}
-	return scope, contents, true
+	markedContents := make([][]byte, len(contents))
+	for i, content := range contents {
+		markedContents[i] = claudeThinkingReplayMarkProvenance(content)
+	}
+	updated, restored := restoreClaudeThinkingReplayContents(req.Payload, markedContents)
+	if restored {
+		req.Payload = updated
+		scope.replayApplied = true
+	}
+	return req, scope
+}
+
+// claudeThinkingReplayMarkProvenance adds a transient _cliproxy_replay_provenance
+// marker to each thinking part in a cached assistant content array. The
+// sanitizer uses the marker to preserve trusted replay signatures and removes
+// it before the body is sent upstream.
+func claudeThinkingReplayMarkProvenance(content []byte) []byte {
+	root := gjson.ParseBytes(content)
+	if !root.IsArray() {
+		return content
+	}
+	parts := root.Array()
+	modified := false
+	outParts := make([]string, len(parts))
+	for i, part := range parts {
+		if strings.TrimSpace(part.Get("type").String()) == "thinking" {
+			updated, _ := sjson.Set(part.Raw, "_cliproxy_replay_provenance", true)
+			outParts[i] = updated
+			modified = true
+		} else {
+			outParts[i] = part.Raw
+		}
+	}
+	if !modified {
+		return content
+	}
+	return []byte("[" + strings.Join(outParts, ",") + "]")
 }
 
 func restoreClaudeThinkingReplayContents(body []byte, cachedContents [][]byte) ([]byte, bool) {

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -345,7 +345,6 @@ func claudeThinkingReplayFindStartIndex(assistantContents []gjson.Result, cached
 		return -1
 	}
 	bestStart := -1
-	bestLen := 0
 	for start := 0; start < len(cachedContents); start++ {
 		j := start
 		prefixLen := 0
@@ -364,13 +363,9 @@ func claudeThinkingReplayFindStartIndex(assistantContents []gjson.Result, cached
 			}
 			prefixLen++
 		}
-		if prefixLen > bestLen || (prefixLen == bestLen && start > bestStart) {
-			bestLen = prefixLen
+		if prefixLen == len(assistantContents) && start > bestStart {
 			bestStart = start
 		}
-	}
-	if bestLen == 0 {
-		return -1
 	}
 	return bestStart
 }

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -37,13 +37,40 @@ func claudeThinkingReplayEnabled(auth *cliproxyauth.Auth, req cliproxyexecutor.R
 }
 
 // A missing session identity intentionally disables replay instead of sharing hidden reasoning across callers.
+// When no caller session is available, we fall back to a credential-scoped key
+// so a standard Claude Messages client that provides no session metadata can
+// still replay same-upstream signatures for the same credential.
 func claudeThinkingReplayScopeFromRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) claudeThinkingReplayScope {
 	sessionKey := codexReasoningReplaySessionKey(ctx, sdktranslator.FormatClaude, req, opts, req.Payload)
-	sessionKey = xaiReasoningReplayIsolateSessionKey(ctx, sessionKey)
+	if sessionKey != "" {
+		sessionKey = xaiReasoningReplayIsolateSessionKey(ctx, sessionKey)
+	}
+	if sessionKey == "" {
+		sessionKey = claudeThinkingReplayCredentialSessionKey(auth)
+	}
 	return claudeThinkingReplayScope{
 		modelFamily: claudeThinkingReplayModelFamily(auth, req.Model),
 		sessionKey:  sessionKey,
 	}
+}
+
+func claudeThinkingReplayCredentialSessionKey(auth *cliproxyauth.Auth) string {
+	identity := ""
+	if auth != nil {
+		identity = strings.TrimSpace(auth.ID)
+		if identity == "" {
+			apiKey, baseURL := claudeCreds(auth)
+			identity = strings.TrimSpace(baseURL)
+			if identity == "" {
+				identity = strings.TrimSpace(apiKey)
+			}
+		}
+	}
+	if identity == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(identity))
+	return "credential:" + hex.EncodeToString(sum[:8])
 }
 
 func claudeThinkingReplayModelFamily(auth *cliproxyauth.Auth, model string) string {

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -37,16 +37,17 @@ func claudeThinkingReplayEnabled(auth *cliproxyauth.Auth, req cliproxyexecutor.R
 }
 
 // A missing session identity intentionally disables replay instead of sharing hidden reasoning across callers.
-// When no caller session is available, we fall back to a credential-scoped key
-// so a standard Claude Messages client that provides no session metadata can
-// still replay same-upstream signatures for the same credential.
+// When no caller session is available, we fall back to a conversation-scoped
+// key derived from the first user message and system content, so distinct
+// conversations through the same credential cannot see each other's cached
+// signatures.
 func claudeThinkingReplayScopeFromRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) claudeThinkingReplayScope {
 	sessionKey := codexReasoningReplaySessionKey(ctx, sdktranslator.FormatClaude, req, opts, req.Payload)
 	if sessionKey != "" {
 		sessionKey = xaiReasoningReplayIsolateSessionKey(ctx, sessionKey)
 	}
 	if sessionKey == "" {
-		sessionKey = claudeThinkingReplayCredentialSessionKey(auth)
+		sessionKey = claudeThinkingReplayConversationSessionKey(req.Payload)
 	}
 	return claudeThinkingReplayScope{
 		modelFamily: claudeThinkingReplayModelFamily(auth, req.Model),
@@ -54,23 +55,35 @@ func claudeThinkingReplayScopeFromRequest(ctx context.Context, auth *cliproxyaut
 	}
 }
 
-func claudeThinkingReplayCredentialSessionKey(auth *cliproxyauth.Auth) string {
-	identity := ""
-	if auth != nil {
-		identity = strings.TrimSpace(auth.ID)
-		if identity == "" {
-			apiKey, baseURL := claudeCreds(auth)
-			identity = strings.TrimSpace(baseURL)
-			if identity == "" {
-				identity = strings.TrimSpace(apiKey)
-			}
-		}
-	}
-	if identity == "" {
+// claudeThinkingReplayConversationSessionKey returns a stable per-conversation
+// key for sessionless clients. It hashes the first message and the system
+// prompt so two different conversations through the same credential do not
+// share replay state.
+func claudeThinkingReplayConversationSessionKey(payload []byte) string {
+	if len(payload) == 0 {
 		return ""
 	}
-	sum := sha256.Sum256([]byte(identity))
-	return "credential:" + hex.EncodeToString(sum[:8])
+	h := sha256.New()
+	h.Write([]byte("conversation"))
+	firstMsg := gjson.GetBytes(payload, "messages.0")
+	if firstMsg.Exists() {
+		if canon, ok := kimiCanonicalJSON([]byte(firstMsg.Raw)); ok {
+			h.Write(canon)
+		} else {
+			h.Write([]byte(firstMsg.Raw))
+		}
+	} else {
+		h.Write([]byte(""))
+	}
+	system := gjson.GetBytes(payload, "system")
+	if system.Exists() {
+		if canon, ok := kimiCanonicalJSON([]byte(system.Raw)); ok {
+			h.Write(canon)
+		} else {
+			h.Write([]byte(system.Raw))
+		}
+	}
+	return "conversation:" + hex.EncodeToString(h.Sum(nil)[:16])
 }
 
 func claudeThinkingReplayModelFamily(auth *cliproxyauth.Auth, model string) string {

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -40,11 +40,12 @@ func claudeThinkingReplayEnabled(auth *cliproxyauth.Auth, req cliproxyexecutor.R
 	return strings.TrimSpace(apiKey) != "" && !isClaudeOAuthToken(apiKey)
 }
 
-// A missing session identity intentionally disables replay instead of sharing hidden reasoning across callers.
-// When no caller session is available, we fall back to a conversation-scoped
-// key derived from the first user message and system content, so distinct
-// conversations through the same credential cannot see each other's cached
-// signatures.
+// A missing session identity or conversation nonce intentionally disables
+// replay instead of sharing hidden reasoning across callers. When the caller
+// provides a conversation nonce (client_metadata.conversation_id,
+// conversation_id body field, or X-Conversation-Id header) but no explicit
+// session, we fall back to a conversation-scoped key that mixes the nonce,
+// caller identity and first message.
 func claudeThinkingReplayScopeFromRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) claudeThinkingReplayScope {
 	modelFamily := claudeThinkingReplayModelFamily(auth, req.Model)
 	callerHash := claudeThinkingReplayCallerHash(auth, req, opts)
@@ -56,17 +57,7 @@ func claudeThinkingReplayScopeFromRequest(ctx context.Context, auth *cliproxyaut
 	}
 	if sessionKey == "" {
 		sessionKey = helps.ClaudeThinkingReplayConversationSessionKey(auth, req, opts)
-		fallback = true
-	}
-	// When the sessionless fallback key is based on messages.0, a compacted
-	// history can change the key and orphan caches. Resolve the original
-	// conversation scope through any remaining message, weighting user
-	// messages and conversation-first-user context more strongly.
-	if fallback && sessionKey != "" {
-		resolvedMessages := claudeThinkingReplayMessageHashes(modelFamily, callerHash, req.Payload)
-		if resolved, ok := internalcache.ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, resolvedMessages, firstUserHash); ok {
-			sessionKey = resolved
-		}
+		fallback = sessionKey != ""
 	}
 	return claudeThinkingReplayScope{
 		modelFamily:   modelFamily,

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -47,7 +47,7 @@ func claudeThinkingReplayScopeFromRequest(ctx context.Context, auth *cliproxyaut
 		sessionKey = xaiReasoningReplayIsolateSessionKey(ctx, sessionKey)
 	}
 	if sessionKey == "" {
-		sessionKey = claudeThinkingReplayConversationSessionKey(req.Payload)
+		sessionKey = claudeThinkingReplayConversationSessionKey(auth, req, opts)
 	}
 	return claudeThinkingReplayScope{
 		modelFamily: claudeThinkingReplayModelFamily(auth, req.Model),
@@ -56,31 +56,54 @@ func claudeThinkingReplayScopeFromRequest(ctx context.Context, auth *cliproxyaut
 }
 
 // claudeThinkingReplayConversationSessionKey returns a stable per-conversation
-// key for sessionless clients. It hashes the first message and the system
-// prompt so two different conversations through the same credential do not
-// share replay state.
-func claudeThinkingReplayConversationSessionKey(payload []byte) string {
+// key for sessionless clients. It mixes caller identity signals (credential id,
+// caller-scope metadata, selected headers) with the first message, system
+// prompt, and tools so two callers sharing a credential and the same initial
+// prompt cannot see each other's replay state.
+func claudeThinkingReplayConversationSessionKey(auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) string {
+	h := sha256.New()
+	h.Write([]byte("conversation"))
+
+	if auth != nil {
+		if id := strings.TrimSpace(auth.ID); id != "" {
+			h.Write([]byte(id))
+		} else if apiKey, _ := claudeCreds(auth); apiKey != "" {
+			h.Write([]byte(apiKey))
+		}
+	}
+
+	if scope := metadataString(opts.Metadata, cliproxyexecutor.CallerScopeMetadataKey); scope != "" {
+		h.Write([]byte(scope))
+	}
+	if scope := metadataString(req.Metadata, cliproxyexecutor.CallerScopeMetadataKey); scope != "" {
+		h.Write([]byte(scope))
+	}
+	if derived := metadataString(opts.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey); derived != "" {
+		h.Write([]byte(derived))
+	}
+	if derived := metadataString(req.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey); derived != "" {
+		h.Write([]byte(derived))
+	}
+
+	if opts.Headers != nil {
+		h.Write([]byte(opts.Headers.Get("User-Agent")))
+		h.Write([]byte(opts.Headers.Get("X-App")))
+		h.Write([]byte(opts.Headers.Get("X-Codex-Client-Id")))
+	}
+
+	payload := req.Payload
 	if len(payload) == 0 {
 		return ""
 	}
-	h := sha256.New()
-	h.Write([]byte("conversation"))
-	firstMsg := gjson.GetBytes(payload, "messages.0")
-	if firstMsg.Exists() {
-		if canon, ok := kimiCanonicalJSON([]byte(firstMsg.Raw)); ok {
-			h.Write(canon)
-		} else {
-			h.Write([]byte(firstMsg.Raw))
+	for _, path := range []string{"messages.0", "system", "tools"} {
+		part := gjson.GetBytes(payload, path)
+		if !part.Exists() {
+			continue
 		}
-	} else {
-		h.Write([]byte(""))
-	}
-	system := gjson.GetBytes(payload, "system")
-	if system.Exists() {
-		if canon, ok := kimiCanonicalJSON([]byte(system.Raw)); ok {
+		if canon, ok := kimiCanonicalJSON([]byte(part.Raw)); ok {
 			h.Write(canon)
 		} else {
-			h.Write([]byte(system.Raw))
+			h.Write([]byte(part.Raw))
 		}
 	}
 	return "conversation:" + hex.EncodeToString(h.Sum(nil)[:16])

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -199,10 +199,47 @@ func stripClaudeThinkingReplayProvenanceMarkers(payload []byte) []byte {
 func restoreClaudeThinkingReplayContents(body []byte, cachedContents [][]byte) ([]byte, bool) {
 	updated := body
 	restored := false
-	for _, cachedContent := range cachedContents {
-		var restoredTurn bool
-		updated, restoredTurn = restoreKimiThinkingReplayContent(updated, cachedContent)
-		restored = restored || restoredTurn
+	consumed := make([]bool, len(cachedContents))
+	messages := gjson.GetBytes(updated, "messages")
+	if !messages.IsArray() {
+		return body, false
+	}
+	for i, message := range messages.Array() {
+		if !strings.EqualFold(strings.TrimSpace(message.Get("role").String()), "assistant") {
+			continue
+		}
+		currentContent := message.Get("content")
+		if !currentContent.IsArray() {
+			continue
+		}
+		for j, cachedContent := range cachedContents {
+			if consumed[j] {
+				continue
+			}
+			if kimiJSONEqual([]byte(currentContent.Raw), cachedContent) {
+				consumed[j] = true
+				break
+			}
+			cachedParts, ok := kimiNonThinkingContentParts(gjson.ParseBytes(cachedContent))
+			if !ok {
+				continue
+			}
+			currentParts, ok := kimiNonThinkingContentParts(currentContent)
+			if !ok || !kimiCanonicalPartsEqual(currentParts, cachedParts) {
+				continue
+			}
+			if kimiContentHasThinking(currentContent) && !kimiThinkingMatchesCachedIgnoringSignature(currentContent, gjson.ParseBytes(cachedContent)) {
+				continue
+			}
+			var errSet error
+			updated, errSet = sjson.SetRawBytes(updated, fmt.Sprintf("messages.%d.content", i), cachedContent)
+			if errSet != nil {
+				return body, false
+			}
+			consumed[j] = true
+			restored = true
+			break
+		}
 	}
 	return updated, restored
 }

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -237,51 +237,73 @@ func restoreClaudeThinkingReplayContents(body []byte, cachedContents [][]byte) (
 	}
 	msgList := messages.Array()
 
-	// Anchor the match window to the first assistant message present in the
-	// incoming request. When clients compact or truncate earlier history, cached
-	// turns older than the first echoed assistant message must not be replayed
-	// into a later matching turn.
-	firstAssistant := -1
+	// Collect the assistant messages whose content we may be able to restore.
+	var assistantContents []gjson.Result
+	var assistantMsgIndices []int
 	for i, message := range msgList {
-		if strings.EqualFold(strings.TrimSpace(message.Get("role").String()), "assistant") {
-			firstAssistant = i
-			break
+		if !strings.EqualFold(strings.TrimSpace(message.Get("role").String()), "assistant") {
+			continue
 		}
+		content := message.Get("content")
+		if !content.IsArray() {
+			continue
+		}
+		assistantContents = append(assistantContents, content)
+		assistantMsgIndices = append(assistantMsgIndices, i)
 	}
-	if firstAssistant >= 0 {
-		start := claudeThinkingReplayFindStartIndex(msgList[firstAssistant].Get("content"), cachedContents)
+
+	// Anchor the match window to the latest suffix of cached turns that matches
+	// the request's assistant sequence. When clients compact or truncate
+	// earlier history, the remaining sequence is a suffix of the conversation;
+	// duplicate visible content must resolve to the correct retained turn.
+	start := -1
+	if len(assistantContents) > 0 {
+		start = claudeThinkingReplayFindStartIndex(assistantContents, cachedContents)
+	}
+	if start >= 0 {
 		for j := 0; j < start; j++ {
 			consumed[j] = true
 		}
 	}
 
-	for i, message := range msgList {
-		if !strings.EqualFold(strings.TrimSpace(message.Get("role").String()), "assistant") {
-			continue
-		}
-		currentContent := message.Get("content")
-		if !currentContent.IsArray() {
-			continue
-		}
-		for j, cachedContent := range cachedContents {
-			if consumed[j] {
-				continue
+	from := 0
+	if start >= 0 {
+		from = start
+	}
+
+	for ai, i := range assistantMsgIndices {
+		content := assistantContents[ai]
+		matchedJ := -1
+		// When anchored, the aligned cached turn should be at start+ai.
+		if start >= 0 && start+ai < len(cachedContents) {
+			if claudeThinkingReplayContentsMatch(content, gjson.ParseBytes(cachedContents[start+ai])) {
+				matchedJ = start + ai
 			}
-			cached := gjson.ParseBytes(cachedContent)
-			if !claudeThinkingReplayContentsMatch(currentContent, cached) {
-				continue
-			}
-			if !kimiJSONEqual([]byte(currentContent.Raw), cachedContent) {
-				var errSet error
-				updated, errSet = sjson.SetRawBytes(updated, fmt.Sprintf("messages.%d.content", i), cachedContent)
-				if errSet != nil {
-					return body, false
+		}
+		if matchedJ < 0 {
+			for j := from; j < len(cachedContents); j++ {
+				if consumed[j] {
+					continue
 				}
-				restored = true
+				cached := gjson.ParseBytes(cachedContents[j])
+				if claudeThinkingReplayContentsMatch(content, cached) {
+					matchedJ = j
+					break
+				}
 			}
-			consumed[j] = true
-			break
 		}
+		if matchedJ < 0 {
+			continue
+		}
+		if !kimiJSONEqual([]byte(content.Raw), cachedContents[matchedJ]) {
+			var errSet error
+			updated, errSet = sjson.SetRawBytes(updated, fmt.Sprintf("messages.%d.content", i), cachedContents[matchedJ])
+			if errSet != nil {
+				return body, false
+			}
+			restored = true
+		}
+		consumed[matchedJ] = true
 	}
 	return updated, restored
 }
@@ -311,20 +333,45 @@ func claudeThinkingReplayContentsMatch(currentContent, cachedContent gjson.Resul
 	return true
 }
 
-// claudeThinkingReplayFindStartIndex finds the index of the first cached turn
-// that matches the first assistant message present in the request. Cached
-// entries before this index are older than the client's oldest echoed
-// assistant message and must not be replayed into later turns.
-func claudeThinkingReplayFindStartIndex(firstContent gjson.Result, cachedContents [][]byte) int {
-	if !firstContent.IsArray() {
-		return 0
+// claudeThinkingReplayFindStartIndex finds the latest starting index in
+// cachedContents such that the full assistantContents sequence can be matched
+// as a subsequence in order. This anchors the replay window to the retained
+// suffix of the conversation, so duplicate visible assistant turns resolve to
+// the correct cached thinking/signature after compaction or truncation.
+// It returns -1 when no such anchor exists.
+func claudeThinkingReplayFindStartIndex(assistantContents []gjson.Result, cachedContents [][]byte) int {
+	if len(assistantContents) == 0 || len(cachedContents) == 0 {
+		return -1
 	}
-	for j, cachedContent := range cachedContents {
-		if claudeThinkingReplayContentsMatch(firstContent, gjson.ParseBytes(cachedContent)) {
-			return j
+	bestStart := -1
+	bestLen := 0
+	for start := 0; start < len(cachedContents); start++ {
+		j := start
+		prefixLen := 0
+		for i := 0; i < len(assistantContents) && j < len(cachedContents); i++ {
+			matched := false
+			for j < len(cachedContents) {
+				if claudeThinkingReplayContentsMatch(assistantContents[i], gjson.ParseBytes(cachedContents[j])) {
+					matched = true
+					j++
+					break
+				}
+				j++
+			}
+			if !matched {
+				break
+			}
+			prefixLen++
+		}
+		if prefixLen > bestLen || (prefixLen == bestLen && start > bestStart) {
+			bestLen = prefixLen
+			bestStart = start
 		}
 	}
-	return 0
+	if bestLen == 0 {
+		return -1
+	}
+	return bestStart
 }
 
 // claudeThinkingReplayMessageHashes returns a stable weighted hash for each

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -40,12 +40,15 @@ func claudeThinkingReplayEnabled(auth *cliproxyauth.Auth, req cliproxyexecutor.R
 	return strings.TrimSpace(apiKey) != "" && !isClaudeOAuthToken(apiKey)
 }
 
-// A missing session identity or conversation nonce intentionally disables
-// replay instead of sharing hidden reasoning across callers. When the caller
-// provides a conversation nonce (client_metadata.conversation_id,
-// conversation_id body field, or X-Conversation-Id header) but no explicit
-// session, we fall back to a conversation-scoped key that mixes the nonce,
-// caller identity and first message.
+// claudeThinkingReplayScopeFromRequest selects a conversation replay scope.
+// It prefers an explicit execution/session metadata or prompt-cache/window key,
+// then a conversation nonce (client_metadata.conversation_id, conversation_id,
+// or X-Conversation-Id), and finally a content-derived fallback keyed by the
+// first user message and system prompt.
+//
+// When the fallback key is content-derived, history compaction changes
+// messages.0 and can orphan the cache. Resolve the original scope through any
+// remaining message aliases, then continue using that key for this request.
 func claudeThinkingReplayScopeFromRequest(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) claudeThinkingReplayScope {
 	modelFamily := claudeThinkingReplayModelFamily(auth, req.Model)
 	callerHash := claudeThinkingReplayCallerHash(auth, req, opts)
@@ -56,8 +59,15 @@ func claudeThinkingReplayScopeFromRequest(ctx context.Context, auth *cliproxyaut
 		sessionKey = xaiReasoningReplayIsolateSessionKey(ctx, sessionKey)
 	}
 	if sessionKey == "" {
-		sessionKey = helps.ClaudeThinkingReplayConversationSessionKey(auth, req, opts)
+		var usedNonce bool
+		sessionKey, usedNonce = helps.ClaudeThinkingReplayConversationSessionKey(auth, req, opts)
 		fallback = sessionKey != ""
+		if fallback && !usedNonce {
+			resolvedMessages := claudeThinkingReplayMessageHashes(modelFamily, callerHash, req.Payload)
+			if resolved, ok := internalcache.ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, resolvedMessages, firstUserHash); ok {
+				sessionKey = resolved
+			}
+		}
 	}
 	return claudeThinkingReplayScope{
 		modelFamily:   modelFamily,

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -47,66 +47,12 @@ func claudeThinkingReplayScopeFromRequest(ctx context.Context, auth *cliproxyaut
 		sessionKey = xaiReasoningReplayIsolateSessionKey(ctx, sessionKey)
 	}
 	if sessionKey == "" {
-		sessionKey = claudeThinkingReplayConversationSessionKey(auth, req, opts)
+		sessionKey = helps.ClaudeThinkingReplayConversationSessionKey(auth, req, opts)
 	}
 	return claudeThinkingReplayScope{
 		modelFamily: claudeThinkingReplayModelFamily(auth, req.Model),
 		sessionKey:  sessionKey,
 	}
-}
-
-// claudeThinkingReplayConversationSessionKey returns a stable per-conversation
-// key for sessionless clients. It mixes caller identity signals (credential id,
-// caller-scope metadata, selected headers) with the first message, system
-// prompt, and tools so two callers sharing a credential and the same initial
-// prompt cannot see each other's replay state.
-func claudeThinkingReplayConversationSessionKey(auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) string {
-	h := sha256.New()
-	h.Write([]byte("conversation"))
-
-	if auth != nil {
-		if id := strings.TrimSpace(auth.ID); id != "" {
-			h.Write([]byte(id))
-		} else if apiKey, _ := claudeCreds(auth); apiKey != "" {
-			h.Write([]byte(apiKey))
-		}
-	}
-
-	if scope := metadataString(opts.Metadata, cliproxyexecutor.CallerScopeMetadataKey); scope != "" {
-		h.Write([]byte(scope))
-	}
-	if scope := metadataString(req.Metadata, cliproxyexecutor.CallerScopeMetadataKey); scope != "" {
-		h.Write([]byte(scope))
-	}
-	if derived := metadataString(opts.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey); derived != "" {
-		h.Write([]byte(derived))
-	}
-	if derived := metadataString(req.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey); derived != "" {
-		h.Write([]byte(derived))
-	}
-
-	if opts.Headers != nil {
-		h.Write([]byte(opts.Headers.Get("User-Agent")))
-		h.Write([]byte(opts.Headers.Get("X-App")))
-		h.Write([]byte(opts.Headers.Get("X-Codex-Client-Id")))
-	}
-
-	payload := req.Payload
-	if len(payload) == 0 {
-		return ""
-	}
-	for _, path := range []string{"messages.0", "system", "tools"} {
-		part := gjson.GetBytes(payload, path)
-		if !part.Exists() {
-			continue
-		}
-		if canon, ok := kimiCanonicalJSON([]byte(part.Raw)); ok {
-			h.Write(canon)
-		} else {
-			h.Write([]byte(part.Raw))
-		}
-	}
-	return "conversation:" + hex.EncodeToString(h.Sum(nil)[:16])
 }
 
 func claudeThinkingReplayModelFamily(auth *cliproxyauth.Auth, model string) string {

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -78,6 +78,30 @@ func claudeThinkingReplayModelFamily(auth *cliproxyauth.Auth, model string) stri
 	return "claude:" + hex.EncodeToString(sum[:8]) + ":" + baseModel
 }
 
+// obfuscateClaudeThinkingReplayContents applies the same sensitive-word
+// obfuscation to cached assistant content that applyCloaking applies to the
+// upstream body. This lets the post-cloak replay match compare like-for-like
+// bytes instead of failing because the caller body is obfuscated and the cache
+// is not.
+func obfuscateClaudeThinkingReplayContents(contents [][]byte, words []string) [][]byte {
+	matcher := helps.BuildSensitiveWordMatcher(words)
+	if matcher == nil {
+		return contents
+	}
+	out := make([][]byte, len(contents))
+	for i, content := range contents {
+		wrapper, _ := sjson.SetRawBytes([]byte(`{"messages":[{"role":"assistant"}]}`), "messages.0.content", content)
+		obfuscated := helps.ObfuscateSensitiveWords(wrapper, matcher)
+		obfuscatedContent := gjson.GetBytes(obfuscated, "messages.0.content")
+		if !obfuscatedContent.Exists() {
+			out[i] = content
+			continue
+		}
+		out[i] = []byte(obfuscatedContent.Raw)
+	}
+	return out
+}
+
 // prepareClaudeThinkingReplayRequest loads cached assistant content for this
 // request and strips any client-supplied _cliproxy_replay_provenance markers
 // from req.Payload. The actual restore is applied to bodyForUpstream after

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -261,13 +261,14 @@ func cacheClaudeThinkingReplayContent(ctx context.Context, scope claudeThinkingR
 	if !scope.valid() || !scope.cacheReady {
 		return
 	}
+	// Unsigned or non-replayable responses must not evict earlier signed turns.
+	// Only append turns that carry signed thinking; prior replay state is retained
+	// for the next request that echoes an earlier assistant message.
 	if kimiThinkingReplayContentIsReplayable(content) {
 		if _, errReplace := internalcache.ReplaceClaudeThinkingReplayIfUnchanged(ctx, scope.modelFamily, scope.sessionKey, scope.snapshot, content); errReplace != nil {
 			log.Warnf("claude compatible thinking replay cache replace failed: %v", errReplace)
 		}
-		return
 	}
-	clearClaudeThinkingReplayContent(ctx, scope)
 }
 
 func clearClaudeThinkingReplayContent(ctx context.Context, scope claudeThinkingReplayScope) {

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -55,14 +55,14 @@ func claudeThinkingReplayScopeFromRequest(ctx context.Context, auth *cliproxyaut
 	firstUserHash := claudeThinkingReplayFirstUserHash(modelFamily, callerHash, req.Payload)
 	sessionKey := codexReasoningReplaySessionKey(ctx, sdktranslator.FormatClaude, req, opts, req.Payload)
 	fallback := false
+	usedNonce := false
 	if sessionKey != "" {
 		sessionKey = xaiReasoningReplayIsolateSessionKey(ctx, sessionKey)
 	}
 	if sessionKey == "" {
-		var usedNonce bool
 		sessionKey, usedNonce = helps.ClaudeThinkingReplayConversationSessionKey(auth, req, opts)
-		fallback = sessionKey != ""
-		if fallback && !usedNonce {
+		fallback = sessionKey != "" && !usedNonce
+		if fallback {
 			resolvedMessages := claudeThinkingReplayMessageHashes(modelFamily, callerHash, req.Payload)
 			if resolved, ok := internalcache.ResolveClaudeThinkingReplaySessionKey(ctx, modelFamily, resolvedMessages, firstUserHash); ok {
 				sessionKey = resolved

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -204,7 +204,27 @@ func restoreClaudeThinkingReplayContents(body []byte, cachedContents [][]byte) (
 	if !messages.IsArray() {
 		return body, false
 	}
-	for i, message := range messages.Array() {
+	msgList := messages.Array()
+
+	// Anchor the match window to the first assistant message present in the
+	// incoming request. When clients compact or truncate earlier history, cached
+	// turns older than the first echoed assistant message must not be replayed
+	// into a later matching turn.
+	firstAssistant := -1
+	for i, message := range msgList {
+		if strings.EqualFold(strings.TrimSpace(message.Get("role").String()), "assistant") {
+			firstAssistant = i
+			break
+		}
+	}
+	if firstAssistant >= 0 {
+		start := claudeThinkingReplayFindStartIndex(msgList[firstAssistant].Get("content"), cachedContents)
+		for j := 0; j < start; j++ {
+			consumed[j] = true
+		}
+	}
+
+	for i, message := range msgList {
 		if !strings.EqualFold(strings.TrimSpace(message.Get("role").String()), "assistant") {
 			continue
 		}
@@ -216,32 +236,64 @@ func restoreClaudeThinkingReplayContents(body []byte, cachedContents [][]byte) (
 			if consumed[j] {
 				continue
 			}
-			if kimiJSONEqual([]byte(currentContent.Raw), cachedContent) {
-				consumed[j] = true
-				break
-			}
-			cachedParts, ok := kimiNonThinkingContentParts(gjson.ParseBytes(cachedContent))
-			if !ok {
+			cached := gjson.ParseBytes(cachedContent)
+			if !claudeThinkingReplayContentsMatch(currentContent, cached) {
 				continue
 			}
-			currentParts, ok := kimiNonThinkingContentParts(currentContent)
-			if !ok || !kimiCanonicalPartsEqual(currentParts, cachedParts) {
-				continue
-			}
-			if kimiContentHasThinking(currentContent) && !kimiThinkingMatchesCachedIgnoringSignature(currentContent, gjson.ParseBytes(cachedContent)) {
-				continue
-			}
-			var errSet error
-			updated, errSet = sjson.SetRawBytes(updated, fmt.Sprintf("messages.%d.content", i), cachedContent)
-			if errSet != nil {
-				return body, false
+			if !kimiJSONEqual([]byte(currentContent.Raw), cachedContent) {
+				var errSet error
+				updated, errSet = sjson.SetRawBytes(updated, fmt.Sprintf("messages.%d.content", i), cachedContent)
+				if errSet != nil {
+					return body, false
+				}
+				restored = true
 			}
 			consumed[j] = true
-			restored = true
 			break
 		}
 	}
 	return updated, restored
+}
+
+// claudeThinkingReplayContentsMatch reports whether an incoming assistant
+// content array matches a cached assistant turn. It accepts exact equality or
+// non-thinking parts equal and, when the incoming content already contains a
+// thinking block, the thinking text matching the cached one.
+func claudeThinkingReplayContentsMatch(currentContent, cachedContent gjson.Result) bool {
+	if !currentContent.IsArray() || !cachedContent.IsArray() {
+		return false
+	}
+	if kimiJSONEqual([]byte(currentContent.Raw), []byte(cachedContent.Raw)) {
+		return true
+	}
+	cachedParts, ok := kimiNonThinkingContentParts(cachedContent)
+	if !ok {
+		return false
+	}
+	currentParts, ok := kimiNonThinkingContentParts(currentContent)
+	if !ok || !kimiCanonicalPartsEqual(currentParts, cachedParts) {
+		return false
+	}
+	if kimiContentHasThinking(currentContent) && !kimiThinkingMatchesCachedIgnoringSignature(currentContent, cachedContent) {
+		return false
+	}
+	return true
+}
+
+// claudeThinkingReplayFindStartIndex finds the index of the first cached turn
+// that matches the first assistant message present in the request. Cached
+// entries before this index are older than the client's oldest echoed
+// assistant message and must not be replayed into later turns.
+func claudeThinkingReplayFindStartIndex(firstContent gjson.Result, cachedContents [][]byte) int {
+	if !firstContent.IsArray() {
+		return 0
+	}
+	for j, cachedContent := range cachedContents {
+		if claudeThinkingReplayContentsMatch(firstContent, gjson.ParseBytes(cachedContent)) {
+			return j
+		}
+	}
+	return 0
 }
 
 func cacheClaudeThinkingReplayResponse(ctx context.Context, scope claudeThinkingReplayScope, response []byte) {

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -507,7 +507,9 @@ func headerFirstValue(headers http.Header, key string) string {
 	}
 	for k, vv := range headers {
 		if strings.EqualFold(k, key) && len(vv) > 0 {
-			return vv[0]
+			if v := strings.TrimSpace(vv[0]); v != "" {
+				return v
+			}
 		}
 	}
 	return ""

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -270,6 +270,10 @@ func restoreClaudeThinkingReplayContents(body []byte, cachedContents [][]byte) (
 	from := 0
 	if start >= 0 {
 		from = start
+	} else {
+		// No cached suffix matches a contiguous block; refuse partial fallback
+		// that could pair a retained turn with the wrong hidden signature.
+		from = len(cachedContents)
 	}
 
 	for ai, i := range assistantMsgIndices {
@@ -344,30 +348,26 @@ func claudeThinkingReplayFindStartIndex(assistantContents []gjson.Result, cached
 	if len(assistantContents) == 0 || len(cachedContents) == 0 {
 		return -1
 	}
-	bestStart := -1
-	for start := 0; start < len(cachedContents); start++ {
-		j := start
-		prefixLen := 0
-		for i := 0; i < len(assistantContents) && j < len(cachedContents); i++ {
-			matched := false
-			for j < len(cachedContents) {
-				if claudeThinkingReplayContentsMatch(assistantContents[i], gjson.ParseBytes(cachedContents[j])) {
-					matched = true
-					j++
+	maxL := len(assistantContents)
+	if maxL > len(cachedContents) {
+		maxL = len(cachedContents)
+	}
+	for l := maxL; l >= 1; l-- {
+		start := len(cachedContents) - l
+		for off := 0; off <= len(assistantContents)-l; off++ {
+			matched := true
+			for k := 0; k < l; k++ {
+				if !claudeThinkingReplayContentsMatch(assistantContents[off+k], gjson.ParseBytes(cachedContents[start+k])) {
+					matched = false
 					break
 				}
-				j++
 			}
-			if !matched {
-				break
+			if matched {
+				return start
 			}
-			prefixLen++
-		}
-		if prefixLen == len(assistantContents) && start > bestStart {
-			bestStart = start
 		}
 	}
-	return bestStart
+	return -1
 }
 
 // claudeThinkingReplayMessageHashes returns a stable weighted hash for each

--- a/internal/runtime/executor/claude_thinking_replay.go
+++ b/internal/runtime/executor/claude_thinking_replay.go
@@ -538,6 +538,26 @@ func cacheClaudeThinkingReplayResponse(ctx context.Context, scope claudeThinking
 	}
 }
 
+// claudeThinkingReplayContentIsReplayable reports whether a content array
+// carries a decodable Claude thinking signature. Only provenanced signed turns
+// are cached; unsigned or malformed-signature responses must not evict earlier
+// replay state.
+func claudeThinkingReplayContentIsReplayable(content []byte) bool {
+	root := gjson.ParseBytes(content)
+	if !root.IsArray() {
+		return false
+	}
+	for _, part := range root.Array() {
+		if strings.TrimSpace(part.Get("type").String()) != "thinking" {
+			continue
+		}
+		if signature.HasDecodableClaudeThinkingSignature(part.Get("signature").String()) {
+			return true
+		}
+	}
+	return false
+}
+
 func cacheClaudeThinkingReplayContent(ctx context.Context, scope claudeThinkingReplayScope, content []byte) {
 	if !scope.valid() || !scope.cacheReady {
 		return
@@ -545,7 +565,7 @@ func cacheClaudeThinkingReplayContent(ctx context.Context, scope claudeThinkingR
 	// Unsigned or non-replayable responses must not evict earlier signed turns.
 	// Only append turns that carry signed thinking; prior replay state is retained
 	// for the next request that echoes an earlier assistant message.
-	if kimiThinkingReplayContentIsReplayable(content) {
+	if claudeThinkingReplayContentIsReplayable(content) {
 		if _, errReplace := internalcache.ReplaceClaudeThinkingReplayIfUnchanged(ctx, scope.modelFamily, scope.sessionKey, scope.snapshot, content); errReplace != nil {
 			log.Warnf("claude compatible thinking replay cache replace failed: %v", errReplace)
 		}

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -695,6 +695,100 @@ func TestClaudeExecutorCompatThinkingReplayRestoresSessionlessSameUpstreamSignat
 	}
 }
 
+func TestClaudeExecutorCompatThinkingReplayIsConversationScopedForSessionlessClients(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	opaqueA := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
+	opaqueSigA := base64.StdEncoding.EncodeToString(opaqueA)
+	opaqueB := bytes.Repeat([]byte{0x34, 0xff, 0x99, 0x11, 0x22, 0x33, 0x44, 0x55}, 4)
+	opaqueSigB := base64.StdEncoding.EncodeToString(opaqueB)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning A","signature":"` + opaqueSigA + `"},{"type":"tool_use","id":"toolu_A","name":"Read","input":{"path":"A"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		if call == 2 {
+			_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning B","signature":"` + opaqueSigB + `"},{"type":"tool_use","id":"toolu_B","name":"Read","input":{"path":"B"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-3","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+
+	// Conversation A first turn, no session metadata.
+	firstAReq, firstAOpts := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"task A"}]}`), "", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstAReq, firstAOpts); errExecute != nil {
+		t.Fatalf("conversation A first Execute() error = %v", errExecute)
+	}
+
+	// Conversation B first turn, same credential, different first user content.
+	firstBReq, firstBOpts := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"task B"}]}`), "", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstBReq, firstBOpts); errExecute != nil {
+		t.Fatalf("conversation B first Execute() error = %v", errExecute)
+	}
+
+	// Conversation A second turn: same first message, so it must restore sigA.
+	secondAReq, secondAOpts := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"task A"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_A","name":"Read","input":{"path":"A"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_A","content":"ok"}]}]}`), "", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondAReq, secondAOpts); errExecute != nil {
+		t.Fatalf("conversation A second Execute() error = %v", errExecute)
+	}
+
+	// Conversation B second turn: same conversation as B, must restore sigB.
+	secondBReq, secondBOpts := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"task B"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_B","name":"Read","input":{"path":"B"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_B","content":"ok"}]}]}`), "", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondBReq, secondBOpts); errExecute != nil {
+		t.Fatalf("conversation B second Execute() error = %v", errExecute)
+	}
+
+	// Conversation B third turn: uses the same assistant content as conversation A.
+	// Because the first user message differs, the cache for conversation B must not
+	// contain conversation A's signature, so the previous assistant signature is
+	// not restored.
+	thirdBReq, thirdBOpts := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"task B"},{"role":"assistant","content":[{"type":"thinking","thinking":"provider reasoning A","signature":"`+opaqueSigA+`"},{"type":"tool_use","id":"toolu_A","name":"Read","input":{"path":"A"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_A","content":"ok"}]}]}`), "", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, thirdBReq, thirdBOpts); errExecute != nil {
+		t.Fatalf("conversation B third Execute() error = %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 5 {
+		t.Fatalf("upstream request count = %d, want 5", len(requestBodies))
+	}
+
+	aContent := gjson.GetBytes(requestBodies[2], "messages.1.content").Array()
+	if aContent[0].Get("signature").String() != opaqueSigA {
+		t.Fatalf("conversation A did not restore its own signature: %s", aContent[0].Get("signature").String())
+	}
+
+	bContent := gjson.GetBytes(requestBodies[3], "messages.1.content").Array()
+	if bContent[0].Get("signature").String() != opaqueSigB {
+		t.Fatalf("conversation B did not restore its own signature: %s", bContent[0].Get("signature").String())
+	}
+
+	leakContent := gjson.GetBytes(requestBodies[4], "messages.1.content").Array()
+	if leakContent[0].Get("signature").String() != "" {
+		t.Fatalf("conversation B leaked conversation A's signature: %s", leakContent[0].Get("signature").String())
+	}
+}
+
 func internalcacheClearClaudeThinkingReplay(t *testing.T) {
 	t.Helper()
 	internalcache.ClearClaudeThinkingReplayCache()

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -895,6 +895,9 @@ func TestClaudeExecutorCompatThinkingReplayRestoresSignedNonToolResponse(t *test
 
 		w.Header().Set("Content-Type", "application/json")
 		if call == 1 {
+			// Upstream returns a signed thinking block followed by a plain text
+			// answer with no tool_use. This must be cached and restored on the
+			// next user turn.
 			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"opaque-signature-non-tool"},{"type":"text","text":"The answer is 42"}],"stop_reason":"end_turn"}`))
 			return
 		}
@@ -910,6 +913,7 @@ func TestClaudeExecutorCompatThinkingReplayRestoresSignedNonToolResponse(t *test
 		t.Fatalf("first Execute() error: %v", errExecute)
 	}
 
+	// Client echoes the assistant's text block without the thinking part.
 	secondPayload := []byte(`{"messages":[{"role":"user","content":"what is the answer"},{"role":"assistant","content":[{"type":"text","text":"The answer is 42"}]},{"role":"user","content":"thanks"}]}`)
 	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "nonstream-replay-non-tool", true, sdktranslator.FormatClaude)
 	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
@@ -968,6 +972,7 @@ func TestClaudeExecutorCompatThinkingReplayRestoresAfterSensitiveWordObfuscation
 		t.Fatalf("first Execute() error: %v", errExecute)
 	}
 
+	// Client echoes the assistant's text, which contains the sensitive word.
 	secondPayload := []byte(`{"messages":[{"role":"user","content":"what is the secret"},{"role":"assistant","content":[{"type":"text","text":"the secret answer"}]},{"role":"user","content":"thanks"}]}`)
 	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "obfuscate-replay", true, sdktranslator.FormatClaude)
 	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
@@ -1204,6 +1209,38 @@ func TestRestoreClaudeThinkingReplayContents_SkipsUnsignedLeadingAssistant(t *te
 
 	if second[0].Get("thinking").String() == "first" {
 		t.Fatalf("dropped first signed turn leaked into later assistant: %s", gjson.GetBytes(updated, "messages.3.content").Raw)
+	}
+}
+
+func TestRestoreClaudeThinkingReplayContents_AnchorsDuplicateSuffixAfterTruncation(t *testing.T) {
+	// Client dropped an older signed turn whose visible content is identical to
+	// the first retained assistant. The retained duplicate must receive the
+	// newer cached thinking/signature, not the older one.
+	body := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"user","content":"continue"},{"role":"assistant","content":[{"type":"text","text":"same"}]},{"role":"user","content":"again"},{"role":"assistant","content":[{"type":"text","text":"different"}]},{"role":"user","content":"final"}]}`)
+	cached := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"old","signature":"sig-old"},{"type":"text","text":"same"}]`),
+		[]byte(`[{"type":"thinking","thinking":"new","signature":"sig-new"},{"type":"text","text":"same"}]`),
+		[]byte(`[{"type":"thinking","thinking":"other","signature":"sig-other"},{"type":"text","text":"different"}]`),
+	}
+
+	updated, restored := restoreClaudeThinkingReplayContents(body, cached)
+	if !restored {
+		t.Fatal("expected restore")
+	}
+
+	first := gjson.GetBytes(updated, "messages.2.content").Array()
+	if first[0].Get("signature").String() != "sig-new" {
+		t.Fatalf("first retained duplicate matched wrong signature: %s", first[0].Get("signature").String())
+	}
+
+	second := gjson.GetBytes(updated, "messages.4.content").Array()
+	if second[0].Get("signature").String() != "sig-other" {
+		t.Fatalf("second retained assistant matched wrong signature: %s", second[0].Get("signature").String())
+	}
+
+	// The dropped older duplicate must not leak into the retained turns.
+	if first[0].Get("signature").String() == "sig-old" {
+		t.Fatalf("dropped older duplicate leaked into first retained assistant: %s", gjson.GetBytes(updated, "messages").Raw)
 	}
 }
 

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -1077,6 +1077,73 @@ func TestRestoreClaudeThinkingReplayContents_MatchesDuplicateTurnsInChronologica
 	}
 }
 
+func TestClaudeExecutorCompatThinkingReplayRetainsSignedTurnAfterUnsignedResponse(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"opaque-sig-retain"},{"type":"text","text":"signed answer"}],"stop_reason":"end_turn"}`))
+			return
+		}
+		if call == 2 {
+			_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"unsigned follow-up"}],"stop_reason":"end_turn"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-3","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	auth := claudeReplayTestAuth(server.URL)
+	executor := NewClaudeExecutor(nil)
+
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"first"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "retain-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error: %v", errExecute)
+	}
+
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"first"},{"role":"assistant","content":[{"type":"text","text":"signed answer"}]},{"role":"user","content":"second"}]}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "retain-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error: %v", errExecute)
+	}
+
+	thirdPayload := []byte(`{"messages":[{"role":"user","content":"first"},{"role":"assistant","content":[{"type":"text","text":"signed answer"}]},{"role":"user","content":"second"},{"role":"assistant","content":[{"type":"text","text":"unsigned follow-up"}]},{"role":"user","content":"third"}]}`)
+	thirdRequest, thirdOptions := claudeReplayTestRequest(thirdPayload, "retain-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, thirdRequest, thirdOptions); errExecute != nil {
+		t.Fatalf("third Execute() error: %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 3 {
+		t.Fatalf("upstream request count = %d, want 3", len(requestBodies))
+	}
+	firstAssistant := gjson.GetBytes(requestBodies[2], "messages.1.content").Array()
+	if firstAssistant[0].Get("signature").String() != "opaque-sig-retain" {
+		t.Fatalf("first signed turn not replayed after unsigned response: %s", gjson.GetBytes(requestBodies[2], "messages.1.content").Raw)
+	}
+	secondAssistant := gjson.GetBytes(requestBodies[2], "messages.3.content").Array()
+	if len(secondAssistant) != 1 || secondAssistant[0].Get("text").String() != "unsigned follow-up" {
+		t.Fatalf("second assistant content changed unexpectedly: %s", gjson.GetBytes(requestBodies[2], "messages.3.content").Raw)
+	}
+}
+
 func internalcacheClearClaudeThinkingReplay(t *testing.T) {
 	t.Helper()
 	internalcache.ClearClaudeThinkingReplayCache()

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -364,6 +365,67 @@ func TestClaudeExecutorCompatThinkingReplayRestoresMultipleOmittedBlocks(t *test
 	}
 	if len(secondContent) != 2 || secondContent[0].Get("type").String() != "thinking" || secondContent[0].Get("signature").String() != "EgM=" {
 		t.Fatalf("second omitted turn was not restored: %s", gjson.GetBytes(requestBodies[2], "messages.3.content").Raw)
+	}
+}
+
+func TestClaudeExecutorCompatThinkingReplayRestoresOpaqueOmittedBlock(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	opaque := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
+	opaqueSig := base64.StdEncoding.EncodeToString(opaque)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"` + opaqueSig + `"},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"inspect"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "opaque-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error = %v", errExecute)
+	}
+
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"inspect"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}]}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "opaque-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error = %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	content := gjson.GetBytes(requestBodies[1], "messages.1.content").Array()
+	if len(content) != 2 {
+		t.Fatalf("second assistant content = %s, want thinking and tool_use", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
+	}
+	if got := content[0].Get("type").String(); got != "thinking" {
+		t.Fatalf("restored first content type = %q, want thinking", got)
+	}
+	if got := content[0].Get("signature").String(); got != opaqueSig {
+		t.Fatalf("restored opaque signature = %q, want %q", got, opaqueSig)
 	}
 }
 

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -992,6 +992,91 @@ func TestClaudeExecutorCompatThinkingReplayRestoresAfterSensitiveWordObfuscation
 	}
 }
 
+func TestClaudeExecutorCompatThinkingReplaySkipsObfuscationWhenCloakingDisabled(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"opaque-sig-obfuscate"},{"type":"text","text":"the secret answer"}],"stop_reason":"end_turn"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	auth := claudeReplayTestAuth(server.URL)
+	auth.Attributes["cloak_mode"] = "never"
+	auth.Attributes["cloak_sensitive_words"] = "secret"
+
+	executor := NewClaudeExecutor(nil)
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"what is the secret"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "obfuscate-replay-disabled", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error: %v", errExecute)
+	}
+
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"what is the secret"},{"role":"assistant","content":[{"type":"text","text":"the secret answer"}]},{"role":"user","content":"thanks"}]}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "obfuscate-replay-disabled", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error: %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	content := gjson.GetBytes(requestBodies[1], "messages.1.content").Array()
+	if len(content) != 2 || content[0].Get("type").String() != "thinking" {
+		t.Fatalf("second assistant content = %s, want restored thinking and text", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
+	}
+	if got := content[0].Get("signature").String(); got != "opaque-sig-obfuscate" {
+		t.Fatalf("restored signature = %q, want opaque-sig-obfuscate", got)
+	}
+	text := content[1].Get("text").String()
+	if text != "the secret answer" {
+		t.Fatalf("sensitive word incorrectly obfuscated when cloaking disabled: %q", text)
+	}
+}
+
+func TestRestoreClaudeThinkingReplayContents_MatchesDuplicateTurnsInChronologicalOrder(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"text","text":"same"}]},{"role":"user","content":"again"},{"role":"assistant","content":[{"type":"text","text":"same"}]}]}`)
+	cached := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"first","signature":"sig-1"},{"type":"text","text":"same"}]`),
+		[]byte(`[{"type":"thinking","thinking":"second","signature":"sig-2"},{"type":"text","text":"same"}]`),
+	}
+
+	updated, restored := restoreClaudeThinkingReplayContents(body, cached)
+	if !restored {
+		t.Fatal("expected restore")
+	}
+
+	first := gjson.GetBytes(updated, "messages.1.content").Array()
+	if first[0].Get("signature").String() != "sig-1" {
+		t.Fatalf("first turn matched wrong signature: %s", first[0].Get("signature").String())
+	}
+
+	second := gjson.GetBytes(updated, "messages.3.content").Array()
+	if second[0].Get("signature").String() != "sig-2" {
+		t.Fatalf("second turn matched wrong signature: %s", second[0].Get("signature").String())
+	}
+}
+
 func internalcacheClearClaudeThinkingReplay(t *testing.T) {
 	t.Helper()
 	internalcache.ClearClaudeThinkingReplayCache()

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -1144,6 +1144,69 @@ func TestClaudeExecutorCompatThinkingReplayRetainsSignedTurnAfterUnsignedRespons
 	}
 }
 
+func TestRestoreClaudeThinkingReplayContents_AlignsAfterTruncatedHistory(t *testing.T) {
+	// Client drops the first assistant turn. The remaining sequence is a suffix
+	// of the conversation, so the first echoed assistant should align with the
+	// second cached turn, not the oldest one.
+	body := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"user","content":"continue"},{"role":"assistant","content":[{"type":"text","text":"second"}]},{"role":"user","content":"again"},{"role":"assistant","content":[{"type":"text","text":"third"}]},{"role":"user","content":"final"}]}`)
+	cached := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"first","signature":"sig-1"},{"type":"text","text":"first"}]`),
+		[]byte(`[{"type":"thinking","thinking":"second","signature":"sig-2"},{"type":"text","text":"second"}]`),
+		[]byte(`[{"type":"thinking","thinking":"third","signature":"sig-3"},{"type":"text","text":"third"}]`),
+	}
+
+	updated, restored := restoreClaudeThinkingReplayContents(body, cached)
+	if !restored {
+		t.Fatal("expected restore")
+	}
+
+	first := gjson.GetBytes(updated, "messages.2.content").Array()
+	if first[0].Get("signature").String() != "sig-2" {
+		t.Fatalf("first retained assistant matched wrong signature: %s", first[0].Get("signature").String())
+	}
+
+	second := gjson.GetBytes(updated, "messages.4.content").Array()
+	if second[0].Get("signature").String() != "sig-3" {
+		t.Fatalf("second retained assistant matched wrong signature: %s", second[0].Get("signature").String())
+	}
+
+	// The dropped first turn must not leak into the retained assistants.
+	if first[0].Get("thinking").String() == "first" || second[0].Get("thinking").String() == "first" {
+		t.Fatalf("dropped first turn leaked into retained assistants: %s", gjson.GetBytes(updated, "messages").Raw)
+	}
+}
+
+func TestRestoreClaudeThinkingReplayContents_SkipsUnsignedLeadingAssistant(t *testing.T) {
+	// Client dropped the first signed assistant and the leading assistant in the
+	// request is an unsigned new turn. No cached entry matches it, so matching
+	// must not start from an older cached turn and the later signed assistant
+	// should still align correctly.
+	body := []byte(`{"messages":[{"role":"user","content":"start"},{"role":"assistant","content":[{"type":"text","text":"new unsigned"}]},{"role":"user","content":"again"},{"role":"assistant","content":[{"type":"text","text":"second"}]},{"role":"user","content":"final"}]}`)
+	cached := [][]byte{
+		[]byte(`[{"type":"thinking","thinking":"first","signature":"sig-1"},{"type":"text","text":"first"}]`),
+		[]byte(`[{"type":"thinking","thinking":"second","signature":"sig-2"},{"type":"text","text":"second"}]`),
+	}
+
+	updated, restored := restoreClaudeThinkingReplayContents(body, cached)
+	if !restored {
+		t.Fatal("expected restore")
+	}
+
+	unsigned := gjson.GetBytes(updated, "messages.1.content").Array()
+	if len(unsigned) != 1 || unsigned[0].Get("text").String() != "new unsigned" {
+		t.Fatalf("unsigned leading assistant content unexpectedly changed: %s", gjson.GetBytes(updated, "messages.1.content").Raw)
+	}
+
+	second := gjson.GetBytes(updated, "messages.3.content").Array()
+	if second[0].Get("signature").String() != "sig-2" {
+		t.Fatalf("later signed assistant matched wrong signature: %s", second[0].Get("signature").String())
+	}
+
+	if second[0].Get("thinking").String() == "first" {
+		t.Fatalf("dropped first signed turn leaked into later assistant: %s", gjson.GetBytes(updated, "messages.3.content").Raw)
+	}
+}
+
 func internalcacheClearClaudeThinkingReplay(t *testing.T) {
 	t.Helper()
 	internalcache.ClearClaudeThinkingReplayCache()

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -570,6 +570,70 @@ func TestClaudeExecutorCompatThinkingReplayRestoresOpaqueOmittedBlock(t *testing
 	}
 }
 
+func TestClaudeExecutorCompatThinkingReplayRestoresEchoedSignedThinking(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	opaque := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
+	opaqueSig := base64.StdEncoding.EncodeToString(opaque)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"` + opaqueSig + `"},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"inspect"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "echoed-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error = %v", errExecute)
+	}
+
+	// Client echoes the complete assistant content, including the signed thinking
+	// block. The sanitizer will clear the opaque signature; the replay cache must
+	// restore the original signed content.
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"inspect"},{"role":"assistant","content":[{"type":"thinking","thinking":"provider reasoning","signature":"` + opaqueSig + `"},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}]}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "echoed-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error = %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	content := gjson.GetBytes(requestBodies[1], "messages.1.content").Array()
+	if len(content) != 2 {
+		t.Fatalf("second assistant content = %s, want thinking and tool_use", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
+	}
+	if got := content[0].Get("type").String(); got != "thinking" {
+		t.Fatalf("restored first content type = %q, want thinking", got)
+	}
+	if got := content[0].Get("signature").String(); got != opaqueSig {
+		t.Fatalf("restored opaque signature = %q, want %q", got, opaqueSig)
+	}
+}
+
 func internalcacheClearClaudeThinkingReplay(t *testing.T) {
 	t.Helper()
 	internalcache.ClearClaudeThinkingReplayCache()

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -789,6 +789,92 @@ func TestClaudeExecutorCompatThinkingReplayIsConversationScopedForSessionlessCli
 	}
 }
 
+func TestClaudeExecutorCompatThinkingReplayIsCallerScopedForSessionlessClients(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	opaqueA := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
+	opaqueSigA := base64.StdEncoding.EncodeToString(opaqueA)
+	opaqueB := bytes.Repeat([]byte{0x34, 0xff, 0x99, 0x11, 0x22, 0x33, 0x44, 0x55}, 4)
+	opaqueSigB := base64.StdEncoding.EncodeToString(opaqueB)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"` + opaqueSigA + `"},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"one"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		if call == 2 {
+			_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"` + opaqueSigB + `"},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"one"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-3","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	basePayload := []byte(`{"messages":[{"role":"user","content":"same task"}]}`)
+
+	// Caller A: first turn.
+	aReq, aOpts := claudeReplayTestRequest(basePayload, "", true, sdktranslator.FormatClaude)
+	aOpts.Headers = http.Header{"User-Agent": []string{"client-A"}}
+	if _, errExecute := executor.Execute(context.Background(), auth, aReq, aOpts); errExecute != nil {
+		t.Fatalf("caller A first Execute() error = %v", errExecute)
+	}
+
+	// Caller B: same credential, same first message, different caller signal.
+	bReq, bOpts := claudeReplayTestRequest(basePayload, "", true, sdktranslator.FormatClaude)
+	bOpts.Headers = http.Header{"User-Agent": []string{"client-B"}}
+	if _, errExecute := executor.Execute(context.Background(), auth, bReq, bOpts); errExecute != nil {
+		t.Fatalf("caller B first Execute() error = %v", errExecute)
+	}
+
+	// Caller A second turn: same User-Agent, must restore sigA.
+	a2Payload := []byte(`{"messages":[{"role":"user","content":"same task"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"one"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}]}`)
+	a2Req, a2Opts := claudeReplayTestRequest(a2Payload, "", true, sdktranslator.FormatClaude)
+	a2Opts.Headers = http.Header{"User-Agent": []string{"client-A"}}
+	if _, errExecute := executor.Execute(context.Background(), auth, a2Req, a2Opts); errExecute != nil {
+		t.Fatalf("caller A second Execute() error = %v", errExecute)
+	}
+
+	// Caller B second turn: same User-Agent, must restore sigB (not sigA).
+	b2Req, b2Opts := claudeReplayTestRequest(a2Payload, "", true, sdktranslator.FormatClaude)
+	b2Opts.Headers = http.Header{"User-Agent": []string{"client-B"}}
+	if _, errExecute := executor.Execute(context.Background(), auth, b2Req, b2Opts); errExecute != nil {
+		t.Fatalf("caller B second Execute() error = %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 4 {
+		t.Fatalf("upstream request count = %d, want 4", len(requestBodies))
+	}
+
+	aContent := gjson.GetBytes(requestBodies[2], "messages.1.content").Array()
+	if aContent[0].Get("signature").String() != opaqueSigA {
+		t.Fatalf("caller A did not restore its own signature: %s", aContent[0].Get("signature").String())
+	}
+
+	bContent := gjson.GetBytes(requestBodies[3], "messages.1.content").Array()
+	if bContent[0].Get("signature").String() != opaqueSigB {
+		t.Fatalf("caller B did not restore its own signature or leaked caller A's: %s", bContent[0].Get("signature").String())
+	}
+}
+
 func internalcacheClearClaudeThinkingReplay(t *testing.T) {
 	t.Helper()
 	internalcache.ClearClaudeThinkingReplayCache()

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -1590,3 +1590,24 @@ func TestClaudeExecutorCompatThinkingReplayCrossFormatStream(t *testing.T) {
 		t.Fatalf("cross-format stream did not replay signed thinking: %s", gjson.GetBytes(requestBodies[1], "messages.0.content").Raw)
 	}
 }
+
+func TestClaudeThinkingReplayFindStartIndex_RefusesPartialAnchor(t *testing.T) {
+	assistant := []gjson.Result{
+		gjson.Parse(`[{"type":"text","text":"A-old"}]`),
+		gjson.Parse(`[{"type":"text","text":"X"}]`),
+	}
+	cached := [][]byte{
+		[]byte(`[{"type":"text","text":"A-old"}]`),
+		[]byte(`[{"type":"text","text":"A-new"}]`),
+	}
+	if got := claudeThinkingReplayFindStartIndex(assistant, cached); got != -1 {
+		t.Fatalf("expected -1 for partial match with unsigned trailing turn, got %d", got)
+	}
+
+	assistantFull := []gjson.Result{
+		gjson.Parse(`[{"type":"text","text":"A-new"}]`),
+	}
+	if got := claudeThinkingReplayFindStartIndex(assistantFull, cached); got != 1 {
+		t.Fatalf("expected latest full match start 1, got %d", got)
+	}
+}

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -16,7 +16,21 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
+
+// claudeReplayPayloadWithConversationID adds a conversation nonce to a payload
+// so sessionless clients can use the fallback conversation replay scope.
+func claudeReplayPayloadWithConversationID(payload []byte, conversationID string) []byte {
+	if conversationID == "" {
+		return payload
+	}
+	updated, err := sjson.SetBytes(payload, "client_metadata.conversation_id", conversationID)
+	if err != nil {
+		return payload
+	}
+	return updated
+}
 
 const claudeReplayResolvedModelInfoKey = "cliproxy.resolved_api_key_model_info"
 
@@ -667,6 +681,7 @@ func TestClaudeExecutorCompatThinkingReplayRestoresSessionlessSameUpstreamSignat
 	executor := NewClaudeExecutor(nil)
 	auth := claudeReplayTestAuth(server.URL)
 	firstRequest, firstOptions := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"inspect"}]}`), "", true, sdktranslator.FormatClaude)
+	firstRequest.Payload = claudeReplayPayloadWithConversationID(firstRequest.Payload, "sessionless-inspect")
 	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
 		t.Fatalf("first Execute() error = %v", errExecute)
 	}
@@ -674,6 +689,7 @@ func TestClaudeExecutorCompatThinkingReplayRestoresSessionlessSameUpstreamSignat
 	// Sessionless client echoes the assistant turn without execution session metadata.
 	secondPayload := []byte(`{"messages":[{"role":"user","content":"inspect"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}]}`)
 	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "", true, sdktranslator.FormatClaude)
+	secondRequest.Payload = claudeReplayPayloadWithConversationID(secondRequest.Payload, "sessionless-inspect")
 	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
 		t.Fatalf("second Execute() error = %v", errExecute)
 	}
@@ -736,24 +752,28 @@ func TestClaudeExecutorCompatThinkingReplayIsConversationScopedForSessionlessCli
 
 	// Conversation A first turn, no session metadata.
 	firstAReq, firstAOpts := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"task A"}]}`), "", true, sdktranslator.FormatClaude)
+	firstAReq.Payload = claudeReplayPayloadWithConversationID(firstAReq.Payload, "conv-A")
 	if _, errExecute := executor.Execute(context.Background(), auth, firstAReq, firstAOpts); errExecute != nil {
 		t.Fatalf("conversation A first Execute() error = %v", errExecute)
 	}
 
 	// Conversation B first turn, same credential, different first user content.
 	firstBReq, firstBOpts := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"task B"}]}`), "", true, sdktranslator.FormatClaude)
+	firstBReq.Payload = claudeReplayPayloadWithConversationID(firstBReq.Payload, "conv-B")
 	if _, errExecute := executor.Execute(context.Background(), auth, firstBReq, firstBOpts); errExecute != nil {
 		t.Fatalf("conversation B first Execute() error = %v", errExecute)
 	}
 
 	// Conversation A second turn: same first message, so it must restore sigA.
 	secondAReq, secondAOpts := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"task A"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_A","name":"Read","input":{"path":"A"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_A","content":"ok"}]}]}`), "", true, sdktranslator.FormatClaude)
+	secondAReq.Payload = claudeReplayPayloadWithConversationID(secondAReq.Payload, "conv-A")
 	if _, errExecute := executor.Execute(context.Background(), auth, secondAReq, secondAOpts); errExecute != nil {
 		t.Fatalf("conversation A second Execute() error = %v", errExecute)
 	}
 
 	// Conversation B second turn: same conversation as B, must restore sigB.
 	secondBReq, secondBOpts := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"task B"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_B","name":"Read","input":{"path":"B"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_B","content":"ok"}]}]}`), "", true, sdktranslator.FormatClaude)
+	secondBReq.Payload = claudeReplayPayloadWithConversationID(secondBReq.Payload, "conv-B")
 	if _, errExecute := executor.Execute(context.Background(), auth, secondBReq, secondBOpts); errExecute != nil {
 		t.Fatalf("conversation B second Execute() error = %v", errExecute)
 	}
@@ -763,6 +783,7 @@ func TestClaudeExecutorCompatThinkingReplayIsConversationScopedForSessionlessCli
 	// contain conversation A's signature, so the previous assistant signature is
 	// not restored.
 	thirdBReq, thirdBOpts := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"task B"},{"role":"assistant","content":[{"type":"thinking","thinking":"provider reasoning A","signature":"`+opaqueSigA+`"},{"type":"tool_use","id":"toolu_A","name":"Read","input":{"path":"A"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_A","content":"ok"}]}]}`), "", true, sdktranslator.FormatClaude)
+	thirdBReq.Payload = claudeReplayPayloadWithConversationID(thirdBReq.Payload, "conv-B")
 	if _, errExecute := executor.Execute(context.Background(), auth, thirdBReq, thirdBOpts); errExecute != nil {
 		t.Fatalf("conversation B third Execute() error = %v", errExecute)
 	}
@@ -831,6 +852,7 @@ func TestClaudeExecutorCompatThinkingReplayIsCallerScopedForSessionlessClients(t
 
 	// Caller A: first turn.
 	aReq, aOpts := claudeReplayTestRequest(basePayload, "", true, sdktranslator.FormatClaude)
+	aReq.Payload = claudeReplayPayloadWithConversationID(aReq.Payload, "caller-scoped")
 	aOpts.Headers = http.Header{"User-Agent": []string{"client-A"}}
 	if _, errExecute := executor.Execute(context.Background(), auth, aReq, aOpts); errExecute != nil {
 		t.Fatalf("caller A first Execute() error = %v", errExecute)
@@ -838,6 +860,7 @@ func TestClaudeExecutorCompatThinkingReplayIsCallerScopedForSessionlessClients(t
 
 	// Caller B: same credential, same first message, different caller signal.
 	bReq, bOpts := claudeReplayTestRequest(basePayload, "", true, sdktranslator.FormatClaude)
+	bReq.Payload = claudeReplayPayloadWithConversationID(bReq.Payload, "caller-scoped")
 	bOpts.Headers = http.Header{"User-Agent": []string{"client-B"}}
 	if _, errExecute := executor.Execute(context.Background(), auth, bReq, bOpts); errExecute != nil {
 		t.Fatalf("caller B first Execute() error = %v", errExecute)
@@ -846,6 +869,7 @@ func TestClaudeExecutorCompatThinkingReplayIsCallerScopedForSessionlessClients(t
 	// Caller A second turn: same User-Agent, must restore sigA.
 	a2Payload := []byte(`{"messages":[{"role":"user","content":"same task"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"one"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}]}`)
 	a2Req, a2Opts := claudeReplayTestRequest(a2Payload, "", true, sdktranslator.FormatClaude)
+	a2Req.Payload = claudeReplayPayloadWithConversationID(a2Req.Payload, "caller-scoped")
 	a2Opts.Headers = http.Header{"User-Agent": []string{"client-A"}}
 	if _, errExecute := executor.Execute(context.Background(), auth, a2Req, a2Opts); errExecute != nil {
 		t.Fatalf("caller A second Execute() error = %v", errExecute)
@@ -853,6 +877,7 @@ func TestClaudeExecutorCompatThinkingReplayIsCallerScopedForSessionlessClients(t
 
 	// Caller B second turn: same User-Agent, must restore sigB (not sigA).
 	b2Req, b2Opts := claudeReplayTestRequest(a2Payload, "", true, sdktranslator.FormatClaude)
+	b2Req.Payload = claudeReplayPayloadWithConversationID(b2Req.Payload, "caller-scoped")
 	b2Opts.Headers = http.Header{"User-Agent": []string{"client-B"}}
 	if _, errExecute := executor.Execute(context.Background(), auth, b2Req, b2Opts); errExecute != nil {
 		t.Fatalf("caller B second Execute() error = %v", errExecute)
@@ -872,6 +897,92 @@ func TestClaudeExecutorCompatThinkingReplayIsCallerScopedForSessionlessClients(t
 	bContent := gjson.GetBytes(requestBodies[3], "messages.1.content").Array()
 	if bContent[0].Get("signature").String() != opaqueSigB {
 		t.Fatalf("caller B did not restore its own signature or leaked caller A's: %s", bContent[0].Get("signature").String())
+	}
+}
+
+func TestClaudeExecutorCompatThinkingReplayIdenticalOpeningsUseConversationNonce(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	opaqueA := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
+	opaqueSigA := base64.StdEncoding.EncodeToString(opaqueA)
+	opaqueB := bytes.Repeat([]byte{0x34, 0xff, 0x99, 0x11, 0x22, 0x33, 0x44, 0x55}, 4)
+	opaqueSigB := base64.StdEncoding.EncodeToString(opaqueB)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning A","signature":"` + opaqueSigA + `"},{"type":"tool_use","id":"toolu_A","name":"Read","input":{"path":"A"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		if call == 2 {
+			_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning B","signature":"` + opaqueSigB + `"},{"type":"tool_use","id":"toolu_A","name":"Read","input":{"path":"A"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-3","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	basePayload := []byte(`{"messages":[{"role":"user","content":"same task"}]}`)
+
+	// Conversation A starts with the same first message and same caller context
+	// as conversation B, but uses a different conversation nonce.
+	aReq, aOpts := claudeReplayTestRequest(basePayload, "", true, sdktranslator.FormatClaude)
+	aReq.Payload = claudeReplayPayloadWithConversationID(aReq.Payload, "conv-identical-A")
+	if _, errExecute := executor.Execute(context.Background(), auth, aReq, aOpts); errExecute != nil {
+		t.Fatalf("conversation A first Execute() error = %v", errExecute)
+	}
+
+	bReq, bOpts := claudeReplayTestRequest(basePayload, "", true, sdktranslator.FormatClaude)
+	bReq.Payload = claudeReplayPayloadWithConversationID(bReq.Payload, "conv-identical-B")
+	if _, errExecute := executor.Execute(context.Background(), auth, bReq, bOpts); errExecute != nil {
+		t.Fatalf("conversation B first Execute() error = %v", errExecute)
+	}
+
+	// Each conversation continues with the echoed assistant turn. The nonces keep
+	// the caches distinct, so A restores sigA and B restores sigB.
+	continuation := []byte(`{"messages":[{"role":"user","content":"same task"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_A","name":"Read","input":{"path":"A"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_A","content":"ok"}]}]}`)
+	a2Req, a2Opts := claudeReplayTestRequest(continuation, "", true, sdktranslator.FormatClaude)
+	a2Req.Payload = claudeReplayPayloadWithConversationID(a2Req.Payload, "conv-identical-A")
+	if _, errExecute := executor.Execute(context.Background(), auth, a2Req, a2Opts); errExecute != nil {
+		t.Fatalf("conversation A second Execute() error = %v", errExecute)
+	}
+
+	b2Req, b2Opts := claudeReplayTestRequest(continuation, "", true, sdktranslator.FormatClaude)
+	b2Req.Payload = claudeReplayPayloadWithConversationID(b2Req.Payload, "conv-identical-B")
+	if _, errExecute := executor.Execute(context.Background(), auth, b2Req, b2Opts); errExecute != nil {
+		t.Fatalf("conversation B second Execute() error = %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 4 {
+		t.Fatalf("upstream request count = %d, want 4", len(requestBodies))
+	}
+
+	aContent := gjson.GetBytes(requestBodies[2], "messages.1.content").Array()
+	if aContent[0].Get("signature").String() != opaqueSigA {
+		t.Fatalf("conversation A did not restore its own signature: %s", aContent[0].Get("signature").String())
+	}
+
+	bContent := gjson.GetBytes(requestBodies[3], "messages.1.content").Array()
+	if bContent[0].Get("signature").String() != opaqueSigB {
+		t.Fatalf("conversation B did not restore its own signature or leaked A's: %s", bContent[0].Get("signature").String())
 	}
 }
 

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -342,6 +342,72 @@ func TestClaudeExecutorCompatThinkingReplayRestoresBeforeMCPToolNameRemap(t *tes
 	}
 }
 
+func TestClaudeExecutorCompatThinkingReplayRestoresOmittedThinkingWithToolProvenance(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			// Upstream returns a tool_use carrying provenance fields the sanitizer
+			// would strip before the replay match if the cached parts were not
+			// normalized.
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"EgI="},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"},"signature":"bad","thoughtSignature":"bad","extra_content":{"google":{"thought_signature":"bad"}},"model":"claude-synthetic-4772"}],"stop_reason":"tool_use"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"inspect"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "tool-provenance-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error = %v", errExecute)
+	}
+
+	// Client echoes the previous assistant's tool_use, including the provenance
+	// fields it received from the translated response.
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"inspect"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"},"signature":"bad","thoughtSignature":"bad","extra_content":{"google":{"thought_signature":"bad"}},"model":"claude-synthetic-4772"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}]}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "tool-provenance-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error = %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	content := gjson.GetBytes(requestBodies[1], "messages.1.content").Array()
+	if len(content) != 2 {
+		t.Fatalf("second assistant content = %s, want thinking and tool_use", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
+	}
+	if got := content[0].Get("type").String(); got != "thinking" {
+		t.Fatalf("restored first content type = %q, want thinking", got)
+	}
+	if got := content[0].Get("signature").String(); got != "EgI=" {
+		t.Fatalf("restored signature = %q, want EgI=", got)
+	}
+	if got := content[1].Get("signature").String(); got != "" {
+		t.Fatalf("restored tool_use still carried a signature: %q", got)
+	}
+}
+
 func TestClaudeExecutorCompatThinkingReplayClearsAfterUpstreamBadRequest(t *testing.T) {
 	internalcacheClearClaudeThinkingReplay(t)
 

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -34,6 +34,29 @@ func claudeReplayPayloadWithConversationID(payload []byte, conversationID string
 
 const claudeReplayResolvedModelInfoKey = "cliproxy.resolved_api_key_model_info"
 
+func TestClaudeThinkingReplayCallerHash_IgnoresWhitespaceOnlyHeaders(t *testing.T) {
+	auth := &cliproxyauth.Auth{ID: "auth-id"}
+	payload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	req := cliproxyexecutor.Request{Payload: payload}
+
+	withWhitespace := claudeThinkingReplayCallerHash(auth, req, cliproxyexecutor.Options{
+		Headers: http.Header{
+			"User-Agent":        []string{"client/1.0"},
+			"X-App":             []string{"   "},
+			"X-Codex-Client-Id": []string{"\t\n"},
+		},
+	})
+	withoutWhitespace := claudeThinkingReplayCallerHash(auth, req, cliproxyexecutor.Options{
+		Headers: http.Header{
+			"User-Agent": []string{"client/1.0"},
+		},
+	})
+
+	if withWhitespace != withoutWhitespace {
+		t.Fatalf("whitespace-only headers changed caller hash: %q vs %q", withWhitespace, withoutWhitespace)
+	}
+}
+
 func claudeReplayTestAuth(baseURL string) *cliproxyauth.Auth {
 	return &cliproxyauth.Auth{
 		ID:       "claude-replay-auth",

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -739,7 +740,7 @@ func TestClaudeExecutorCompatThinkingReplayIsConversationScopedForSessionlessCli
 
 	opaqueA := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
 	opaqueSigA := base64.StdEncoding.EncodeToString(opaqueA)
-	opaqueB := bytes.Repeat([]byte{0x34, 0xff, 0x99, 0x11, 0x22, 0x33, 0x44, 0x55}, 4)
+	opaqueB := bytes.Repeat([]byte{0x12, 0x99, 0x99, 0x99, 0x22, 0x33, 0x44, 0x55}, 4)
 	opaqueSigB := base64.StdEncoding.EncodeToString(opaqueB)
 
 	var mu sync.Mutex
@@ -838,7 +839,7 @@ func TestClaudeExecutorCompatThinkingReplayIsCallerScopedForSessionlessClients(t
 
 	opaqueA := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
 	opaqueSigA := base64.StdEncoding.EncodeToString(opaqueA)
-	opaqueB := bytes.Repeat([]byte{0x34, 0xff, 0x99, 0x11, 0x22, 0x33, 0x44, 0x55}, 4)
+	opaqueB := bytes.Repeat([]byte{0x12, 0x99, 0x99, 0x99, 0x22, 0x33, 0x44, 0x55}, 4)
 	opaqueSigB := base64.StdEncoding.EncodeToString(opaqueB)
 
 	var mu sync.Mutex
@@ -928,7 +929,7 @@ func TestClaudeExecutorCompatThinkingReplayIdenticalOpeningsUseConversationNonce
 
 	opaqueA := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
 	opaqueSigA := base64.StdEncoding.EncodeToString(opaqueA)
-	opaqueB := bytes.Repeat([]byte{0x34, 0xff, 0x99, 0x11, 0x22, 0x33, 0x44, 0x55}, 4)
+	opaqueB := bytes.Repeat([]byte{0x12, 0x99, 0x99, 0x99, 0x22, 0x33, 0x44, 0x55}, 4)
 	opaqueSigB := base64.StdEncoding.EncodeToString(opaqueB)
 
 	var mu sync.Mutex
@@ -1032,7 +1033,7 @@ func TestClaudeExecutorCompatThinkingReplayRestoresSignedNonToolResponse(t *test
 			// Upstream returns a signed thinking block followed by a plain text
 			// answer with no tool_use. This must be cached and restored on the
 			// next user turn.
-			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"opaque-signature-non-tool"},{"type":"text","text":"The answer is 42"}],"stop_reason":"end_turn"}`))
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"EgI="},{"type":"text","text":"The answer is 42"}],"stop_reason":"end_turn"}`))
 			return
 		}
 		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
@@ -1063,8 +1064,8 @@ func TestClaudeExecutorCompatThinkingReplayRestoresSignedNonToolResponse(t *test
 	if len(content) != 2 || content[0].Get("type").String() != "thinking" {
 		t.Fatalf("second assistant content = %s, want restored thinking and text", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
 	}
-	if got := content[0].Get("signature").String(); got != "opaque-signature-non-tool" {
-		t.Fatalf("restored signature = %q, want opaque-signature-non-tool", got)
+	if got := content[0].Get("signature").String(); got != "EgI=" {
+		t.Fatalf("restored signature = %q, want EgI=", got)
 	}
 }
 
@@ -1088,7 +1089,7 @@ func TestClaudeExecutorCompatThinkingReplayRestoresAfterSensitiveWordObfuscation
 
 		w.Header().Set("Content-Type", "application/json")
 		if call == 1 {
-			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"opaque-sig-obfuscate"},{"type":"text","text":"the secret answer"}],"stop_reason":"end_turn"}`))
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"EgI="},{"type":"text","text":"the secret answer"}],"stop_reason":"end_turn"}`))
 			return
 		}
 		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
@@ -1122,8 +1123,8 @@ func TestClaudeExecutorCompatThinkingReplayRestoresAfterSensitiveWordObfuscation
 	if len(content) != 2 || content[0].Get("type").String() != "thinking" {
 		t.Fatalf("second assistant content = %s, want restored thinking and text", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
 	}
-	if got := content[0].Get("signature").String(); got != "opaque-sig-obfuscate" {
-		t.Fatalf("restored signature = %q, want opaque-sig-obfuscate", got)
+	if got := content[0].Get("signature").String(); got != "EgI=" {
+		t.Fatalf("restored signature = %q, want EgI=", got)
 	}
 	text := content[1].Get("text").String()
 	if text == "the secret answer" {
@@ -1151,7 +1152,7 @@ func TestClaudeExecutorCompatThinkingReplaySkipsObfuscationWhenCloakingDisabled(
 
 		w.Header().Set("Content-Type", "application/json")
 		if call == 1 {
-			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"opaque-sig-obfuscate"},{"type":"text","text":"the secret answer"}],"stop_reason":"end_turn"}`))
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"EgI="},{"type":"text","text":"the secret answer"}],"stop_reason":"end_turn"}`))
 			return
 		}
 		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
@@ -1184,8 +1185,8 @@ func TestClaudeExecutorCompatThinkingReplaySkipsObfuscationWhenCloakingDisabled(
 	if len(content) != 2 || content[0].Get("type").String() != "thinking" {
 		t.Fatalf("second assistant content = %s, want restored thinking and text", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
 	}
-	if got := content[0].Get("signature").String(); got != "opaque-sig-obfuscate" {
-		t.Fatalf("restored signature = %q, want opaque-sig-obfuscate", got)
+	if got := content[0].Get("signature").String(); got != "EgI=" {
+		t.Fatalf("restored signature = %q, want EgI=", got)
 	}
 	text := content[1].Get("text").String()
 	if text != "the secret answer" {
@@ -1236,7 +1237,7 @@ func TestClaudeExecutorCompatThinkingReplayRetainsSignedTurnAfterUnsignedRespons
 
 		w.Header().Set("Content-Type", "application/json")
 		if call == 1 {
-			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"opaque-sig-retain"},{"type":"text","text":"signed answer"}],"stop_reason":"end_turn"}`))
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"EgI="},{"type":"text","text":"signed answer"}],"stop_reason":"end_turn"}`))
 			return
 		}
 		if call == 2 {
@@ -1274,7 +1275,7 @@ func TestClaudeExecutorCompatThinkingReplayRetainsSignedTurnAfterUnsignedRespons
 		t.Fatalf("upstream request count = %d, want 3", len(requestBodies))
 	}
 	firstAssistant := gjson.GetBytes(requestBodies[2], "messages.1.content").Array()
-	if firstAssistant[0].Get("signature").String() != "opaque-sig-retain" {
+	if firstAssistant[0].Get("signature").String() != "EgI=" {
 		t.Fatalf("first signed turn not replayed after unsigned response: %s", gjson.GetBytes(requestBodies[2], "messages.1.content").Raw)
 	}
 	secondAssistant := gjson.GetBytes(requestBodies[2], "messages.3.content").Array()
@@ -1398,7 +1399,7 @@ func TestClaudeExecutorCompatThinkingReplayRetainsScopeAfterHistoryCompaction(t 
 
 		w.Header().Set("Content-Type", "application/json")
 		if call == 1 {
-			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"opaque-sig-compact"},{"type":"text","text":"compact answer"}],"stop_reason":"end_turn"}`))
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"EgI="},{"type":"text","text":"compact answer"}],"stop_reason":"end_turn"}`))
 			return
 		}
 		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
@@ -1429,7 +1430,7 @@ func TestClaudeExecutorCompatThinkingReplayRetainsScopeAfterHistoryCompaction(t 
 		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
 	}
 	assistant := gjson.GetBytes(requestBodies[1], "messages.0.content").Array()
-	if assistant[0].Get("signature").String() != "opaque-sig-compact" {
+	if assistant[0].Get("signature").String() != "EgI=" {
 		t.Fatalf("compacted request did not resolve the original replay scope: %s", gjson.GetBytes(requestBodies[1], "messages.0.content").Raw)
 	}
 }
@@ -1454,7 +1455,7 @@ func TestClaudeExecutorCompatThinkingReplayRetainsNoNonceScopeAfterHistoryCompac
 
 		w.Header().Set("Content-Type", "application/json")
 		if call == 1 {
-			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"opaque-sig-nonceless"},{"type":"text","text":"compact answer"}],"stop_reason":"end_turn"}`))
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"EgI="},{"type":"text","text":"compact answer"}],"stop_reason":"end_turn"}`))
 			return
 		}
 		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
@@ -1482,7 +1483,7 @@ func TestClaudeExecutorCompatThinkingReplayRetainsNoNonceScopeAfterHistoryCompac
 		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
 	}
 	assistant := gjson.GetBytes(requestBodies[1], "messages.0.content").Array()
-	if assistant[0].Get("signature").String() != "opaque-sig-nonceless" {
+	if assistant[0].Get("signature").String() != "EgI=" {
 		t.Fatalf("compacted request did not resolve the no-nonce replay scope: %s", gjson.GetBytes(requestBodies[1], "messages.0.content").Raw)
 	}
 }
@@ -1491,4 +1492,101 @@ func internalcacheClearClaudeThinkingReplay(t *testing.T) {
 	t.Helper()
 	internalcache.ClearClaudeThinkingReplayCache()
 	t.Cleanup(internalcache.ClearClaudeThinkingReplayCache)
+}
+
+func TestClaudeExecutorCompatThinkingReplayCrossFormatStream(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	opaque := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
+	opaqueSig := base64.StdEncoding.EncodeToString(opaque)
+
+	streamResponse := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_1","model":"claude-synthetic-4772"}}`,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"provider reasoning"}}`,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"` + opaqueSig + `"}}`,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":0}`,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"hello"}}`,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":1}`,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}`,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		if call == 1 {
+			_, _ = w.Write([]byte(streamResponse))
+			return
+		}
+		_, _ = w.Write([]byte(streamResponse))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	payload := []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
+	req, opts := claudeReplayTestRequest(payload, "stream-cross-format", true, sdktranslator.FormatClaude)
+	opts.Stream = true
+	opts.ResponseFormat = sdktranslator.FormatOpenAI
+
+	result, err := executor.ExecuteStream(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("first ExecuteStream() error: %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+	}
+
+	secondPayload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"text","text":"hello"}]},{"role":"user","content":"next"}]}`)
+	secondReq, secondOpts := claudeReplayTestRequest(secondPayload, "stream-cross-format", true, sdktranslator.FormatClaude)
+	secondOpts.Stream = true
+	secondOpts.ResponseFormat = sdktranslator.FormatOpenAI
+
+	result, err = executor.ExecuteStream(context.Background(), auth, secondReq, secondOpts)
+	if err != nil {
+		t.Fatalf("second ExecuteStream() error: %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	assistant := gjson.GetBytes(requestBodies[1], "messages.0.content").Array()
+	if len(assistant) == 0 || assistant[0].Get("signature").String() != opaqueSig {
+		t.Fatalf("cross-format stream did not replay signed thinking: %s", gjson.GetBytes(requestBodies[1], "messages.0.content").Raw)
+	}
 }

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -1207,6 +1207,62 @@ func TestRestoreClaudeThinkingReplayContents_SkipsUnsignedLeadingAssistant(t *te
 	}
 }
 
+func TestClaudeExecutorCompatThinkingReplayRetainsScopeAfterHistoryCompaction(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"opaque-sig-compact"},{"type":"text","text":"compact answer"}],"stop_reason":"end_turn"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	auth := claudeReplayTestAuth(server.URL)
+	executor := NewClaudeExecutor(nil)
+
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "compact-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error: %v", errExecute)
+	}
+
+	// Compacted follow-up: the first user message is removed, but the assistant
+	// turn that was just produced remains. The sessionless fallback scope must
+	// resolve to the original conversation through the assistant alias.
+	compactedPayload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"text","text":"compact answer"}]},{"role":"user","content":"next"}]}`)
+	compactedRequest, compactedOptions := claudeReplayTestRequest(compactedPayload, "compact-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, compactedRequest, compactedOptions); errExecute != nil {
+		t.Fatalf("compacted Execute() error: %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	assistant := gjson.GetBytes(requestBodies[1], "messages.0.content").Array()
+	if assistant[0].Get("signature").String() != "opaque-sig-compact" {
+		t.Fatalf("compacted request did not resolve the original replay scope: %s", gjson.GetBytes(requestBodies[1], "messages.0.content").Raw)
+	}
+}
+
 func internalcacheClearClaudeThinkingReplay(t *testing.T) {
 	t.Helper()
 	internalcache.ClearClaudeThinkingReplayCache()

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -267,6 +267,81 @@ func claudeReplayThinkingStream() string {
 		"data: {\"type\":\"message_stop\"}\n\n"
 }
 
+func TestClaudeExecutorCompatThinkingReplayRestoresBeforeMCPToolNameRemap(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			// The upstream tool name is the alias; echo it back so the cache stores
+			// the caller-facing name after restoreClaudeOAuthToolNamesFromResponse.
+			aliasName := gjson.GetBytes(body, "tools.0.name").String()
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"EgI="},{"type":"tool_use","id":"toolu_1","name":"` + aliasName + `","input":{"path":"README.md"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	auth.Attributes["fingerprint_profile"] = "claude-code-cli"
+
+	tools := `[{"name":"my_tool","input_schema":{"type":"object"}}]`
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"call my_tool"}],"tools":` + tools + `}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "mcp-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error = %v", errExecute)
+	}
+
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"call my_tool"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"my_tool","input":{"path":"README.md"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}],"tools":` + tools + `}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "mcp-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error = %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+
+	secondContent := gjson.GetBytes(requestBodies[1], "messages.1.content").Array()
+	if len(secondContent) != 2 {
+		t.Fatalf("second assistant content = %s, want thinking and tool_use", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
+	}
+	if got := secondContent[0].Get("type").String(); got != "thinking" {
+		t.Fatalf("restored first content type = %q, want thinking", got)
+	}
+	if got := secondContent[0].Get("signature").String(); got != "EgI=" {
+		t.Fatalf("restored signature = %q, want EgI=", got)
+	}
+
+	// The restored tool_use name must be remapped for upstream, matching the
+	// alias in the second request's tools array.
+	secondToolName := gjson.GetBytes(requestBodies[1], "tools.0.name").String()
+	if secondToolName == "" || secondToolName == "my_tool" {
+		t.Fatalf("second request tool name was not aliased: %q", secondToolName)
+	}
+	if got := secondContent[1].Get("name").String(); got != secondToolName {
+		t.Fatalf("restored tool_use name = %q, want alias %q", got, secondToolName)
+	}
+}
+
 func TestClaudeExecutorCompatThinkingReplayClearsAfterUpstreamBadRequest(t *testing.T) {
 	internalcacheClearClaudeThinkingReplay(t)
 

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -1434,6 +1434,59 @@ func TestClaudeExecutorCompatThinkingReplayRetainsScopeAfterHistoryCompaction(t 
 	}
 }
 
+func TestClaudeExecutorCompatThinkingReplayRetainsNoNonceScopeAfterHistoryCompaction(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"opaque-sig-nonceless"},{"type":"text","text":"compact answer"}],"stop_reason":"end_turn"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	auth := claudeReplayTestAuth(server.URL)
+	executor := NewClaudeExecutor(nil)
+
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error: %v", errExecute)
+	}
+
+	compactedPayload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"text","text":"compact answer"}]},{"role":"user","content":"next"}]}`)
+	compactedRequest, compactedOptions := claudeReplayTestRequest(compactedPayload, "", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, compactedRequest, compactedOptions); errExecute != nil {
+		t.Fatalf("compacted Execute() error: %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	assistant := gjson.GetBytes(requestBodies[1], "messages.0.content").Array()
+	if assistant[0].Get("signature").String() != "opaque-sig-nonceless" {
+		t.Fatalf("compacted request did not resolve the no-nonce replay scope: %s", gjson.GetBytes(requestBodies[1], "messages.0.content").Raw)
+	}
+}
+
 func internalcacheClearClaudeThinkingReplay(t *testing.T) {
 	t.Helper()
 	internalcache.ClearClaudeThinkingReplayCache()

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -1488,6 +1488,58 @@ func TestClaudeExecutorCompatThinkingReplayRetainsNoNonceScopeAfterHistoryCompac
 	}
 }
 
+func TestClaudeExecutorCompatThinkingReplayNoAliasForNonceScope(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"EgI="},{"type":"text","text":"compact answer"}],"stop_reason":"end_turn"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	auth := claudeReplayTestAuth(server.URL)
+	executor := NewClaudeExecutor(nil)
+
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "", true, sdktranslator.FormatClaude)
+	firstRequest.Payload = claudeReplayPayloadWithConversationID(firstRequest.Payload, "nonce-scope")
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error: %v", errExecute)
+	}
+
+	// A later no-nonce compacted request should not resolve to the nonce scope:
+	// aliases are registered only for content-derived scopes.
+	compactedPayload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"text","text":"compact answer"}]},{"role":"user","content":"next"}]}`)
+	compactedRequest, compactedOptions := claudeReplayTestRequest(compactedPayload, "", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, compactedRequest, compactedOptions); errExecute != nil {
+		t.Fatalf("compacted Execute() error: %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2; nonce scope registered aliases and was resolved", len(requestBodies))
+	}
+}
+
 func internalcacheClearClaudeThinkingReplay(t *testing.T) {
 	t.Helper()
 	internalcache.ClearClaudeThinkingReplayCache()

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -634,6 +634,67 @@ func TestClaudeExecutorCompatThinkingReplayRestoresEchoedSignedThinking(t *testi
 	}
 }
 
+func TestClaudeExecutorCompatThinkingReplayRestoresSessionlessSameUpstreamSignature(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	opaque := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
+	opaqueSig := base64.StdEncoding.EncodeToString(opaque)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"` + opaqueSig + `"},{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"}}],"stop_reason":"tool_use"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	firstRequest, firstOptions := claudeReplayTestRequest([]byte(`{"messages":[{"role":"user","content":"inspect"}]}`), "", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error = %v", errExecute)
+	}
+
+	// Sessionless client echoes the assistant turn without execution session metadata.
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"inspect"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"path":"README.md"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}]}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error = %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	content := gjson.GetBytes(requestBodies[1], "messages.1.content").Array()
+	if len(content) != 2 {
+		t.Fatalf("second assistant content = %s, want thinking and tool_use", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
+	}
+	if got := content[0].Get("type").String(); got != "thinking" {
+		t.Fatalf("restored first content type = %q, want thinking", got)
+	}
+	if got := content[0].Get("signature").String(); got != opaqueSig {
+		t.Fatalf("sessionless restored signature = %q, want %q", got, opaqueSig)
+	}
+}
+
 func internalcacheClearClaudeThinkingReplay(t *testing.T) {
 	t.Helper()
 	internalcache.ClearClaudeThinkingReplayCache()

--- a/internal/runtime/executor/claude_thinking_replay_test.go
+++ b/internal/runtime/executor/claude_thinking_replay_test.go
@@ -875,6 +875,123 @@ func TestClaudeExecutorCompatThinkingReplayIsCallerScopedForSessionlessClients(t
 	}
 }
 
+func TestClaudeExecutorCompatThinkingReplayRestoresSignedNonToolResponse(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"opaque-signature-non-tool"},{"type":"text","text":"The answer is 42"}],"stop_reason":"end_turn"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(nil)
+	auth := claudeReplayTestAuth(server.URL)
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"what is the answer"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "nonstream-replay-non-tool", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error: %v", errExecute)
+	}
+
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"what is the answer"},{"role":"assistant","content":[{"type":"text","text":"The answer is 42"}]},{"role":"user","content":"thanks"}]}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "nonstream-replay-non-tool", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error: %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	content := gjson.GetBytes(requestBodies[1], "messages.1.content").Array()
+	if len(content) != 2 || content[0].Get("type").String() != "thinking" {
+		t.Fatalf("second assistant content = %s, want restored thinking and text", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
+	}
+	if got := content[0].Get("signature").String(); got != "opaque-signature-non-tool" {
+		t.Fatalf("restored signature = %q, want opaque-signature-non-tool", got)
+	}
+}
+
+func TestClaudeExecutorCompatThinkingReplayRestoresAfterSensitiveWordObfuscation(t *testing.T) {
+	internalcacheClearClaudeThinkingReplay(t)
+
+	var mu sync.Mutex
+	var requestBodies [][]byte
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		mu.Lock()
+		requestBodies = append(requestBodies, bytes.Clone(body))
+		callCount++
+		call := callCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(`{"id":"msg-1","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"thinking","thinking":"provider reasoning","signature":"opaque-sig-obfuscate"},{"type":"text","text":"the secret answer"}],"stop_reason":"end_turn"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"id":"msg-2","type":"message","role":"assistant","model":"claude-synthetic-4772","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn"}`))
+	}))
+	defer server.Close()
+
+	auth := claudeReplayTestAuth(server.URL)
+	auth.Attributes["cloak_mode"] = "always"
+	auth.Attributes["cloak_sensitive_words"] = "secret"
+
+	executor := NewClaudeExecutor(nil)
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"what is the secret"}]}`)
+	firstRequest, firstOptions := claudeReplayTestRequest(firstPayload, "obfuscate-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, firstRequest, firstOptions); errExecute != nil {
+		t.Fatalf("first Execute() error: %v", errExecute)
+	}
+
+	secondPayload := []byte(`{"messages":[{"role":"user","content":"what is the secret"},{"role":"assistant","content":[{"type":"text","text":"the secret answer"}]},{"role":"user","content":"thanks"}]}`)
+	secondRequest, secondOptions := claudeReplayTestRequest(secondPayload, "obfuscate-replay", true, sdktranslator.FormatClaude)
+	if _, errExecute := executor.Execute(context.Background(), auth, secondRequest, secondOptions); errExecute != nil {
+		t.Fatalf("second Execute() error: %v", errExecute)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(requestBodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(requestBodies))
+	}
+	content := gjson.GetBytes(requestBodies[1], "messages.1.content").Array()
+	if len(content) != 2 || content[0].Get("type").String() != "thinking" {
+		t.Fatalf("second assistant content = %s, want restored thinking and text", gjson.GetBytes(requestBodies[1], "messages.1.content").Raw)
+	}
+	if got := content[0].Get("signature").String(); got != "opaque-sig-obfuscate" {
+		t.Fatalf("restored signature = %q, want opaque-sig-obfuscate", got)
+	}
+	text := content[1].Get("text").String()
+	if text == "the secret answer" {
+		t.Fatalf("sensitive word not obfuscated in restored text: %q", text)
+	}
+}
+
 func internalcacheClearClaudeThinkingReplay(t *testing.T) {
 	t.Helper()
 	internalcache.ClearClaudeThinkingReplayCache()

--- a/internal/runtime/executor/helps/claude_thinking_replay_session.go
+++ b/internal/runtime/executor/helps/claude_thinking_replay_session.go
@@ -15,12 +15,47 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+// conversationNonceSources lists the gjson paths and header names that may
+// carry an explicit conversation identifier. An explicit nonce is required for
+// the fallback conversation key so two identical conversation openings do not
+// share a replay scope.
+var conversationNonceSources = struct {
+	paths  []string
+	header []string
+}{
+	paths:  []string{"client_metadata.conversation_id", "client_metadata.conversationId", "conversation_id"},
+	header: []string{"X-Conversation-Id", "Conversation-Id", "Conversation_id"},
+}
+
+// claudeReplayConversationNonce returns a genuine conversation nonce when one
+// is explicitly provided by the caller. It returns an empty string when no
+// nonce exists, signaling that fallback replay should not be used.
+func claudeReplayConversationNonce(payload []byte, headers http.Header) string {
+	for _, path := range conversationNonceSources.paths {
+		if value := strings.TrimSpace(gjson.GetBytes(payload, path).String()); value != "" {
+			return value
+		}
+	}
+	for _, key := range conversationNonceSources.header {
+		if value := headerFirstValue(headers, key); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
 // ClaudeThinkingReplayConversationSessionKey returns a stable per-conversation
-// key for sessionless clients. It mixes a caller identity (credential id,
-// caller-scope metadata, selected headers) with the first message, system
-// prompt, and tools so two callers sharing a credential and the same initial
-// prompt cannot see each other's replay state.
+// key for sessionless clients when the caller provides a genuine conversation
+// nonce. It mixes the caller identity with the nonce, first message and system
+// prompt so two identical openings with different nonces cannot see each
+// other's replay state. If no nonce is present it returns an empty string,
+// which disables fallback replay.
 func ClaudeThinkingReplayConversationSessionKey(auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) string {
+	nonce := claudeReplayConversationNonce(req.Payload, opts.Headers)
+	if nonce == "" {
+		return ""
+	}
+
 	h := sha256.New()
 	hashString(h, "conversation")
 
@@ -46,6 +81,7 @@ func ClaudeThinkingReplayConversationSessionKey(auth *cliproxyauth.Auth, req cli
 	hashString(h, headerFirstValue(opts.Headers, "User-Agent"))
 	hashString(h, headerFirstValue(opts.Headers, "X-App"))
 	hashString(h, headerFirstValue(opts.Headers, "X-Codex-Client-Id"))
+	hashString(h, nonce)
 
 	if len(req.Payload) == 0 {
 		return ""

--- a/internal/runtime/executor/helps/claude_thinking_replay_session.go
+++ b/internal/runtime/executor/helps/claude_thinking_replay_session.go
@@ -3,8 +3,10 @@ package helps
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"hash"
 	"strings"
 
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -19,33 +21,33 @@ import (
 // prompt cannot see each other's replay state.
 func ClaudeThinkingReplayConversationSessionKey(auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) string {
 	h := sha256.New()
-	h.Write([]byte("conversation"))
+	hashString(h, "conversation")
 
 	if auth != nil {
 		if id := strings.TrimSpace(auth.ID); id != "" {
-			h.Write([]byte(id))
+			hashString(h, id)
 		} else if apiKey, _ := claudeCredentialKey(auth); apiKey != "" {
-			h.Write([]byte(apiKey))
+			hashString(h, apiKey)
+		} else {
+			hashString(h, "")
 		}
+	} else {
+		hashString(h, "")
 	}
 
-	if scope := metadataString(opts.Metadata, cliproxyexecutor.CallerScopeMetadataKey); scope != "" {
-		h.Write([]byte(scope))
-	}
-	if scope := metadataString(req.Metadata, cliproxyexecutor.CallerScopeMetadataKey); scope != "" {
-		h.Write([]byte(scope))
-	}
-	if derived := metadataString(opts.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey); derived != "" {
-		h.Write([]byte(derived))
-	}
-	if derived := metadataString(req.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey); derived != "" {
-		h.Write([]byte(derived))
-	}
+	hashString(h, metadataString(opts.Metadata, cliproxyexecutor.CallerScopeMetadataKey))
+	hashString(h, metadataString(req.Metadata, cliproxyexecutor.CallerScopeMetadataKey))
+	hashString(h, metadataString(opts.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey))
+	hashString(h, metadataString(req.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey))
 
 	if opts.Headers != nil {
-		h.Write([]byte(opts.Headers.Get("User-Agent")))
-		h.Write([]byte(opts.Headers.Get("X-App")))
-		h.Write([]byte(opts.Headers.Get("X-Codex-Client-Id")))
+		hashString(h, opts.Headers.Get("User-Agent"))
+		hashString(h, opts.Headers.Get("X-App"))
+		hashString(h, opts.Headers.Get("X-Codex-Client-Id"))
+	} else {
+		hashString(h, "")
+		hashString(h, "")
+		hashString(h, "")
 	}
 
 	if len(req.Payload) == 0 {
@@ -54,15 +56,30 @@ func ClaudeThinkingReplayConversationSessionKey(auth *cliproxyauth.Auth, req cli
 	for _, path := range []string{"messages.0", "system", "tools"} {
 		part := gjson.GetBytes(req.Payload, path)
 		if !part.Exists() {
+			hashBytes(h, nil)
 			continue
 		}
 		if canon, ok := claudeReplayCanonicalJSON([]byte(part.Raw)); ok {
-			h.Write(canon)
+			hashBytes(h, canon)
 		} else {
-			h.Write([]byte(part.Raw))
+			hashBytes(h, []byte(part.Raw))
 		}
 	}
 	return "conversation:" + hex.EncodeToString(h.Sum(nil)[:16])
+}
+
+// hashString writes s to h as a length-prefixed UTF-8 string so adjacent
+// fields cannot be confused when concatenated.
+func hashString(h hash.Hash, s string) {
+	hashBytes(h, []byte(s))
+}
+
+// hashBytes writes b to h as a length-prefixed byte slice.
+func hashBytes(h hash.Hash, b []byte) {
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(b)))
+	h.Write(length[:])
+	h.Write(b)
 }
 
 // claudeCredentialKey returns the most identifying credential value available

--- a/internal/runtime/executor/helps/claude_thinking_replay_session.go
+++ b/internal/runtime/executor/helps/claude_thinking_replay_session.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"hash"
+	"net/http"
 	"strings"
 
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -40,20 +41,16 @@ func ClaudeThinkingReplayConversationSessionKey(auth *cliproxyauth.Auth, req cli
 	hashString(h, metadataString(opts.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey))
 	hashString(h, metadataString(req.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey))
 
-	if opts.Headers != nil {
-		hashString(h, opts.Headers.Get("User-Agent"))
-		hashString(h, opts.Headers.Get("X-App"))
-		hashString(h, opts.Headers.Get("X-Codex-Client-Id"))
-	} else {
-		hashString(h, "")
-		hashString(h, "")
-		hashString(h, "")
-	}
+	// Read identity headers case-insensitively so callers that supply lowercase
+	// keys (e.g. x-codex-client-id) are not collapsed with missing values.
+	hashString(h, headerFirstValue(opts.Headers, "User-Agent"))
+	hashString(h, headerFirstValue(opts.Headers, "X-App"))
+	hashString(h, headerFirstValue(opts.Headers, "X-Codex-Client-Id"))
 
 	if len(req.Payload) == 0 {
 		return ""
 	}
-	for _, path := range []string{"messages.0", "system", "tools"} {
+	for _, path := range []string{"messages.0", "system"} {
 		part := gjson.GetBytes(req.Payload, path)
 		if !part.Exists() {
 			hashBytes(h, nil)
@@ -66,6 +63,20 @@ func ClaudeThinkingReplayConversationSessionKey(auth *cliproxyauth.Auth, req cli
 		}
 	}
 	return "conversation:" + hex.EncodeToString(h.Sum(nil)[:16])
+}
+
+// headerFirstValue returns the first value for key from headers, matching the
+// key case-insensitively to tolerate callers that use lowercase header names.
+func headerFirstValue(headers http.Header, key string) string {
+	if headers == nil {
+		return ""
+	}
+	for k, vv := range headers {
+		if strings.EqualFold(k, key) && len(vv) > 0 {
+			return vv[0]
+		}
+	}
+	return ""
 }
 
 // hashString writes s to h as a length-prefixed UTF-8 string so adjacent

--- a/internal/runtime/executor/helps/claude_thinking_replay_session.go
+++ b/internal/runtime/executor/helps/claude_thinking_replay_session.go
@@ -1,0 +1,95 @@
+package helps
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
+)
+
+// ClaudeThinkingReplayConversationSessionKey returns a stable per-conversation
+// key for sessionless clients. It mixes a caller identity (credential id,
+// caller-scope metadata, selected headers) with the first message, system
+// prompt, and tools so two callers sharing a credential and the same initial
+// prompt cannot see each other's replay state.
+func ClaudeThinkingReplayConversationSessionKey(auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) string {
+	h := sha256.New()
+	h.Write([]byte("conversation"))
+
+	if auth != nil {
+		if id := strings.TrimSpace(auth.ID); id != "" {
+			h.Write([]byte(id))
+		} else if apiKey, _ := claudeCredentialKey(auth); apiKey != "" {
+			h.Write([]byte(apiKey))
+		}
+	}
+
+	if scope := metadataString(opts.Metadata, cliproxyexecutor.CallerScopeMetadataKey); scope != "" {
+		h.Write([]byte(scope))
+	}
+	if scope := metadataString(req.Metadata, cliproxyexecutor.CallerScopeMetadataKey); scope != "" {
+		h.Write([]byte(scope))
+	}
+	if derived := metadataString(opts.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey); derived != "" {
+		h.Write([]byte(derived))
+	}
+	if derived := metadataString(req.Metadata, cliproxyexecutor.DerivedSessionIDMetadataKey); derived != "" {
+		h.Write([]byte(derived))
+	}
+
+	if opts.Headers != nil {
+		h.Write([]byte(opts.Headers.Get("User-Agent")))
+		h.Write([]byte(opts.Headers.Get("X-App")))
+		h.Write([]byte(opts.Headers.Get("X-Codex-Client-Id")))
+	}
+
+	if len(req.Payload) == 0 {
+		return ""
+	}
+	for _, path := range []string{"messages.0", "system", "tools"} {
+		part := gjson.GetBytes(req.Payload, path)
+		if !part.Exists() {
+			continue
+		}
+		if canon, ok := claudeReplayCanonicalJSON([]byte(part.Raw)); ok {
+			h.Write(canon)
+		} else {
+			h.Write([]byte(part.Raw))
+		}
+	}
+	return "conversation:" + hex.EncodeToString(h.Sum(nil)[:16])
+}
+
+// claudeCredentialKey returns the most identifying credential value available
+// for an auth without importing the executor package.
+func claudeCredentialKey(auth *cliproxyauth.Auth) (apiKey, baseURL string) {
+	if auth == nil {
+		return "", ""
+	}
+	if auth.Attributes != nil {
+		apiKey = auth.Attributes["api_key"]
+		baseURL = auth.Attributes["base_url"]
+	}
+	return apiKey, baseURL
+}
+
+// claudeReplayCanonicalJSON returns a stable JSON encoding for the given value,
+// matching the ordering used by the executor's replay match.
+func claudeReplayCanonicalJSON(raw []byte) ([]byte, bool) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, false
+	}
+	canon, err := json.Marshal(value)
+	if err != nil {
+		return nil, false
+	}
+	return canon, true
+}

--- a/internal/runtime/executor/helps/claude_thinking_replay_session.go
+++ b/internal/runtime/executor/helps/claude_thinking_replay_session.go
@@ -45,15 +45,19 @@ func claudeReplayConversationNonce(payload []byte, headers http.Header) string {
 }
 
 // ClaudeThinkingReplayConversationSessionKey returns a stable per-conversation
-// key for sessionless clients when the caller provides a genuine conversation
-// nonce. It mixes the caller identity with the nonce, first message and system
-// prompt so two identical openings with different nonces cannot see each
-// other's replay state. If no nonce is present it returns an empty string,
-// which disables fallback replay.
-func ClaudeThinkingReplayConversationSessionKey(auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) string {
-	nonce := claudeReplayConversationNonce(req.Payload, opts.Headers)
-	if nonce == "" {
-		return ""
+// key for sessionless clients. It returns usedNonce=true when an explicit
+// conversation nonce (client_metadata.conversation_id, conversation_id, or
+// X-Conversation-Id) was used. A nonce-based key is derived from stable
+// caller fields only, so it survives history compaction and gives two
+// identical openings with different nonces distinct scopes.
+//
+// When no nonce is present, the key falls back to the first user message and
+// system prompt so replay still works for stateless clients; alias resolution
+// in the executor can then recover the original conversation after history
+// compaction.
+func ClaudeThinkingReplayConversationSessionKey(auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (string, bool) {
+	if len(req.Payload) == 0 {
+		return "", false
 	}
 
 	h := sha256.New()
@@ -81,11 +85,17 @@ func ClaudeThinkingReplayConversationSessionKey(auth *cliproxyauth.Auth, req cli
 	hashString(h, headerFirstValue(opts.Headers, "User-Agent"))
 	hashString(h, headerFirstValue(opts.Headers, "X-App"))
 	hashString(h, headerFirstValue(opts.Headers, "X-Codex-Client-Id"))
-	hashString(h, nonce)
 
-	if len(req.Payload) == 0 {
-		return ""
+	nonce := claudeReplayConversationNonce(req.Payload, opts.Headers)
+	if nonce != "" {
+		hashString(h, nonce)
+		return "conversation:" + hex.EncodeToString(h.Sum(nil)[:16]), true
 	}
+
+	// No explicit nonce: fall back to the first user message and system prompt.
+	// Two different callers with the same opening are still separated by the
+	// caller fields above; two conversations from the same caller with the same
+	// opening share a scope. Use a conversation nonce to avoid that.
 	for _, path := range []string{"messages.0", "system"} {
 		part := gjson.GetBytes(req.Payload, path)
 		if !part.Exists() {
@@ -98,7 +108,7 @@ func ClaudeThinkingReplayConversationSessionKey(auth *cliproxyauth.Auth, req cli
 			hashBytes(h, []byte(part.Raw))
 		}
 	}
-	return "conversation:" + hex.EncodeToString(h.Sum(nil)[:16])
+	return "conversation:" + hex.EncodeToString(h.Sum(nil)[:16]), false
 }
 
 // headerFirstValue returns the first non-empty, trimmed value for key from

--- a/internal/runtime/executor/helps/claude_thinking_replay_session.go
+++ b/internal/runtime/executor/helps/claude_thinking_replay_session.go
@@ -101,15 +101,18 @@ func ClaudeThinkingReplayConversationSessionKey(auth *cliproxyauth.Auth, req cli
 	return "conversation:" + hex.EncodeToString(h.Sum(nil)[:16])
 }
 
-// headerFirstValue returns the first value for key from headers, matching the
-// key case-insensitively to tolerate callers that use lowercase header names.
+// headerFirstValue returns the first non-empty, trimmed value for key from
+// headers, matching the key case-insensitively to tolerate callers that use
+// lowercase header names. Whitespace-only values are treated as missing.
 func headerFirstValue(headers http.Header, key string) string {
 	if headers == nil {
 		return ""
 	}
 	for k, vv := range headers {
 		if strings.EqualFold(k, key) && len(vv) > 0 {
-			return vv[0]
+			if v := strings.TrimSpace(vv[0]); v != "" {
+				return v
+			}
 		}
 	}
 	return ""

--- a/internal/runtime/executor/helps/claude_thinking_replay_session_test.go
+++ b/internal/runtime/executor/helps/claude_thinking_replay_session_test.go
@@ -14,7 +14,7 @@ func TestClaudeThinkingReplayConversationSessionKey_DelimitsConcatenatedFields(t
 
 	// auth.ID="ab" and no caller scope. The raw concatenation of relevant
 	// caller fields is "ab".
-	keyA := ClaudeThinkingReplayConversationSessionKey(
+	keyA, _ := ClaudeThinkingReplayConversationSessionKey(
 		&cliproxyauth.Auth{ID: "ab"},
 		req,
 		cliproxyexecutor.Options{},
@@ -22,7 +22,7 @@ func TestClaudeThinkingReplayConversationSessionKey_DelimitsConcatenatedFields(t
 
 	// auth.ID="a" and caller scope "bc". The raw concatenation of the same
 	// fields is also "abc", but the field boundaries must differ.
-	keyB := ClaudeThinkingReplayConversationSessionKey(
+	keyB, _ := ClaudeThinkingReplayConversationSessionKey(
 		&cliproxyauth.Auth{ID: "a"},
 		req,
 		cliproxyexecutor.Options{
@@ -48,8 +48,8 @@ func TestClaudeThinkingReplayConversationSessionKey_IgnoresToolsList(t *testing.
 	optsA := cliproxyexecutor.Options{}
 	optsB := cliproxyexecutor.Options{}
 
-	keyA := ClaudeThinkingReplayConversationSessionKey(&cliproxyauth.Auth{ID: "caller"}, cliproxyexecutor.Request{Payload: a}, optsA)
-	keyB := ClaudeThinkingReplayConversationSessionKey(&cliproxyauth.Auth{ID: "caller"}, cliproxyexecutor.Request{Payload: b}, optsB)
+	keyA, _ := ClaudeThinkingReplayConversationSessionKey(&cliproxyauth.Auth{ID: "caller"}, cliproxyexecutor.Request{Payload: a}, optsA)
+	keyB, _ := ClaudeThinkingReplayConversationSessionKey(&cliproxyauth.Auth{ID: "caller"}, cliproxyexecutor.Request{Payload: b}, optsB)
 	if keyA == "" || keyB == "" {
 		t.Fatalf("empty key: %q, %q", keyA, keyB)
 	}
@@ -78,8 +78,8 @@ func TestClaudeThinkingReplayConversationSessionKey_ReadsHeadersCaseInsensitivel
 		},
 	}
 
-	lowerKey := ClaudeThinkingReplayConversationSessionKey(auth, req, lowerOpts)
-	upperKey := ClaudeThinkingReplayConversationSessionKey(auth, req, upperOpts)
+	lowerKey, _ := ClaudeThinkingReplayConversationSessionKey(auth, req, lowerOpts)
+	upperKey, _ := ClaudeThinkingReplayConversationSessionKey(auth, req, upperOpts)
 	if lowerKey == "" || upperKey == "" {
 		t.Fatalf("conversation key empty: %q, %q", lowerKey, upperKey)
 	}
@@ -106,8 +106,8 @@ func TestClaudeThinkingReplayConversationSessionKey_IgnoresWhitespaceOnlyHeaders
 		},
 	}
 
-	withKey := ClaudeThinkingReplayConversationSessionKey(auth, req, withWhitespace)
-	withoutKey := ClaudeThinkingReplayConversationSessionKey(auth, req, withoutWhitespace)
+	withKey, _ := ClaudeThinkingReplayConversationSessionKey(auth, req, withWhitespace)
+	withoutKey, _ := ClaudeThinkingReplayConversationSessionKey(auth, req, withoutWhitespace)
 	if withKey == "" || withoutKey == "" {
 		t.Fatalf("conversation key empty: %q, %q", withKey, withoutKey)
 	}
@@ -115,7 +115,8 @@ func TestClaudeThinkingReplayConversationSessionKey_IgnoresWhitespaceOnlyHeaders
 		t.Fatalf("whitespace-only headers changed the replay key: %q vs %q", withKey, withoutKey)
 	}
 
-	// A whitespace-only conversation header must not become the nonce.
+	// A whitespace-only conversation header must not become the nonce, but the
+	// no-nonce content-derived fallback should still produce a key.
 	wsNoncePayload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
 	wsNonceReq := cliproxyexecutor.Request{Payload: wsNoncePayload}
 	wsOpts := cliproxyexecutor.Options{
@@ -123,8 +124,12 @@ func TestClaudeThinkingReplayConversationSessionKey_IgnoresWhitespaceOnlyHeaders
 			"X-Conversation-Id": {"   "},
 		},
 	}
-	if got := ClaudeThinkingReplayConversationSessionKey(auth, wsNonceReq, wsOpts); got != "" {
-		t.Fatalf("whitespace-only conversation header produced a key: %q", got)
+	got, usedNonce := ClaudeThinkingReplayConversationSessionKey(auth, wsNonceReq, wsOpts)
+	if got == "" {
+		t.Fatal("whitespace-only conversation header disabled the content fallback")
+	}
+	if usedNonce {
+		t.Fatalf("whitespace-only conversation header was used as nonce: %q", got)
 	}
 }
 
@@ -141,8 +146,8 @@ func TestClaudeThinkingReplayConversationSessionKey_StableForIdenticalInputs(t *
 	}
 
 	auth := &cliproxyauth.Auth{ID: "auth-id"}
-	first := ClaudeThinkingReplayConversationSessionKey(auth, req, opts)
-	second := ClaudeThinkingReplayConversationSessionKey(auth, req, opts)
+	first, _ := ClaudeThinkingReplayConversationSessionKey(auth, req, opts)
+	second, _ := ClaudeThinkingReplayConversationSessionKey(auth, req, opts)
 	if first == "" {
 		t.Fatal("conversation key empty for stable inputs")
 	}
@@ -158,8 +163,8 @@ func TestClaudeThinkingReplayConversationSessionKey_DistinctForDifferentConversa
 	auth := &cliproxyauth.Auth{ID: "auth-id"}
 	opts := cliproxyexecutor.Options{}
 
-	keyA := ClaudeThinkingReplayConversationSessionKey(auth, reqA, opts)
-	keyB := ClaudeThinkingReplayConversationSessionKey(auth, reqB, opts)
+	keyA, _ := ClaudeThinkingReplayConversationSessionKey(auth, reqA, opts)
+	keyB, _ := ClaudeThinkingReplayConversationSessionKey(auth, reqB, opts)
 	if keyA == "" || keyB == "" {
 		t.Fatalf("conversation key empty: %q, %q", keyA, keyB)
 	}
@@ -168,12 +173,54 @@ func TestClaudeThinkingReplayConversationSessionKey_DistinctForDifferentConversa
 	}
 }
 
-func TestClaudeThinkingReplayConversationSessionKey_EmptyWhenNoConversationNonce(t *testing.T) {
+func TestClaudeThinkingReplayConversationSessionKey_StableWithNonceAcrossHistoryCompaction(t *testing.T) {
+	// The caller keeps the same conversation nonce but removes the first user
+	// turn (history compaction). The nonce-based key must stay the same.
+	firstPayload := []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-compact"}}`)
+	compactedPayload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"text","text":"hi"}]},{"role":"user","content":"next"}],"client_metadata":{"conversation_id":"conv-compact"}}`)
+
+	auth := &cliproxyauth.Auth{ID: "auth-id"}
+	opts := cliproxyexecutor.Options{}
+
+	firstKey, usedNonce1 := ClaudeThinkingReplayConversationSessionKey(auth, cliproxyexecutor.Request{Payload: firstPayload}, opts)
+	compactedKey, usedNonce2 := ClaudeThinkingReplayConversationSessionKey(auth, cliproxyexecutor.Request{Payload: compactedPayload}, opts)
+	if firstKey == "" || compactedKey == "" {
+		t.Fatalf("conversation key empty: %q, %q", firstKey, compactedKey)
+	}
+	if !usedNonce1 || !usedNonce2 {
+		t.Fatalf("expected conversation nonce to drive the key")
+	}
+	if firstKey != compactedKey {
+		t.Fatalf("nonce-based key changed across compaction: %q vs %q", firstKey, compactedKey)
+	}
+}
+
+func TestClaudeThinkingReplayConversationSessionKey_DerivesContentKeyWhenNoConversationNonce(t *testing.T) {
 	payload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
 	req := cliproxyexecutor.Request{Payload: payload}
 	auth := &cliproxyauth.Auth{ID: "auth-id"}
 
-	if got := ClaudeThinkingReplayConversationSessionKey(auth, req, cliproxyexecutor.Options{}); got != "" {
-		t.Fatalf("expected empty key without conversation nonce, got %q", got)
+	key, usedNonce := ClaudeThinkingReplayConversationSessionKey(auth, req, cliproxyexecutor.Options{})
+	if key == "" {
+		t.Fatal("expected a content-derived key without conversation nonce")
+	}
+	if usedNonce {
+		t.Fatalf("expected no conversation nonce, got key %q", key)
+	}
+}
+
+func TestClaudeThinkingReplayConversationSessionKey_DistinctContentKeysForDifferentOpenings(t *testing.T) {
+	a := cliproxyexecutor.Request{Payload: []byte(`{"messages":[{"role":"user","content":"hello"}]}`)}
+	b := cliproxyexecutor.Request{Payload: []byte(`{"messages":[{"role":"user","content":"world"}]}`)}
+	auth := &cliproxyauth.Auth{ID: "auth-id"}
+	opts := cliproxyexecutor.Options{}
+
+	keyA, _ := ClaudeThinkingReplayConversationSessionKey(auth, a, opts)
+	keyB, _ := ClaudeThinkingReplayConversationSessionKey(auth, b, opts)
+	if keyA == "" || keyB == "" {
+		t.Fatalf("conversation key empty: %q, %q", keyA, keyB)
+	}
+	if keyA == keyB {
+		t.Fatalf("different content produced the same key: %q", keyA)
 	}
 }

--- a/internal/runtime/executor/helps/claude_thinking_replay_session_test.go
+++ b/internal/runtime/executor/helps/claude_thinking_replay_session_test.go
@@ -88,6 +88,46 @@ func TestClaudeThinkingReplayConversationSessionKey_ReadsHeadersCaseInsensitivel
 	}
 }
 
+func TestClaudeThinkingReplayConversationSessionKey_IgnoresWhitespaceOnlyHeaders(t *testing.T) {
+	basePayload := []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-ws"}}`)
+	req := cliproxyexecutor.Request{Payload: basePayload}
+	auth := &cliproxyauth.Auth{ID: "auth-id"}
+
+	withWhitespace := cliproxyexecutor.Options{
+		Headers: map[string][]string{
+			"User-Agent":        {"client/1.0"},
+			"X-App":             {"   "},
+			"X-Codex-Client-Id": {"\t\n"},
+		},
+	}
+	withoutWhitespace := cliproxyexecutor.Options{
+		Headers: map[string][]string{
+			"User-Agent": {"client/1.0"},
+		},
+	}
+
+	withKey := ClaudeThinkingReplayConversationSessionKey(auth, req, withWhitespace)
+	withoutKey := ClaudeThinkingReplayConversationSessionKey(auth, req, withoutWhitespace)
+	if withKey == "" || withoutKey == "" {
+		t.Fatalf("conversation key empty: %q, %q", withKey, withoutKey)
+	}
+	if withKey != withoutKey {
+		t.Fatalf("whitespace-only headers changed the replay key: %q vs %q", withKey, withoutKey)
+	}
+
+	// A whitespace-only conversation header must not become the nonce.
+	wsNoncePayload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	wsNonceReq := cliproxyexecutor.Request{Payload: wsNoncePayload}
+	wsOpts := cliproxyexecutor.Options{
+		Headers: map[string][]string{
+			"X-Conversation-Id": {"   "},
+		},
+	}
+	if got := ClaudeThinkingReplayConversationSessionKey(auth, wsNonceReq, wsOpts); got != "" {
+		t.Fatalf("whitespace-only conversation header produced a key: %q", got)
+	}
+}
+
 func TestClaudeThinkingReplayConversationSessionKey_StableForIdenticalInputs(t *testing.T) {
 	payload := []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-stable"}}`)
 	req := cliproxyexecutor.Request{Payload: payload}

--- a/internal/runtime/executor/helps/claude_thinking_replay_session_test.go
+++ b/internal/runtime/executor/helps/claude_thinking_replay_session_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestClaudeThinkingReplayConversationSessionKey_DelimitsConcatenatedFields(t *testing.T) {
-	payload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	payload := []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-1"}}`)
 	req := cliproxyexecutor.Request{Payload: payload}
 
 	// auth.ID="ab" and no caller scope. The raw concatenation of relevant
@@ -32,13 +32,16 @@ func TestClaudeThinkingReplayConversationSessionKey_DelimitsConcatenatedFields(t
 		},
 	)
 
+	if keyA == "" || keyB == "" {
+		t.Fatalf("conversation key empty: %q, %q", keyA, keyB)
+	}
 	if keyA == keyB {
 		t.Fatalf("distinct caller tuples collided on the same replay key: %q", keyA)
 	}
 }
 
 func TestClaudeThinkingReplayConversationSessionKey_IgnoresToolsList(t *testing.T) {
-	base := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	base := []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-tools"}}`)
 	a := append([]byte(nil), base...)
 	b, _ := sjson.SetRawBytes(base, "tools", []byte(`[{"name":"tool_a"}]`))
 
@@ -56,7 +59,7 @@ func TestClaudeThinkingReplayConversationSessionKey_IgnoresToolsList(t *testing.
 }
 
 func TestClaudeThinkingReplayConversationSessionKey_ReadsHeadersCaseInsensitively(t *testing.T) {
-	payload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	payload := []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-header"}}`)
 	req := cliproxyexecutor.Request{Payload: payload}
 	auth := &cliproxyauth.Auth{ID: "auth-id"}
 
@@ -77,13 +80,16 @@ func TestClaudeThinkingReplayConversationSessionKey_ReadsHeadersCaseInsensitivel
 
 	lowerKey := ClaudeThinkingReplayConversationSessionKey(auth, req, lowerOpts)
 	upperKey := ClaudeThinkingReplayConversationSessionKey(auth, req, upperOpts)
+	if lowerKey == "" || upperKey == "" {
+		t.Fatalf("conversation key empty: %q, %q", lowerKey, upperKey)
+	}
 	if lowerKey != upperKey {
 		t.Fatalf("lowercase and canonical headers produced different keys: %q vs %q", lowerKey, upperKey)
 	}
 }
 
 func TestClaudeThinkingReplayConversationSessionKey_StableForIdenticalInputs(t *testing.T) {
-	payload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	payload := []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-stable"}}`)
 	req := cliproxyexecutor.Request{Payload: payload}
 	opts := cliproxyexecutor.Options{
 		Headers: map[string][]string{
@@ -97,7 +103,37 @@ func TestClaudeThinkingReplayConversationSessionKey_StableForIdenticalInputs(t *
 	auth := &cliproxyauth.Auth{ID: "auth-id"}
 	first := ClaudeThinkingReplayConversationSessionKey(auth, req, opts)
 	second := ClaudeThinkingReplayConversationSessionKey(auth, req, opts)
+	if first == "" {
+		t.Fatal("conversation key empty for stable inputs")
+	}
 	if first != second {
 		t.Fatalf("same inputs produced different keys: %q vs %q", first, second)
+	}
+}
+
+func TestClaudeThinkingReplayConversationSessionKey_DistinctForDifferentConversationIDs(t *testing.T) {
+	basePayload := []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-a"}}`)
+	reqA := cliproxyexecutor.Request{Payload: basePayload}
+	reqB := cliproxyexecutor.Request{Payload: []byte(`{"messages":[{"role":"user","content":"hello"}],"client_metadata":{"conversation_id":"conv-b"}}`)}
+	auth := &cliproxyauth.Auth{ID: "auth-id"}
+	opts := cliproxyexecutor.Options{}
+
+	keyA := ClaudeThinkingReplayConversationSessionKey(auth, reqA, opts)
+	keyB := ClaudeThinkingReplayConversationSessionKey(auth, reqB, opts)
+	if keyA == "" || keyB == "" {
+		t.Fatalf("conversation key empty: %q, %q", keyA, keyB)
+	}
+	if keyA == keyB {
+		t.Fatalf("different conversation ids produced the same key: %q", keyA)
+	}
+}
+
+func TestClaudeThinkingReplayConversationSessionKey_EmptyWhenNoConversationNonce(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	req := cliproxyexecutor.Request{Payload: payload}
+	auth := &cliproxyauth.Auth{ID: "auth-id"}
+
+	if got := ClaudeThinkingReplayConversationSessionKey(auth, req, cliproxyexecutor.Options{}); got != "" {
+		t.Fatalf("expected empty key without conversation nonce, got %q", got)
 	}
 }

--- a/internal/runtime/executor/helps/claude_thinking_replay_session_test.go
+++ b/internal/runtime/executor/helps/claude_thinking_replay_session_test.go
@@ -1,0 +1,57 @@
+package helps
+
+import (
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestClaudeThinkingReplayConversationSessionKey_DelimitsConcatenatedFields(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	req := cliproxyexecutor.Request{Payload: payload}
+
+	// auth.ID="ab" and no caller scope. The raw concatenation of relevant
+	// caller fields is "ab".
+	keyA := ClaudeThinkingReplayConversationSessionKey(
+		&cliproxyauth.Auth{ID: "ab"},
+		req,
+		cliproxyexecutor.Options{},
+	)
+
+	// auth.ID="a" and caller scope "bc". The raw concatenation of the same
+	// fields is also "abc", but the field boundaries must differ.
+	keyB := ClaudeThinkingReplayConversationSessionKey(
+		&cliproxyauth.Auth{ID: "a"},
+		req,
+		cliproxyexecutor.Options{
+			Metadata: map[string]any{
+				cliproxyexecutor.CallerScopeMetadataKey: "bc",
+			},
+		},
+	)
+
+	if keyA == keyB {
+		t.Fatalf("distinct caller tuples collided on the same replay key: %q", keyA)
+	}
+}
+
+func TestClaudeThinkingReplayConversationSessionKey_StableForIdenticalInputs(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	req := cliproxyexecutor.Request{Payload: payload}
+	opts := cliproxyexecutor.Options{
+		Headers: map[string][]string{
+			"User-Agent": {"client/1.0"},
+		},
+		Metadata: map[string]any{
+			cliproxyexecutor.CallerScopeMetadataKey: "scope",
+		},
+	}
+
+	auth := &cliproxyauth.Auth{ID: "auth-id"}
+	first := ClaudeThinkingReplayConversationSessionKey(auth, req, opts)
+	second := ClaudeThinkingReplayConversationSessionKey(auth, req, opts)
+	if first != second {
+		t.Fatalf("same inputs produced different keys: %q vs %q", first, second)
+	}
+}

--- a/internal/runtime/executor/helps/claude_thinking_replay_session_test.go
+++ b/internal/runtime/executor/helps/claude_thinking_replay_session_test.go
@@ -5,6 +5,7 @@ import (
 
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/sjson"
 )
 
 func TestClaudeThinkingReplayConversationSessionKey_DelimitsConcatenatedFields(t *testing.T) {
@@ -33,6 +34,51 @@ func TestClaudeThinkingReplayConversationSessionKey_DelimitsConcatenatedFields(t
 
 	if keyA == keyB {
 		t.Fatalf("distinct caller tuples collided on the same replay key: %q", keyA)
+	}
+}
+
+func TestClaudeThinkingReplayConversationSessionKey_IgnoresToolsList(t *testing.T) {
+	base := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	a := append([]byte(nil), base...)
+	b, _ := sjson.SetRawBytes(base, "tools", []byte(`[{"name":"tool_a"}]`))
+
+	optsA := cliproxyexecutor.Options{}
+	optsB := cliproxyexecutor.Options{}
+
+	keyA := ClaudeThinkingReplayConversationSessionKey(&cliproxyauth.Auth{ID: "caller"}, cliproxyexecutor.Request{Payload: a}, optsA)
+	keyB := ClaudeThinkingReplayConversationSessionKey(&cliproxyauth.Auth{ID: "caller"}, cliproxyexecutor.Request{Payload: b}, optsB)
+	if keyA == "" || keyB == "" {
+		t.Fatalf("empty key: %q, %q", keyA, keyB)
+	}
+	if keyA != keyB {
+		t.Fatalf("different tools list changed the replay key: %q vs %q", keyA, keyB)
+	}
+}
+
+func TestClaudeThinkingReplayConversationSessionKey_ReadsHeadersCaseInsensitively(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+	req := cliproxyexecutor.Request{Payload: payload}
+	auth := &cliproxyauth.Auth{ID: "auth-id"}
+
+	lowerOpts := cliproxyexecutor.Options{
+		Headers: map[string][]string{
+			"x-codex-client-id": {"client-lowercase"},
+			"x-app":             {"app-lowercase"},
+			"user-agent":        {"agent-lowercase"},
+		},
+	}
+	upperOpts := cliproxyexecutor.Options{
+		Headers: map[string][]string{
+			"X-Codex-Client-Id": {"client-lowercase"},
+			"X-App":             {"app-lowercase"},
+			"User-Agent":        {"agent-lowercase"},
+		},
+	}
+
+	lowerKey := ClaudeThinkingReplayConversationSessionKey(auth, req, lowerOpts)
+	upperKey := ClaudeThinkingReplayConversationSessionKey(auth, req, upperOpts)
+	if lowerKey != upperKey {
+		t.Fatalf("lowercase and canonical headers produced different keys: %q vs %q", lowerKey, upperKey)
 	}
 }
 

--- a/internal/runtime/executor/helps/cloak_utils.go
+++ b/internal/runtime/executor/helps/cloak_utils.go
@@ -71,6 +71,13 @@ func GenerateFakeUserIDWithSessionID(sessionID string) string {
 	return generateFakeUserIDWithSessionID(sessionID)
 }
 
+// GenerateRandomFakeUserIDForSession returns a metadata.user_id with a fresh
+// random device_id while keeping the session_id stable. This is the legacy
+// per-request random behavior used when cache-user-id is false.
+func GenerateRandomFakeUserIDForSession(sessionID string) string {
+	return generateDeterministicFakeUserID(uuid.New().String(), sessionID)
+}
+
 func IsValidUserID(userID string) bool {
 	return isValidUserID(userID)
 }

--- a/internal/runtime/executor/helps/cloak_utils.go
+++ b/internal/runtime/executor/helps/cloak_utils.go
@@ -1,12 +1,13 @@
 package helps
 
 import (
-	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"regexp"
 
 	"github.com/google/uuid"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
 var claudeMetadataDeviceIDPattern = regexp.MustCompile(`^[a-f0-9]{64}$`)
@@ -19,18 +20,31 @@ type claudeMetadataUserID struct {
 
 // generateFakeUserID generates metadata.user_id in the JSON string format used
 // by Claude Code 2.1.78 and newer.
-func generateFakeUserID() string {
-	return generateFakeUserIDWithSessionID(uuid.New().String())
+// The device_id is derived deterministically from the credential seed +
+// session, preserving prompt-cache prefix stability even on cache-miss paths.
+func generateFakeUserID(apiKey string, auth *cliproxyauth.Auth) string {
+	seed := claudeCredentialSeed(apiKey, auth)
+	return generateDeterministicFakeUserID(seed, CachedSessionID(apiKey, auth))
 }
 
 func generateFakeUserIDWithSessionID(sessionID string) string {
+	return generateDeterministicFakeUserID("", sessionID)
+}
+
+// GenerateRandomFakeUserIDForSession returns a metadata.user_id with a fresh
+// random device_id while keeping the session_id stable. This is the legacy
+// per-request random behavior used when cache-user-id is false.
+func GenerateRandomFakeUserIDForSession(sessionID string) string {
+	return generateDeterministicFakeUserID(uuid.New().String(), sessionID)
+}
+
+func generateDeterministicFakeUserID(seed, sessionID string) string {
 	if _, errParse := uuid.Parse(sessionID); errParse != nil {
 		sessionID = uuid.New().String()
 	}
-	hexBytes := make([]byte, 32)
-	_, _ = rand.Read(hexBytes)
+	h := sha256.Sum256([]byte(seed + ":" + sessionID))
 	value, _ := json.Marshal(claudeMetadataUserID{
-		DeviceID:    hex.EncodeToString(hexBytes),
+		DeviceID:    hex.EncodeToString(h[:]),
 		AccountUUID: "",
 		SessionID:   sessionID,
 	})
@@ -57,7 +71,7 @@ func isValidUserID(userID string) bool {
 }
 
 func GenerateFakeUserID() string {
-	return generateFakeUserID()
+	return generateFakeUserID("", nil)
 }
 
 func GenerateFakeUserIDWithSessionID(sessionID string) string {

--- a/internal/runtime/executor/helps/cloak_utils.go
+++ b/internal/runtime/executor/helps/cloak_utils.go
@@ -1,7 +1,7 @@
 package helps
 
 import (
-	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"regexp"
@@ -19,18 +19,25 @@ type claudeMetadataUserID struct {
 
 // generateFakeUserID generates metadata.user_id in the JSON string format used
 // by Claude Code 2.1.78 and newer.
+// The device_id is derived deterministically so the same auth + session always
+// produces the same upstream request metadata and preserves prompt-cache prefix
+// stability. Callers that need a per-request random value can still supply a
+// fresh session UUID.
 func generateFakeUserID() string {
-	return generateFakeUserIDWithSessionID(uuid.New().String())
+	return generateDeterministicFakeUserID("", uuid.New().String())
 }
 
 func generateFakeUserIDWithSessionID(sessionID string) string {
+	return generateDeterministicFakeUserID("", sessionID)
+}
+
+func generateDeterministicFakeUserID(seed, sessionID string) string {
 	if _, errParse := uuid.Parse(sessionID); errParse != nil {
 		sessionID = uuid.New().String()
 	}
-	hexBytes := make([]byte, 32)
-	_, _ = rand.Read(hexBytes)
+	h := sha256.Sum256([]byte(seed + ":" + sessionID))
 	value, _ := json.Marshal(claudeMetadataUserID{
-		DeviceID:    hex.EncodeToString(hexBytes),
+		DeviceID:    hex.EncodeToString(h[:]),
 		AccountUUID: "",
 		SessionID:   sessionID,
 	})

--- a/internal/runtime/executor/helps/session_id_cache.go
+++ b/internal/runtime/executor/helps/session_id_cache.go
@@ -71,13 +71,23 @@ func CachedSessionID(apiKey string) string {
 	if errValue == nil && value != "" {
 		return value
 	}
-	return uuid.New().String()
+	return deterministicSessionID(apiKey)
+}
+
+// deterministicSessionID returns a version-5 UUID derived from apiKey so
+// different workers and cache misses produce the same session for the same
+// credential. A missing apiKey falls back to a stable anonymous namespace UUID.
+func deterministicSessionID(apiKey string) string {
+	if apiKey == "" {
+		return uuid.NewSHA1(uuid.NameSpaceURL, []byte("cpa:claude:session:anonymous")).String()
+	}
+	return uuid.NewSHA1(uuid.NameSpaceURL, []byte(apiKey)).String()
 }
 
 // CachedSessionIDRequired returns a stable session UUID per apiKey for request-time paths.
 func CachedSessionIDRequired(ctx context.Context, apiKey string) (string, error) {
 	if apiKey == "" {
-		return uuid.New().String(), nil
+		return deterministicSessionID(apiKey), nil
 	}
 	client, homeMode, errClient := currentClaudeIDKVClient()
 	if homeMode {
@@ -95,7 +105,7 @@ func CachedSessionIDRequired(ctx context.Context, apiKey string) (string, error)
 			}
 			return strings.TrimSpace(string(raw)), nil
 		}
-		newID := uuid.New().String()
+		newID := deterministicSessionID(apiKey)
 		if _, errSet := client.KVSetNX(ctx, key, []byte(newID), sessionIDTTL); errSet != nil {
 			return "", errSet
 		}
@@ -130,7 +140,7 @@ func CachedSessionIDRequired(ctx context.Context, apiKey string) (string, error)
 		sessionIDCacheMu.Unlock()
 	}
 
-	newID := uuid.New().String()
+	newID := deterministicSessionID(apiKey)
 
 	sessionIDCacheMu.Lock()
 	entry, ok = sessionIDCache[key]

--- a/internal/runtime/executor/helps/session_id_cache.go
+++ b/internal/runtime/executor/helps/session_id_cache.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	homekv "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
 type sessionIDCacheEntry struct {
@@ -60,31 +61,66 @@ func purgeExpiredSessionIDs() {
 	sessionIDCacheMu.Unlock()
 }
 
-func sessionIDCacheKey(apiKey string) string {
-	sum := sha256.Sum256([]byte(apiKey))
+func claudeCredentialSeed(apiKey string, auth *cliproxyauth.Auth) string {
+	if seed := strings.TrimSpace(apiKey); seed != "" {
+		return seed
+	}
+	if auth != nil {
+		if id := strings.TrimSpace(auth.ID); id != "" {
+			return "auth-id|" + id
+		}
+		if index := strings.TrimSpace(auth.Index); index != "" {
+			return "auth-index|" + index
+		}
+		if fileName := strings.TrimSpace(auth.FileName); fileName != "" {
+			return "auth-file|" + fileName
+		}
+		if label := strings.TrimSpace(auth.Label); label != "" {
+			return "auth-label|" + label
+		}
+		if provider := strings.TrimSpace(auth.Provider); provider != "" {
+			return "auth-provider|" + provider
+		}
+	}
+	return "anonymous"
+}
+
+func sessionIDCacheKey(seed string) string {
+	sum := sha256.Sum256([]byte(seed))
 	return hex.EncodeToString(sum[:])
 }
 
-// CachedSessionID returns a stable session UUID per apiKey, refreshing the TTL on each access.
-func CachedSessionID(apiKey string) string {
-	value, errValue := CachedSessionIDRequired(context.Background(), apiKey)
+// CachedSessionID returns a stable session UUID per credential, refreshing the TTL on each access.
+func CachedSessionID(apiKey string, auth *cliproxyauth.Auth) string {
+	value, errValue := CachedSessionIDRequired(context.Background(), apiKey, auth)
 	if errValue == nil && value != "" {
 		return value
 	}
-	return uuid.New().String()
+	return deterministicSessionID(claudeCredentialSeed(apiKey, auth))
 }
 
-// CachedSessionIDRequired returns a stable session UUID per apiKey for request-time paths.
-func CachedSessionIDRequired(ctx context.Context, apiKey string) (string, error) {
-	if apiKey == "" {
-		return uuid.New().String(), nil
+// deterministicSessionID returns a version-5 UUID derived from the credential
+// seed so different workers and cache misses produce the same session for the
+// same credential. No stable identity falls back to a stable anonymous UUID.
+func deterministicSessionID(seed string) string {
+	if seed == "" || seed == "anonymous" {
+		return uuid.NewSHA1(uuid.NameSpaceURL, []byte("cpa:claude:session:anonymous")).String()
+	}
+	return uuid.NewSHA1(uuid.NameSpaceURL, []byte(seed)).String()
+}
+
+// CachedSessionIDRequired returns a stable session UUID per credential for request-time paths.
+func CachedSessionIDRequired(ctx context.Context, apiKey string, auth *cliproxyauth.Auth) (string, error) {
+	seed := claudeCredentialSeed(apiKey, auth)
+	if seed == "anonymous" {
+		return deterministicSessionID(seed), nil
 	}
 	client, homeMode, errClient := currentClaudeIDKVClient()
 	if homeMode {
 		if errClient != nil {
 			return "", errClient
 		}
-		key := claudeSessionIDKVKey(apiKey)
+		key := claudeSessionIDKVKey(seed)
 		raw, found, errGet := client.KVGet(ctx, key)
 		if errGet != nil {
 			return "", errGet
@@ -95,7 +131,7 @@ func CachedSessionIDRequired(ctx context.Context, apiKey string) (string, error)
 			}
 			return strings.TrimSpace(string(raw)), nil
 		}
-		newID := uuid.New().String()
+		newID := deterministicSessionID(seed)
 		if _, errSet := client.KVSetNX(ctx, key, []byte(newID), sessionIDTTL); errSet != nil {
 			return "", errSet
 		}
@@ -111,7 +147,7 @@ func CachedSessionIDRequired(ctx context.Context, apiKey string) (string, error)
 
 	sessionIDCacheCleanupOnce.Do(startSessionIDCacheCleanup)
 
-	key := sessionIDCacheKey(apiKey)
+	key := sessionIDCacheKey(seed)
 	now := time.Now()
 
 	sessionIDCacheMu.RLock()
@@ -130,7 +166,7 @@ func CachedSessionIDRequired(ctx context.Context, apiKey string) (string, error)
 		sessionIDCacheMu.Unlock()
 	}
 
-	newID := uuid.New().String()
+	newID := deterministicSessionID(seed)
 
 	sessionIDCacheMu.Lock()
 	entry, ok = sessionIDCache[key]
@@ -143,6 +179,6 @@ func CachedSessionIDRequired(ctx context.Context, apiKey string) (string, error)
 	return entry.value, nil
 }
 
-func claudeSessionIDKVKey(apiKey string) string {
-	return "cpa:claude:session-id:" + homekv.HashKeyPart(apiKey)
+func claudeSessionIDKVKey(seed string) string {
+	return "cpa:claude:session-id:" + homekv.HashKeyPart(seed)
 }

--- a/internal/runtime/executor/helps/session_id_cache_test.go
+++ b/internal/runtime/executor/helps/session_id_cache_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
 func resetSessionIDCache() {
@@ -84,12 +85,12 @@ func TestCachedSessionIDRequiredHomeReusesKVAcrossLocalCacheReset(t *testing.T) 
 	client := newFakeClaudeIDKVClient()
 	useFakeClaudeIDKVClient(t, client, true, nil)
 
-	first, errFirst := CachedSessionIDRequired(context.Background(), "api-key-1")
+	first, errFirst := CachedSessionIDRequired(context.Background(), "api-key-1", nil)
 	if errFirst != nil {
 		t.Fatalf("CachedSessionIDRequired() first error = %v", errFirst)
 	}
 	resetSessionIDCache()
-	second, errSecond := CachedSessionIDRequired(context.Background(), "api-key-1")
+	second, errSecond := CachedSessionIDRequired(context.Background(), "api-key-1", nil)
 	if errSecond != nil {
 		t.Fatalf("CachedSessionIDRequired() second error = %v", errSecond)
 	}
@@ -114,7 +115,7 @@ func TestCachedSessionIDRequiredEmptyAPIKeyDoesNotUseHomeKV(t *testing.T) {
 	client := newFakeClaudeIDKVClient()
 	useFakeClaudeIDKVClient(t, client, true, nil)
 
-	value, errValue := CachedSessionIDRequired(context.Background(), "")
+	value, errValue := CachedSessionIDRequired(context.Background(), "", nil)
 	if errValue != nil {
 		t.Fatalf("CachedSessionIDRequired(empty) error = %v", errValue)
 	}
@@ -139,7 +140,7 @@ func TestCachedSessionIDRequiredHomeKVFailures(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			useFakeClaudeIDKVClient(t, tc.client, true, nil)
-			if _, errValue := CachedSessionIDRequired(context.Background(), "api-key-1"); errValue == nil {
+			if _, errValue := CachedSessionIDRequired(context.Background(), "api-key-1", nil); errValue == nil {
 				t.Fatalf("CachedSessionIDRequired() error = nil, want error")
 			}
 		})
@@ -151,7 +152,7 @@ func TestCachedSessionIDRequiredHomeRequiresReadAfterSet(t *testing.T) {
 	client.setNoPersist = true
 	useFakeClaudeIDKVClient(t, client, true, nil)
 
-	if _, errValue := CachedSessionIDRequired(context.Background(), "api-key-1"); errValue == nil {
+	if _, errValue := CachedSessionIDRequired(context.Background(), "api-key-1", nil); errValue == nil {
 		t.Fatalf("CachedSessionIDRequired() error = nil, want missing-after-set error")
 	}
 }
@@ -161,11 +162,11 @@ func TestCachedSessionIDRequiredNonHomeModeUsesLocalMap(t *testing.T) {
 	client := newFakeClaudeIDKVClient()
 	useFakeClaudeIDKVClient(t, client, false, nil)
 
-	first, errFirst := CachedSessionIDRequired(context.Background(), "api-key-1")
+	first, errFirst := CachedSessionIDRequired(context.Background(), "api-key-1", nil)
 	if errFirst != nil {
 		t.Fatalf("CachedSessionIDRequired() first error = %v", errFirst)
 	}
-	second, errSecond := CachedSessionIDRequired(context.Background(), "api-key-1")
+	second, errSecond := CachedSessionIDRequired(context.Background(), "api-key-1", nil)
 	if errSecond != nil {
 		t.Fatalf("CachedSessionIDRequired() second error = %v", errSecond)
 	}
@@ -174,5 +175,33 @@ func TestCachedSessionIDRequiredNonHomeModeUsesLocalMap(t *testing.T) {
 	}
 	if client.getCount != 0 || client.setCount != 0 || client.expireCount != 0 {
 		t.Fatalf("KV calls = get %d set %d expire %d, want all zero", client.getCount, client.setCount, client.expireCount)
+	}
+}
+
+func TestCachedSessionIDRequiredDistinctEmptyAPIKeyCredentials(t *testing.T) {
+	resetSessionIDCache()
+
+	authA := &cliproxyauth.Auth{ID: "custom-header-cred-a"}
+	authB := &cliproxyauth.Auth{ID: "custom-header-cred-b"}
+
+	a, errA := CachedSessionIDRequired(context.Background(), "", authA)
+	if errA != nil {
+		t.Fatalf("CachedSessionIDRequired(authA) error = %v", errA)
+	}
+	b, errB := CachedSessionIDRequired(context.Background(), "", authB)
+	if errB != nil {
+		t.Fatalf("CachedSessionIDRequired(authB) error = %v", errB)
+	}
+	if a == b {
+		t.Fatalf("custom-header-only credentials share the same session id %q", a)
+	}
+
+	// Same credential stays stable.
+	a2, errA2 := CachedSessionIDRequired(context.Background(), "", authA)
+	if errA2 != nil {
+		t.Fatalf("CachedSessionIDRequired(authA) second error = %v", errA2)
+	}
+	if a != a2 {
+		t.Fatalf("same credential got different session ids: %q vs %q", a, a2)
 	}
 }

--- a/internal/runtime/executor/helps/user_id_cache.go
+++ b/internal/runtime/executor/helps/user_id_cache.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	homekv "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
 
 type userIDCacheEntry struct {
@@ -49,30 +50,31 @@ func purgeExpiredUserIDs() {
 	userIDCacheMu.Unlock()
 }
 
-func userIDCacheKey(apiKey string) string {
-	sum := sha256.Sum256([]byte(apiKey))
+func userIDCacheKey(seed string) string {
+	sum := sha256.Sum256([]byte(seed))
 	return hex.EncodeToString(sum[:])
 }
 
-func CachedUserID(apiKey string) string {
-	value, errValue := CachedUserIDRequired(context.Background(), apiKey)
+func CachedUserID(apiKey string, auth *cliproxyauth.Auth) string {
+	value, errValue := CachedUserIDRequired(context.Background(), apiKey, auth)
 	if errValue == nil && value != "" {
 		return value
 	}
-	return generateFakeUserID()
+	return generateFakeUserID(apiKey, auth)
 }
 
-// CachedUserIDRequired returns a stable fake user ID per apiKey for request-time paths.
-func CachedUserIDRequired(ctx context.Context, apiKey string) (string, error) {
+// CachedUserIDRequired returns a stable fake user ID per credential for request-time paths.
+func CachedUserIDRequired(ctx context.Context, apiKey string, auth *cliproxyauth.Auth) (string, error) {
+	seed := claudeCredentialSeed(apiKey, auth)
 	newUserID := func() (string, error) {
-		sessionID, errSessionID := CachedSessionIDRequired(ctx, apiKey)
+		sessionID, errSessionID := CachedSessionIDRequired(ctx, apiKey, auth)
 		if errSessionID != nil {
 			return "", errSessionID
 		}
-		return generateFakeUserIDWithSessionID(sessionID), nil
+		return generateDeterministicFakeUserID(seed, sessionID), nil
 	}
 
-	if apiKey == "" {
+	if seed == "anonymous" {
 		return newUserID()
 	}
 	client, homeMode, errClient := currentClaudeIDKVClient()
@@ -80,7 +82,7 @@ func CachedUserIDRequired(ctx context.Context, apiKey string) (string, error) {
 		if errClient != nil {
 			return "", errClient
 		}
-		key := claudeUserIDKVKey(apiKey)
+		key := claudeUserIDKVKey(seed)
 		raw, found, errGet := client.KVGet(ctx, key)
 		if errGet != nil {
 			return "", errGet
@@ -110,7 +112,7 @@ func CachedUserIDRequired(ctx context.Context, apiKey string) (string, error) {
 
 	userIDCacheCleanupOnce.Do(startUserIDCacheCleanup)
 
-	key := userIDCacheKey(apiKey)
+	key := userIDCacheKey(seed)
 	now := time.Now()
 
 	userIDCacheMu.RLock()
@@ -145,6 +147,6 @@ func CachedUserIDRequired(ctx context.Context, apiKey string) (string, error) {
 	return entry.value, nil
 }
 
-func claudeUserIDKVKey(apiKey string) string {
-	return "cpa:claude:user-id:" + homekv.HashKeyPart(apiKey)
+func claudeUserIDKVKey(seed string) string {
+	return "cpa:claude:user-id:" + homekv.HashKeyPart(seed)
 }

--- a/internal/runtime/executor/helps/user_id_cache.go
+++ b/internal/runtime/executor/helps/user_id_cache.go
@@ -69,7 +69,7 @@ func CachedUserIDRequired(ctx context.Context, apiKey string) (string, error) {
 		if errSessionID != nil {
 			return "", errSessionID
 		}
-		return generateFakeUserIDWithSessionID(sessionID), nil
+		return generateDeterministicFakeUserID(apiKey, sessionID), nil
 	}
 
 	if apiKey == "" {

--- a/internal/runtime/executor/helps/user_id_cache_test.go
+++ b/internal/runtime/executor/helps/user_id_cache_test.go
@@ -71,11 +71,23 @@ func TestCachedUserID_ExpiresAfterTTL(t *testing.T) {
 	userIDCacheMu.Unlock()
 
 	newID := CachedUserID("api-key-expired")
-	if newID == expiredID {
-		t.Fatalf("expected expired user_id to be replaced, got %q", newID)
-	}
 	if newID == "" {
 		t.Fatal("expected regenerated user_id to be non-empty")
+	}
+	if !IsValidUserID(newID) {
+		t.Fatalf("regenerated user_id %q is not valid", newID)
+	}
+	// The derived user_id is deterministic, so it is the same value with a
+	// refreshed TTL rather than a new random replacement.
+	if newID != expiredID {
+		t.Fatalf("expected deterministic user_id to be stable after expiry, got %q want %q", newID, expiredID)
+	}
+
+	userIDCacheMu.RLock()
+	entry := userIDCache[cacheKey]
+	userIDCacheMu.RUnlock()
+	if !entry.expire.After(time.Now().Add(30 * time.Minute)) {
+		t.Fatalf("expected expired cache entry to be refreshed, got expire %v", entry.expire)
 	}
 }
 

--- a/internal/runtime/executor/helps/user_id_cache_test.go
+++ b/internal/runtime/executor/helps/user_id_cache_test.go
@@ -33,8 +33,8 @@ func TestCachedUserIDUsesCachedClaudeSessionID(t *testing.T) {
 	resetSessionIDCache()
 
 	const key = "api-key-shared-session"
-	sessionID := CachedSessionID(key)
-	userID := CachedUserID(key)
+	sessionID := CachedSessionID(key, nil)
+	userID := CachedUserID(key, nil)
 	var value claudeMetadataUserID
 	if errUnmarshal := json.Unmarshal([]byte(userID), &value); errUnmarshal != nil {
 		t.Fatalf("unmarshal user ID: %v", errUnmarshal)
@@ -47,8 +47,8 @@ func TestCachedUserIDUsesCachedClaudeSessionID(t *testing.T) {
 func TestCachedUserID_ReusesWithinTTL(t *testing.T) {
 	resetUserIDCache()
 
-	first := CachedUserID("api-key-1")
-	second := CachedUserID("api-key-1")
+	first := CachedUserID("api-key-1", nil)
+	second := CachedUserID("api-key-1", nil)
 
 	if first == "" {
 		t.Fatal("expected generated user_id to be non-empty")
@@ -61,7 +61,7 @@ func TestCachedUserID_ReusesWithinTTL(t *testing.T) {
 func TestCachedUserID_ExpiresAfterTTL(t *testing.T) {
 	resetUserIDCache()
 
-	expiredID := CachedUserID("api-key-expired")
+	expiredID := CachedUserID("api-key-expired", nil)
 	cacheKey := userIDCacheKey("api-key-expired")
 	userIDCacheMu.Lock()
 	userIDCache[cacheKey] = userIDCacheEntry{
@@ -70,20 +70,32 @@ func TestCachedUserID_ExpiresAfterTTL(t *testing.T) {
 	}
 	userIDCacheMu.Unlock()
 
-	newID := CachedUserID("api-key-expired")
-	if newID == expiredID {
-		t.Fatalf("expected expired user_id to be replaced, got %q", newID)
-	}
+	newID := CachedUserID("api-key-expired", nil)
 	if newID == "" {
 		t.Fatal("expected regenerated user_id to be non-empty")
+	}
+	if !IsValidUserID(newID) {
+		t.Fatalf("regenerated user_id %q is not valid", newID)
+	}
+	// The derived user_id is deterministic, so it is the same value with a
+	// refreshed TTL rather than a new random replacement.
+	if newID != expiredID {
+		t.Fatalf("expected deterministic user_id to be stable after expiry, got %q want %q", newID, expiredID)
+	}
+
+	userIDCacheMu.RLock()
+	entry := userIDCache[cacheKey]
+	userIDCacheMu.RUnlock()
+	if !entry.expire.After(time.Now().Add(30 * time.Minute)) {
+		t.Fatalf("expected expired cache entry to be refreshed, got expire %v", entry.expire)
 	}
 }
 
 func TestCachedUserID_IsScopedByAPIKey(t *testing.T) {
 	resetUserIDCache()
 
-	first := CachedUserID("api-key-1")
-	second := CachedUserID("api-key-2")
+	first := CachedUserID("api-key-1", nil)
+	second := CachedUserID("api-key-2", nil)
 
 	if first == second {
 		t.Fatalf("expected different API keys to have different user_ids, got %q", first)
@@ -94,7 +106,7 @@ func TestCachedUserID_RenewsTTLOnHit(t *testing.T) {
 	resetUserIDCache()
 
 	key := "api-key-renew"
-	id := CachedUserID(key)
+	id := CachedUserID(key, nil)
 	cacheKey := userIDCacheKey(key)
 
 	soon := time.Now()
@@ -105,7 +117,7 @@ func TestCachedUserID_RenewsTTLOnHit(t *testing.T) {
 	}
 	userIDCacheMu.Unlock()
 
-	if refreshed := CachedUserID(key); refreshed != id {
+	if refreshed := CachedUserID(key, nil); refreshed != id {
 		t.Fatalf("expected cached user_id to be reused before expiry, got %q", refreshed)
 	}
 
@@ -123,12 +135,12 @@ func TestCachedUserIDRequiredHomeReusesKVAcrossLocalCacheReset(t *testing.T) {
 	client := newFakeClaudeIDKVClient()
 	useFakeClaudeIDKVClient(t, client, true, nil)
 
-	first, errFirst := CachedUserIDRequired(context.Background(), "api-key-1")
+	first, errFirst := CachedUserIDRequired(context.Background(), "api-key-1", nil)
 	if errFirst != nil {
 		t.Fatalf("CachedUserIDRequired() first error = %v", errFirst)
 	}
 	resetUserIDCache()
-	second, errSecond := CachedUserIDRequired(context.Background(), "api-key-1")
+	second, errSecond := CachedUserIDRequired(context.Background(), "api-key-1", nil)
 	if errSecond != nil {
 		t.Fatalf("CachedUserIDRequired() second error = %v", errSecond)
 	}
@@ -153,7 +165,7 @@ func TestCachedUserIDRequiredEmptyAPIKeyDoesNotUseHomeKV(t *testing.T) {
 	client := newFakeClaudeIDKVClient()
 	useFakeClaudeIDKVClient(t, client, true, nil)
 
-	value, errValue := CachedUserIDRequired(context.Background(), "")
+	value, errValue := CachedUserIDRequired(context.Background(), "", nil)
 	if errValue != nil {
 		t.Fatalf("CachedUserIDRequired(empty) error = %v", errValue)
 	}
@@ -178,10 +190,39 @@ func TestCachedUserIDRequiredHomeKVFailures(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			useFakeClaudeIDKVClient(t, tc.client, true, nil)
-			if _, errValue := CachedUserIDRequired(context.Background(), "api-key-1"); errValue == nil {
+			if _, errValue := CachedUserIDRequired(context.Background(), "api-key-1", nil); errValue == nil {
 				t.Fatalf("CachedUserIDRequired() error = nil, want error")
 			}
 		})
+	}
+}
+
+func TestCachedUserIDFallbackIsDeterministic(t *testing.T) {
+	resetUserIDCache()
+	client := newFakeClaudeIDKVClient()
+	useFakeClaudeIDKVClient(t, client, true, errors.New("kv down"))
+
+	// Forcing CachedUserIDRequired to fall through to the no-cache path; the
+	// fallback must still derive a stable, auth-seeded user_id.
+	first := CachedUserID("fallback-key", nil)
+	if !IsValidUserID(first) {
+		t.Fatalf("fallback user_id %q is not valid", first)
+	}
+
+	second := CachedUserID("fallback-key", nil)
+	if first != second {
+		t.Fatalf("fallback user_id not deterministic: %q vs %q", first, second)
+	}
+}
+
+func TestGenerateFakeUserIDIsDeterministic(t *testing.T) {
+	first := GenerateFakeUserID()
+	second := GenerateFakeUserID()
+	if !IsValidUserID(first) {
+		t.Fatalf("GenerateFakeUserID() %q is not valid", first)
+	}
+	if first != second {
+		t.Fatalf("GenerateFakeUserID() not deterministic: %q vs %q", first, second)
 	}
 }
 
@@ -190,7 +231,7 @@ func TestCachedUserIDRequiredHomeRequiresReadAfterSet(t *testing.T) {
 	client.setNoPersist = true
 	useFakeClaudeIDKVClient(t, client, true, nil)
 
-	if _, errValue := CachedUserIDRequired(context.Background(), "api-key-1"); errValue == nil {
+	if _, errValue := CachedUserIDRequired(context.Background(), "api-key-1", nil); errValue == nil {
 		t.Fatalf("CachedUserIDRequired() error = nil, want missing-after-set error")
 	}
 }

--- a/internal/runtime/executor/kimi_thinking_replay.go
+++ b/internal/runtime/executor/kimi_thinking_replay.go
@@ -125,20 +125,15 @@ func kimiThinkingReplayContentIsReplayable(content []byte) bool {
 		return false
 	}
 	hasSignedThinking := false
-	hasToolUse := false
 	for _, part := range root.Array() {
 		switch strings.TrimSpace(part.Get("type").String()) {
 		case "thinking":
 			if strings.TrimSpace(part.Get("signature").String()) != "" {
 				hasSignedThinking = true
 			}
-		case "tool_use":
-			if strings.TrimSpace(part.Get("id").String()) != "" {
-				hasToolUse = true
-			}
 		}
 	}
-	return hasSignedThinking && hasToolUse
+	return hasSignedThinking
 }
 
 func restoreKimiThinkingReplayContent(body, cachedContent []byte) ([]byte, bool) {
@@ -244,7 +239,6 @@ func kimiNonThinkingContentParts(content gjson.Result) ([][]byte, bool) {
 		return nil, false
 	}
 	parts := make([][]byte, 0, len(content.Array()))
-	hasToolUse := false
 	for _, part := range content.Array() {
 		switch strings.TrimSpace(part.Get("type").String()) {
 		case "thinking", "redacted_thinking":
@@ -253,7 +247,6 @@ func kimiNonThinkingContentParts(content gjson.Result) ([][]byte, bool) {
 			if strings.TrimSpace(part.Get("id").String()) == "" {
 				return nil, false
 			}
-			hasToolUse = true
 		}
 		canonical, ok := kimiCanonicalJSON([]byte(part.Raw))
 		if !ok {
@@ -261,7 +254,7 @@ func kimiNonThinkingContentParts(content gjson.Result) ([][]byte, bool) {
 		}
 		parts = append(parts, canonical)
 	}
-	return parts, hasToolUse
+	return parts, true
 }
 
 func kimiCanonicalPartsEqual(left, right [][]byte) bool {

--- a/internal/runtime/executor/kimi_thinking_replay.go
+++ b/internal/runtime/executor/kimi_thinking_replay.go
@@ -27,6 +27,7 @@ type kimiThinkingReplayScope struct {
 	replayApplied bool
 	fallbackKey   bool
 	callerHash    string
+	firstUserHash string
 }
 
 func (s kimiThinkingReplayScope) valid() bool {

--- a/internal/runtime/executor/kimi_thinking_replay.go
+++ b/internal/runtime/executor/kimi_thinking_replay.go
@@ -25,6 +25,8 @@ type kimiThinkingReplayScope struct {
 	snapshot      internalcache.KimiThinkingReplaySnapshot
 	cacheReady    bool
 	replayApplied bool
+	fallbackKey   bool
+	callerHash    string
 }
 
 func (s kimiThinkingReplayScope) valid() bool {

--- a/internal/runtime/executor/kimi_thinking_replay.go
+++ b/internal/runtime/executor/kimi_thinking_replay.go
@@ -298,6 +298,7 @@ type kimiThinkingReplayStreamBlock struct {
 	thinking             strings.Builder
 	signature            strings.Builder
 	input                strings.Builder
+	citations            []byte
 	textInitialized      bool
 	thinkingInitialized  bool
 	signatureInitialized bool
@@ -396,6 +397,27 @@ func (a *kimiThinkingReplayStreamAccumulator) observeBlockDelta(root gjson.Resul
 			block.input.WriteString(suffix)
 			block.hasInputDelta = true
 		}
+	case "citations_delta":
+		citation := delta.Get("citation")
+		if !citation.IsObject() {
+			a.abandon()
+			return
+		}
+		raw := []byte(citation.Raw)
+		if len(block.citations) == 0 {
+			if !a.reserveBytes(len(raw) + 2) {
+				return
+			}
+			block.citations = append(append([]byte("["), raw...), ']')
+		} else {
+			if !a.reserveBytes(len(raw) + 1) {
+				return
+			}
+			block.citations = block.citations[:len(block.citations)-1]
+			block.citations = append(block.citations, ',')
+			block.citations = append(block.citations, raw...)
+			block.citations = append(block.citations, ']')
+		}
 	default:
 		a.abandon()
 	}
@@ -472,6 +494,9 @@ func (a *kimiThinkingReplayStreamAccumulator) content() ([]byte, bool) {
 		}
 		if errSet == nil && block.hasInputDelta {
 			raw, errSet = sjson.SetRawBytes(raw, "input", []byte(block.input.String()))
+		}
+		if errSet == nil && len(block.citations) > 0 {
+			raw, errSet = sjson.SetRawBytes(raw, "citations", block.citations)
 		}
 		if errSet != nil {
 			a.abandon()

--- a/internal/runtime/executor/kimi_thinking_replay.go
+++ b/internal/runtime/executor/kimi_thinking_replay.go
@@ -160,11 +160,15 @@ func restoreKimiThinkingReplayContent(body, cachedContent []byte) ([]byte, bool)
 		if kimiJSONEqual([]byte(currentContent.Raw), cachedContent) {
 			return body, false
 		}
-		if kimiContentHasThinking(currentContent) {
-			continue
-		}
 		currentParts, currentOK := kimiNonThinkingContentParts(currentContent)
 		if !currentOK || !kimiCanonicalPartsEqual(currentParts, cachedParts) {
+			continue
+		}
+		// Non-thinking parts already match. If the current content has a
+		// thinking block, restore only when it matches the cached thinking block
+		// ignoring signature, so a sanitized echoed turn gets its cached
+		// provenance back.
+		if kimiContentHasThinking(currentContent) && !kimiThinkingMatchesCachedIgnoringSignature(currentContent, gjson.ParseBytes(cachedContent)) {
 			continue
 		}
 		updated, errSet := sjson.SetRawBytes(body, fmt.Sprintf("messages.%d.content", index), cachedContent)
@@ -187,6 +191,52 @@ func kimiContentHasThinking(content gjson.Result) bool {
 		}
 	}
 	return false
+}
+
+// kimiThinkingMatchesCachedIgnoringSignature checks that every thinking or
+// redacted_thinking part in current matches the corresponding cached part after
+// removing signature fields. Non-thinking parts are assumed to be equal by the
+// caller (kimiNonThinkingContentParts/kimiCanonicalPartsEqual).
+func kimiThinkingMatchesCachedIgnoringSignature(current, cached gjson.Result) bool {
+	if !current.IsArray() || !cached.IsArray() {
+		return false
+	}
+	currentParts := current.Array()
+	cachedParts := cached.Array()
+	if len(currentParts) != len(cachedParts) {
+		return false
+	}
+	for i, curPart := range currentParts {
+		cachedPart := cachedParts[i]
+		curType := strings.TrimSpace(curPart.Get("type").String())
+		cachedType := strings.TrimSpace(cachedPart.Get("type").String())
+		if curType != cachedType {
+			return false
+		}
+		switch curType {
+		case "thinking", "redacted_thinking":
+			curClean := kimiThinkingPartWithoutSignature(curPart)
+			cachedClean := kimiThinkingPartWithoutSignature(cachedPart)
+			curCanon, ok1 := kimiCanonicalJSON([]byte(curClean))
+			cachedCanon, ok2 := kimiCanonicalJSON([]byte(cachedClean))
+			if !ok1 || !ok2 || !bytes.Equal(curCanon, cachedCanon) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// kimiThinkingPartWithoutSignature returns a thinking/redacted_thinking part
+// with signature fields removed so two parts can be compared ignoring provenance.
+func kimiThinkingPartWithoutSignature(part gjson.Result) string {
+	updated := part.Raw
+	for _, path := range []string{"signature", "thoughtSignature", "thought_signature", "extra_content.google.thought_signature"} {
+		if gjson.Get(updated, path).Exists() {
+			updated, _ = sjson.Delete(updated, path)
+		}
+	}
+	return updated
 }
 
 func kimiNonThinkingContentParts(content gjson.Result) ([][]byte, bool) {

--- a/internal/runtime/executor/kimi_thinking_replay_test.go
+++ b/internal/runtime/executor/kimi_thinking_replay_test.go
@@ -358,6 +358,35 @@ func TestKimiExecutorClaudeStreamReplaysThinkingAcrossK3VariantSwitch(t *testing
 	}
 }
 
+func TestKimiThinkingReplayStreamAccumulator_PreservesCitations(t *testing.T) {
+	accumulator := newKimiThinkingReplayStreamAccumulator()
+	chunks := []byte(
+		"event: message_start\n" +
+			`data: {"type":"message_start","message":{"id":"msg_1","model":"k3"}}` + "\n\n" +
+			"event: content_block_start\n" +
+			`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":"","citations":[]}}` + "\n\n" +
+			"event: content_block_delta\n" +
+			`data: {"type":"content_block_delta","index":0,"delta":{"type":"citations_delta","citation":{"type":"web_search_result_location","url":"https://example.com"}}}` + "\n\n" +
+			"event: content_block_delta\n" +
+			`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"answer"}}` + "\n\n" +
+			"event: content_block_stop\n" +
+			`data: {"type":"content_block_stop","index":0}` + "\n\n" +
+			"event: message_stop\n" +
+			`data: {"type":"message_stop"}` + "\n\n",
+	)
+	accumulator.observe(chunks)
+	content, ok := accumulator.content()
+	if !ok {
+		t.Fatal("accumulator did not complete")
+	}
+	if !strings.Contains(string(content), `"citations"`) {
+		t.Fatalf("cached content missing citations: %s", content)
+	}
+	if !strings.Contains(string(content), `"https://example.com"`) {
+		t.Fatalf("cached citation missing url: %s", content)
+	}
+}
+
 func TestKimiThinkingReplayUnknownStreamDeltaPreservesPreviousCache(t *testing.T) {
 	internalcache.ClearKimiThinkingReplayCache()
 	t.Cleanup(internalcache.ClearKimiThinkingReplayCache)

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -125,6 +125,17 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 				continue
 			}
 
+			// Trusted replay cache provenance: the executor marked this thinking part
+			// after restoring it from the same model/auth/session replay cache. Preserve
+			// its signature and strip the transient marker before sending upstream.
+			if part.Get("_cliproxy_replay_provenance").Bool() {
+				updated, _ := sjson.Delete(part.Raw, "_cliproxy_replay_provenance")
+				keptParts = append(keptParts, updated)
+				report.Preserved++
+				messageModified = true
+				continue
+			}
+
 			rawSignature := part.Get("signature").String()
 			if opts.PreserveEmptyThinkingBlocks {
 				// In compat mode the block shape must survive, but the signature still

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -357,8 +357,8 @@ func isClaudeReplayableShortSignature(rawSignature string) (bool, string) {
 			// Reject nested or residual provider prefixes (e.g. claude#vendor#...).
 			return false, ""
 		}
-		if isShortClaudeSyntheticSignature(payload) {
-			return true, payload
+		if ok, normalized := isShortClaudeSyntheticSignature(payload); ok {
+			return true, normalized
 		}
 		return false, ""
 	}
@@ -366,8 +366,8 @@ func isClaudeReplayableShortSignature(rawSignature string) (bool, string) {
 		// Unrecognized provider prefix (e.g. vendor#...).
 		return false, ""
 	}
-	if isShortClaudeSyntheticSignature(rawSignature) {
-		return true, rawSignature
+	if ok, normalized := isShortClaudeSyntheticSignature(rawSignature); ok {
+		return true, normalized
 	}
 	return false, ""
 }
@@ -375,18 +375,22 @@ func isClaudeReplayableShortSignature(rawSignature string) (bool, string) {
 // isShortClaudeSyntheticSignature reports whether rawSignature is the minimal
 // 1-2 byte E-prefixed synthetic used by the Claude thinking replay cache.
 // Anything larger is rejected without decoding, so this does not allocate for
-// multi-kilobyte opaque blobs.
-func isShortClaudeSyntheticSignature(rawSignature string) bool {
+// multi-kilobyte opaque blobs. The returned string is the trimmed, normalized
+// form to avoid forwarding whitespace-padded signatures upstream.
+func isShortClaudeSyntheticSignature(rawSignature string) (bool, string) {
 	sig := strings.TrimSpace(rawSignature)
 	// Valid base64 is a multiple of 4 characters; 4 characters decode to at most
 	// 3 bytes. Only 1-2 byte payloads can be the short synthetic, so anything
 	// longer is rejected before decoding.
 	if len(sig) > 4 {
-		return false
+		return false, ""
 	}
 	decoded, err := base64.StdEncoding.DecodeString(sig)
 	if err != nil || len(decoded) == 0 || len(decoded) > 2 {
-		return false
+		return false, ""
 	}
-	return decoded[0] == 0x12
+	if decoded[0] != 0x12 {
+		return false, ""
+	}
+	return true, sig
 }

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -125,15 +125,13 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 				continue
 			}
 
-			// Trusted replay cache provenance: the executor marked this thinking part
-			// after restoring it from the same model/auth/session replay cache. Preserve
-			// its signature and strip the transient marker before sending upstream.
-			if part.Get("_cliproxy_replay_provenance").Bool() {
+			// Replay provenance is added only internally by the executor after the
+			// sanitizer has already run. Any client-supplied marker is untrusted and
+			// must be stripped so it cannot bypass signature validation.
+			if part.Get("_cliproxy_replay_provenance").Exists() {
 				updated, _ := sjson.Delete(part.Raw, "_cliproxy_replay_provenance")
-				keptParts = append(keptParts, updated)
-				report.Preserved++
+				part = gjson.Parse(updated)
 				messageModified = true
-				continue
 			}
 
 			rawSignature := part.Get("signature").String()

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -150,10 +150,13 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 					messageModified = true
 				default:
 					// DropBlock, DropSignature, or NoCompatibleReplacement: keep the
-					// block shape for the compat endpoint, but strip the signature unless
-					// it is an unprefixed, non-foreign decodable Claude E/R shape (short
-					// synthetic signatures used by the Claude thinking replay cache).
-					if targetProvider == SignatureProviderClaude && isClaudeReplayableShortSignature(rawSignature) {
+					// block shape for the compat endpoint. Preserve empty placeholders
+					// with their required signature member, and keep only unprefixed,
+					// non-foreign decodable Claude E/R shapes as a fallback.
+					if isEmptyClaudeThinkingPlaceholder(part) {
+						report.Preserved++
+						keptParts = append(keptParts, part.Raw)
+					} else if targetProvider == SignatureProviderClaude && isClaudeReplayableShortSignature(rawSignature) {
 						report.Preserved++
 						keptParts = append(keptParts, part.Raw)
 					} else {
@@ -317,13 +320,19 @@ func deleteEmptyJSONObjectPath(raw, path string) (string, bool) {
 // isClaudeReplayableShortSignature preserves decodable Claude E/R-shaped
 // signatures in compat mode, but only when the value is not explicitly
 // prefixed or identified as a foreign provider. This prevents Gemini
-// E-prefixed signatures (or values like "gemini#<E-sig>") from slipping
-// through the Claude fallback and failing upstream validation.
+// E-prefixed signatures (or values like "gemini#<E-sig>") and unrecognized
+// vendor prefixes (e.g. "vendor#<E-sig>") from slipping through the Claude
+// fallback and failing upstream validation.
 func isClaudeReplayableShortSignature(rawSignature string) bool {
 	if !HasDecodableClaudeThinkingSignature(rawSignature) {
 		return false
 	}
-	if provider, _, ok := SplitSignatureProviderPrefix(rawSignature); ok && provider != SignatureProviderClaude {
+	if provider, _, ok := SplitSignatureProviderPrefix(rawSignature); ok {
+		if provider != SignatureProviderClaude {
+			return false
+		}
+	} else if strings.Contains(rawSignature, "#") {
+		// Unrecognized provider prefix (e.g. vendor#...).
 		return false
 	}
 	detected := DetectSignatureProviderForBlock(rawSignature, SignatureBlockKindClaudeThinking)

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -1,6 +1,7 @@
 package signature
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strings"
 
@@ -328,13 +329,14 @@ func deleteEmptyJSONObjectPath(raw, path string) (string, bool) {
 	return updated, true
 }
 
-// isClaudeReplayableShortSignature reports whether rawSignature is a proven
+// isClaudeReplayableShortSignature reports whether rawSignature is a short
 // Claude thinking signature safe to replay. It rejects foreign provider
 // prefixes and, when a "claude#" prefix is present, validates the payload
 // behind the prefix and returns the unprefixed value. Unknown or
-// unprovenanced E/R-shaped opaque payloads (e.g. Grok/xAI encrypted_content
-// that happens to start with 'E' or 'R') are rejected so the compat fallback
-// never forwards untrusted signatures to a Claude-compatible target.
+// unprovenanced E/R-shaped opaque payloads are rejected unless they are the
+// minimal short synthetic shape used by the Claude thinking replay cache
+// (e.g. "EgI="); longer unknown blobs such as Grok/xAI encrypted_content that
+// happens to base64-encode to 'E' or 'R' are never forwarded.
 func isClaudeReplayableShortSignature(rawSignature string) (bool, string) {
 	if provider, payload, ok := SplitSignatureProviderPrefix(rawSignature); ok {
 		if provider != SignatureProviderClaude {
@@ -345,15 +347,15 @@ func isClaudeReplayableShortSignature(rawSignature string) (bool, string) {
 			return false, ""
 		}
 		// Validate the payload behind the prefix; only a proven Claude thinking
-		// signature may pass this fallback.
+		// signature or the minimal short synthetic may pass this fallback.
 		if !HasDecodableClaudeThinkingSignature(payload) {
 			return false, ""
 		}
 		detected := DetectSignatureProviderForBlock(payload, SignatureBlockKindClaudeThinking)
-		if detected != SignatureProviderClaude {
-			return false, ""
+		if detected == SignatureProviderClaude || isShortClaudeSyntheticSignature(payload) {
+			return true, payload
 		}
-		return true, payload
+		return false, ""
 	}
 	if strings.Contains(rawSignature, "#") {
 		// Unrecognized provider prefix (e.g. vendor#...).
@@ -363,8 +365,21 @@ func isClaudeReplayableShortSignature(rawSignature string) (bool, string) {
 		return false, ""
 	}
 	detected := DetectSignatureProviderForBlock(rawSignature, SignatureBlockKindClaudeThinking)
-	if detected != SignatureProviderClaude {
-		return false, ""
+	if detected == SignatureProviderClaude || isShortClaudeSyntheticSignature(rawSignature) {
+		return true, rawSignature
 	}
-	return true, rawSignature
+	return false, ""
+}
+
+// isShortClaudeSyntheticSignature identifies the minimal E-prefixed short
+// signatures used by the Claude thinking replay cache (e.g. "EgI="). These
+// payloads are too small for DetectSignatureProviderForBlock to classify, but
+// they are a known short synthetic shape rather than untrusted opaque
+// ciphertext.
+func isShortClaudeSyntheticSignature(rawSignature string) bool {
+	decoded, err := base64.StdEncoding.DecodeString(stripClaudeSignaturePrefix(rawSignature))
+	if err != nil {
+		return false
+	}
+	return len(decoded) <= 2
 }

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -156,9 +156,20 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 					if isEmptyClaudeThinkingPlaceholder(part) {
 						report.Preserved++
 						keptParts = append(keptParts, part.Raw)
-					} else if targetProvider == SignatureProviderClaude && isClaudeReplayableShortSignature(rawSignature) {
-						report.Preserved++
-						keptParts = append(keptParts, part.Raw)
+					} else if targetProvider == SignatureProviderClaude {
+						if replayable, normalized := isClaudeReplayableShortSignature(rawSignature); replayable {
+							report.Preserved++
+							if normalized != rawSignature {
+								updated, _ := sjson.Set(part.Raw, "signature", normalized)
+								keptParts = append(keptParts, updated)
+							} else {
+								keptParts = append(keptParts, part.Raw)
+							}
+						} else {
+							report.DroppedSignatures++
+							updated, _ := sjson.Delete(part.Raw, "signature")
+							keptParts = append(keptParts, updated)
+						}
 					} else {
 						report.DroppedSignatures++
 						updated, _ := sjson.Delete(part.Raw, "signature")
@@ -317,27 +328,39 @@ func deleteEmptyJSONObjectPath(raw, path string) (string, bool) {
 	return updated, true
 }
 
-// isClaudeReplayableShortSignature preserves decodable Claude E/R-shaped
-// signatures in compat mode, but only when the value is not explicitly
-// prefixed or identified as a foreign provider. This prevents Gemini
-// E-prefixed signatures (or values like "gemini#<E-sig>") and unrecognized
-// vendor prefixes (e.g. "vendor#<E-sig>") from slipping through the Claude
-// fallback and failing upstream validation.
-func isClaudeReplayableShortSignature(rawSignature string) bool {
-	if !HasDecodableClaudeThinkingSignature(rawSignature) {
-		return false
-	}
-	if provider, _, ok := SplitSignatureProviderPrefix(rawSignature); ok {
+// isClaudeReplayableShortSignature reports whether rawSignature is a decodable
+// Claude E/R-shaped value safe to replay. It rejects foreign provider prefixes
+// and, when a "claude#" prefix is present, validates the payload behind the
+// prefix and returns the unprefixed value. This prevents Gemini E-prefixed
+// signatures (e.g. "gemini#<E-sig>"), unrecognized vendor prefixes, or genuine
+// Gemini payloads mislabeled with a Claude prefix from slipping through the
+// Claude fallback.
+func isClaudeReplayableShortSignature(rawSignature string) (bool, string) {
+	if provider, payload, ok := SplitSignatureProviderPrefix(rawSignature); ok {
 		if provider != SignatureProviderClaude {
-			return false
+			return false, ""
 		}
-	} else if strings.Contains(rawSignature, "#") {
+		// Validate the payload behind the prefix; a genuine Gemini or other
+		// foreign signature hiding behind "claude#" must be rejected.
+		if !HasDecodableClaudeThinkingSignature(payload) {
+			return false, ""
+		}
+		detected := DetectSignatureProviderForBlock(payload, SignatureBlockKindClaudeThinking)
+		if detected != SignatureProviderUnknown && detected != SignatureProviderClaude {
+			return false, ""
+		}
+		return true, payload
+	}
+	if strings.Contains(rawSignature, "#") {
 		// Unrecognized provider prefix (e.g. vendor#...).
-		return false
+		return false, ""
+	}
+	if !HasDecodableClaudeThinkingSignature(rawSignature) {
+		return false, ""
 	}
 	detected := DetectSignatureProviderForBlock(rawSignature, SignatureBlockKindClaudeThinking)
 	if detected != SignatureProviderUnknown && detected != SignatureProviderClaude {
-		return false
+		return false, ""
 	}
-	return true
+	return true, rawSignature
 }

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -93,7 +93,7 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 			partType := part.Get("type").String()
 			if partType == "tool_use" {
 				if opts.DropToolSignatures {
-					updatedPart, changed := stripClaudeToolUseSignatureFields(part)
+					updatedPart, changed := StripClaudeToolUseSignatureFields(part)
 					if changed {
 						messageModified = true
 						report.DroppedSignatures++
@@ -244,7 +244,11 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 	return output, report
 }
 
-func stripClaudeToolUseSignatureFields(part gjson.Result) (string, bool) {
+// StripClaudeToolUseSignatureFields removes tool-use signature/provenance
+// fields and empty extra_content.google/extra_content wrappers. It is exported
+// so the executor's replay-cache match can normalize cached tool_use parts with
+// the same logic the upstream sanitizer applies.
+func StripClaudeToolUseSignatureFields(part gjson.Result) (string, bool) {
 	updated := part.Raw
 	changed := false
 	for _, sigPath := range claudeToolUseProvenancePaths() {

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -126,8 +126,43 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 
 			rawSignature := part.Get("signature").String()
 			if opts.PreserveEmptyThinkingBlocks {
-				report.Preserved++
-				keptParts = append(keptParts, part.Raw)
+				// In compat mode the block shape must survive, but the signature still
+				// needs to be normalized, emulated, or stripped to avoid sending an
+				// incompatible or opaque signature to the upstream.
+				decision := DecideSignatureCompatibilityForModel(targetProvider, opts.TargetModel, rawSignature, SignatureBlockKindClaudeThinking)
+				decision.Reason = fmt.Sprintf("messages[%d].content[%d]: %s", i, j, decision.Reason)
+				report.Decisions = append(report.Decisions, decision)
+
+				switch decision.Action {
+				case SignatureActionPreserve:
+					report.Preserved++
+					if decision.NormalizedSignature != "" && decision.NormalizedSignature != rawSignature {
+						updated, _ := sjson.Set(part.Raw, "signature", decision.NormalizedSignature)
+						keptParts = append(keptParts, updated)
+						messageModified = true
+					} else {
+						keptParts = append(keptParts, part.Raw)
+					}
+				case SignatureActionReplaceWithGeminiBypass:
+					report.ReplacedSignatures++
+					updated, _ := sjson.Set(part.Raw, "signature", decision.ReplacementSignature)
+					keptParts = append(keptParts, updated)
+					messageModified = true
+				default:
+					// DropBlock, DropSignature, or NoCompatibleReplacement: keep the
+					// block shape for the compat endpoint, but strip the signature unless
+					// it is at least a decodable Claude E/R shape (short synthetic
+					// signatures used by the Claude thinking replay cache).
+					if targetProvider == SignatureProviderClaude && HasDecodableClaudeThinkingSignature(rawSignature) {
+						report.Preserved++
+						keptParts = append(keptParts, part.Raw)
+					} else {
+						report.DroppedSignatures++
+						updated, _ := sjson.Delete(part.Raw, "signature")
+						keptParts = append(keptParts, updated)
+					}
+					messageModified = true
+				}
 				continue
 			}
 			if targetProvider == SignatureProviderClaude && isEmptyClaudeThinkingPlaceholder(part) && !opts.DropEmptyThinkingPlaceholders {

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -329,14 +329,16 @@ func deleteEmptyJSONObjectPath(raw, path string) (string, bool) {
 	return updated, true
 }
 
-// isClaudeReplayableShortSignature reports whether rawSignature is a short
-// Claude thinking signature safe to replay. It rejects foreign provider
-// prefixes and, when a "claude#" prefix is present, validates the payload
-// behind the prefix and returns the unprefixed value. Unknown or
-// unprovenanced E/R-shaped opaque payloads are rejected unless they are the
-// minimal short synthetic shape used by the Claude thinking replay cache
-// (e.g. "EgI="); longer unknown blobs such as Grok/xAI encrypted_content that
-// happens to base64-encode to 'E' or 'R' are never forwarded.
+// isClaudeReplayableShortSignature is the final compat fallback for thinking
+// blocks. It accepts only the minimal 1-2 byte E-prefixed synthetic shape used
+// by the Claude thinking replay cache (e.g. "EgI="). Anything larger or
+// foreign-prefixed is rejected, so Grok/xAI encrypted_content that happens to
+// base64-encode to 'E' or 'R' is never forwarded.
+//
+// Longer valid Claude signatures are already handled by
+// DecideSignatureCompatibilityForModel before this fallback runs; the detector
+// call here would be redundant and is deliberately avoided for both correctness
+// and cost.
 func isClaudeReplayableShortSignature(rawSignature string) (bool, string) {
 	if provider, payload, ok := SplitSignatureProviderPrefix(rawSignature); ok {
 		if provider != SignatureProviderClaude {
@@ -346,13 +348,7 @@ func isClaudeReplayableShortSignature(rawSignature string) (bool, string) {
 			// Reject nested or residual provider prefixes (e.g. claude#vendor#...).
 			return false, ""
 		}
-		// Validate the payload behind the prefix; only a proven Claude thinking
-		// signature or the minimal short synthetic may pass this fallback.
-		if !HasDecodableClaudeThinkingSignature(payload) {
-			return false, ""
-		}
-		detected := DetectSignatureProviderForBlock(payload, SignatureBlockKindClaudeThinking)
-		if detected == SignatureProviderClaude || isShortClaudeSyntheticSignature(payload) {
+		if isShortClaudeSyntheticSignature(payload) {
 			return true, payload
 		}
 		return false, ""
@@ -361,25 +357,27 @@ func isClaudeReplayableShortSignature(rawSignature string) (bool, string) {
 		// Unrecognized provider prefix (e.g. vendor#...).
 		return false, ""
 	}
-	if !HasDecodableClaudeThinkingSignature(rawSignature) {
-		return false, ""
-	}
-	detected := DetectSignatureProviderForBlock(rawSignature, SignatureBlockKindClaudeThinking)
-	if detected == SignatureProviderClaude || isShortClaudeSyntheticSignature(rawSignature) {
+	if isShortClaudeSyntheticSignature(rawSignature) {
 		return true, rawSignature
 	}
 	return false, ""
 }
 
-// isShortClaudeSyntheticSignature identifies the minimal E-prefixed short
-// signatures used by the Claude thinking replay cache (e.g. "EgI="). These
-// payloads are too small for DetectSignatureProviderForBlock to classify, but
-// they are a known short synthetic shape rather than untrusted opaque
-// ciphertext.
+// isShortClaudeSyntheticSignature reports whether rawSignature is the minimal
+// 1-2 byte E-prefixed synthetic used by the Claude thinking replay cache.
+// Anything larger is rejected without decoding, so this does not allocate for
+// multi-kilobyte opaque blobs.
 func isShortClaudeSyntheticSignature(rawSignature string) bool {
-	decoded, err := base64.StdEncoding.DecodeString(stripClaudeSignaturePrefix(rawSignature))
-	if err != nil {
+	sig := strings.TrimSpace(rawSignature)
+	// Valid base64 is a multiple of 4 characters; 4 characters decode to at most
+	// 3 bytes. Only 1-2 byte payloads can be the short synthetic, so anything
+	// longer is rejected before decoding.
+	if len(sig) > 4 {
 		return false
 	}
-	return len(decoded) <= 2
+	decoded, err := base64.StdEncoding.DecodeString(sig)
+	if err != nil || len(decoded) == 0 || len(decoded) > 2 {
+		return false
+	}
+	return decoded[0] == 0x12
 }

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -340,6 +340,10 @@ func isClaudeReplayableShortSignature(rawSignature string) (bool, string) {
 		if provider != SignatureProviderClaude {
 			return false, ""
 		}
+		if strings.Contains(payload, "#") {
+			// Reject nested or residual provider prefixes (e.g. claude#vendor#...).
+			return false, ""
+		}
 		// Validate the payload behind the prefix; a genuine Gemini or other
 		// foreign signature hiding behind "claude#" must be rejected.
 		if !HasDecodableClaudeThinkingSignature(payload) {

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -151,9 +151,9 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 				default:
 					// DropBlock, DropSignature, or NoCompatibleReplacement: keep the
 					// block shape for the compat endpoint, but strip the signature unless
-					// it is at least a decodable Claude E/R shape (short synthetic
-					// signatures used by the Claude thinking replay cache).
-					if targetProvider == SignatureProviderClaude && HasDecodableClaudeThinkingSignature(rawSignature) {
+					// it is an unprefixed, non-foreign decodable Claude E/R shape (short
+					// synthetic signatures used by the Claude thinking replay cache).
+					if targetProvider == SignatureProviderClaude && isClaudeReplayableShortSignature(rawSignature) {
 						report.Preserved++
 						keptParts = append(keptParts, part.Raw)
 					} else {
@@ -312,4 +312,23 @@ func deleteEmptyJSONObjectPath(raw, path string) (string, bool) {
 		return raw, false
 	}
 	return updated, true
+}
+
+// isClaudeReplayableShortSignature preserves decodable Claude E/R-shaped
+// signatures in compat mode, but only when the value is not explicitly
+// prefixed or identified as a foreign provider. This prevents Gemini
+// E-prefixed signatures (or values like "gemini#<E-sig>") from slipping
+// through the Claude fallback and failing upstream validation.
+func isClaudeReplayableShortSignature(rawSignature string) bool {
+	if !HasDecodableClaudeThinkingSignature(rawSignature) {
+		return false
+	}
+	if provider, _, ok := SplitSignatureProviderPrefix(rawSignature); ok && provider != SignatureProviderClaude {
+		return false
+	}
+	detected := DetectSignatureProviderForBlock(rawSignature, SignatureBlockKindClaudeThinking)
+	if detected != SignatureProviderUnknown && detected != SignatureProviderClaude {
+		return false
+	}
+	return true
 }

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -167,12 +167,12 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 							}
 						} else {
 							report.DroppedSignatures++
-							updated, _ := sjson.Delete(part.Raw, "signature")
+							updated, _ := sjson.Set(part.Raw, "signature", "")
 							keptParts = append(keptParts, updated)
 						}
 					} else {
 						report.DroppedSignatures++
-						updated, _ := sjson.Delete(part.Raw, "signature")
+						updated, _ := sjson.Set(part.Raw, "signature", "")
 						keptParts = append(keptParts, updated)
 					}
 					messageModified = true

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -328,13 +328,13 @@ func deleteEmptyJSONObjectPath(raw, path string) (string, bool) {
 	return updated, true
 }
 
-// isClaudeReplayableShortSignature reports whether rawSignature is a decodable
-// Claude E/R-shaped value safe to replay. It rejects foreign provider prefixes
-// and, when a "claude#" prefix is present, validates the payload behind the
-// prefix and returns the unprefixed value. This prevents Gemini E-prefixed
-// signatures (e.g. "gemini#<E-sig>"), unrecognized vendor prefixes, or genuine
-// Gemini payloads mislabeled with a Claude prefix from slipping through the
-// Claude fallback.
+// isClaudeReplayableShortSignature reports whether rawSignature is a proven
+// Claude thinking signature safe to replay. It rejects foreign provider
+// prefixes and, when a "claude#" prefix is present, validates the payload
+// behind the prefix and returns the unprefixed value. Unknown or
+// unprovenanced E/R-shaped opaque payloads (e.g. Grok/xAI encrypted_content
+// that happens to start with 'E' or 'R') are rejected so the compat fallback
+// never forwards untrusted signatures to a Claude-compatible target.
 func isClaudeReplayableShortSignature(rawSignature string) (bool, string) {
 	if provider, payload, ok := SplitSignatureProviderPrefix(rawSignature); ok {
 		if provider != SignatureProviderClaude {
@@ -344,13 +344,13 @@ func isClaudeReplayableShortSignature(rawSignature string) (bool, string) {
 			// Reject nested or residual provider prefixes (e.g. claude#vendor#...).
 			return false, ""
 		}
-		// Validate the payload behind the prefix; a genuine Gemini or other
-		// foreign signature hiding behind "claude#" must be rejected.
+		// Validate the payload behind the prefix; only a proven Claude thinking
+		// signature may pass this fallback.
 		if !HasDecodableClaudeThinkingSignature(payload) {
 			return false, ""
 		}
 		detected := DetectSignatureProviderForBlock(payload, SignatureBlockKindClaudeThinking)
-		if detected != SignatureProviderUnknown && detected != SignatureProviderClaude {
+		if detected != SignatureProviderClaude {
 			return false, ""
 		}
 		return true, payload
@@ -363,7 +363,7 @@ func isClaudeReplayableShortSignature(rawSignature string) (bool, string) {
 		return false, ""
 	}
 	detected := DetectSignatureProviderForBlock(rawSignature, SignatureBlockKindClaudeThinking)
-	if detected != SignatureProviderUnknown && detected != SignatureProviderClaude {
+	if detected != SignatureProviderClaude {
 		return false, ""
 	}
 	return true, rawSignature

--- a/internal/signature/claude_messages_sanitize_compat_test.go
+++ b/internal/signature/claude_messages_sanitize_compat_test.go
@@ -21,44 +21,44 @@ func TestSanitizeClaudeMessagesForClaudeUpstreamPreservesEmptyThinkingInCompatMo
 	}
 }
 
-func TestSanitizeClaudeMessagesForClaudeUpstreamStripsGeminiPrefixInCompatMode(t *testing.T) {
+func TestSanitizeClaudeMessagesForClaudeUpstreamRetainsEmptySignatureOnGeminiPrefixInCompatMode(t *testing.T) {
 	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"gemini#EgI="}]}]}`)
 
 	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
 	part := gjson.GetBytes(withCompat, "messages.0.content.0")
-	if part.Get("type").String() != "thinking" || part.Get("signature").String() != "" {
-		t.Fatalf("compat sanitizer preserved gemini-prefixed signature: %s", withCompat)
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not retain empty signature member on foreign-prefixed thinking block: %s", withCompat)
 	}
 }
 
-func TestSanitizeClaudeMessagesForClaudeUpstreamStripsMislabeledClaudePrefixInCompatMode(t *testing.T) {
+func TestSanitizeClaudeMessagesForClaudeUpstreamRetainsEmptySignatureOnMislabeledClaudePrefixInCompatMode(t *testing.T) {
 	geminiSig := testGemini3ThoughtSignature([]byte{0x01, 0x0c, 0x39, 0xd6, 0xc7, 0x34})
 	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"claude#` + geminiSig + `"}]}]}`)
 
 	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
 	part := gjson.GetBytes(withCompat, "messages.0.content.0")
-	if part.Get("type").String() != "thinking" || part.Get("signature").Exists() {
-		t.Fatalf("compat sanitizer preserved Gemini payload behind claude# prefix: %s", withCompat)
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not retain empty signature member on mislabeled claude# block: %s", withCompat)
 	}
 }
 
-func TestSanitizeClaudeMessagesForClaudeUpstreamStripsNestedClaudePrefixInCompatMode(t *testing.T) {
+func TestSanitizeClaudeMessagesForClaudeUpstreamRetainsEmptySignatureOnNestedClaudePrefixInCompatMode(t *testing.T) {
 	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"claude#vendor#EgI="}]}]}`)
 
 	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
 	part := gjson.GetBytes(withCompat, "messages.0.content.0")
-	if part.Get("type").String() != "thinking" || part.Get("signature").Exists() {
-		t.Fatalf("compat sanitizer preserved nested claude#vendor# signature: %s", withCompat)
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not retain empty signature member on nested claude# block: %s", withCompat)
 	}
 }
 
-func TestSanitizeClaudeMessagesForClaudeUpstreamStripsUnknownVendorPrefixInCompatMode(t *testing.T) {
+func TestSanitizeClaudeMessagesForClaudeUpstreamRetainsEmptySignatureOnUnknownVendorPrefixInCompatMode(t *testing.T) {
 	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"vendor#EgI="}]}]}`)
 
 	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
 	part := gjson.GetBytes(withCompat, "messages.0.content.0")
-	if part.Get("type").String() != "thinking" || part.Get("signature").Exists() {
-		t.Fatalf("compat sanitizer preserved unknown vendor-prefixed signature: %s", withCompat)
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not retain empty signature member on unknown-vendor block: %s", withCompat)
 	}
 }
 
@@ -72,7 +72,7 @@ func TestSanitizeClaudeMessagesForClaudeUpstreamStripsOpaqueThinkingSignatureInC
 
 	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "deepseek-v4", true)
 	part := gjson.GetBytes(withCompat, "messages.0.content.0")
-	if part.Get("type").String() != "thinking" || part.Get("signature").String() != "" {
-		t.Fatalf("compat sanitizer dropped opaque thinking block: %s", withCompat)
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not retain empty signature member on opaque-signature block: %s", withCompat)
 	}
 }

--- a/internal/signature/claude_messages_sanitize_compat_test.go
+++ b/internal/signature/claude_messages_sanitize_compat_test.go
@@ -42,6 +42,16 @@ func TestSanitizeClaudeMessagesForClaudeUpstreamStripsMislabeledClaudePrefixInCo
 	}
 }
 
+func TestSanitizeClaudeMessagesForClaudeUpstreamStripsNestedClaudePrefixInCompatMode(t *testing.T) {
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"claude#vendor#EgI="}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || part.Get("signature").Exists() {
+		t.Fatalf("compat sanitizer preserved nested claude#vendor# signature: %s", withCompat)
+	}
+}
+
 func TestSanitizeClaudeMessagesForClaudeUpstreamStripsUnknownVendorPrefixInCompatMode(t *testing.T) {
 	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"vendor#EgI="}]}]}`)
 

--- a/internal/signature/claude_messages_sanitize_compat_test.go
+++ b/internal/signature/claude_messages_sanitize_compat_test.go
@@ -1,6 +1,8 @@
 package signature
 
 import (
+	"bytes"
+	"encoding/base64"
 	"testing"
 
 	"github.com/tidwall/gjson"
@@ -59,6 +61,21 @@ func TestSanitizeClaudeMessagesForClaudeUpstreamRetainsEmptySignatureOnUnknownVe
 	part := gjson.GetBytes(withCompat, "messages.0.content.0")
 	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
 		t.Fatalf("compat sanitizer did not retain empty signature member on unknown-vendor block: %s", withCompat)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamRejectsGrokOpaqueERInCompatMode(t *testing.T) {
+	// Grok/xAI encrypted_content is uniformly distributed and can base64-encode
+	// to a string starting with 'E' or 'R', but it is not a valid Claude
+	// thinking signature and must not pass the short-signature fallback.
+	grokLike := bytes.Repeat([]byte{0x12, 0xff, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33}, 4)
+	sig := base64.StdEncoding.EncodeToString(grokLike)
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"` + sig + `"}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer did not clear Grok-style E/R opaque signature: %s", withCompat)
 	}
 }
 

--- a/internal/signature/claude_messages_sanitize_compat_test.go
+++ b/internal/signature/claude_messages_sanitize_compat_test.go
@@ -21,6 +21,16 @@ func TestSanitizeClaudeMessagesForClaudeUpstreamPreservesEmptyThinkingInCompatMo
 	}
 }
 
+func TestSanitizeClaudeMessagesForClaudeUpstreamStripsGeminiPrefixInCompatMode(t *testing.T) {
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"gemini#EgI="}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer preserved gemini-prefixed signature: %s", withCompat)
+	}
+}
+
 func TestSanitizeClaudeMessagesForClaudeUpstreamStripsOpaqueThinkingSignatureInCompatMode(t *testing.T) {
 	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"opaque-deepseek-id"}]}]}`)
 

--- a/internal/signature/claude_messages_sanitize_compat_test.go
+++ b/internal/signature/claude_messages_sanitize_compat_test.go
@@ -31,6 +31,17 @@ func TestSanitizeClaudeMessagesForClaudeUpstreamStripsGeminiPrefixInCompatMode(t
 	}
 }
 
+func TestSanitizeClaudeMessagesForClaudeUpstreamStripsMislabeledClaudePrefixInCompatMode(t *testing.T) {
+	geminiSig := testGemini3ThoughtSignature([]byte{0x01, 0x0c, 0x39, 0xd6, 0xc7, 0x34})
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"claude#` + geminiSig + `"}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || part.Get("signature").Exists() {
+		t.Fatalf("compat sanitizer preserved Gemini payload behind claude# prefix: %s", withCompat)
+	}
+}
+
 func TestSanitizeClaudeMessagesForClaudeUpstreamStripsUnknownVendorPrefixInCompatMode(t *testing.T) {
 	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"vendor#EgI="}]}]}`)
 

--- a/internal/signature/claude_messages_sanitize_compat_test.go
+++ b/internal/signature/claude_messages_sanitize_compat_test.go
@@ -64,6 +64,19 @@ func TestSanitizeClaudeMessagesForClaudeUpstreamRetainsEmptySignatureOnUnknownVe
 	}
 }
 
+func TestSanitizeClaudeMessagesForClaudeUpstreamNormalizesWhitespacePaddedShortSignatureInCompatMode(t *testing.T) {
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"  EgI=  "}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() {
+		t.Fatalf("compat sanitizer dropped the thinking block: %s", withCompat)
+	}
+	if got := part.Get("signature").String(); got != "EgI=" {
+		t.Fatalf("compat sanitizer forwarded whitespace-padded short signature %q, want %q", got, "EgI=")
+	}
+}
+
 func TestSanitizeClaudeMessagesForClaudeUpstreamRejectsGrokOpaqueERInCompatMode(t *testing.T) {
 	// Grok/xAI encrypted_content is uniformly distributed and can base64-encode
 	// to a string starting with 'E' or 'R', but it is not a valid Claude

--- a/internal/signature/claude_messages_sanitize_compat_test.go
+++ b/internal/signature/claude_messages_sanitize_compat_test.go
@@ -21,7 +21,7 @@ func TestSanitizeClaudeMessagesForClaudeUpstreamPreservesEmptyThinkingInCompatMo
 	}
 }
 
-func TestSanitizeClaudeMessagesForClaudeUpstreamPreservesOpaqueThinkingSignatureInCompatMode(t *testing.T) {
+func TestSanitizeClaudeMessagesForClaudeUpstreamStripsOpaqueThinkingSignatureInCompatMode(t *testing.T) {
 	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"opaque-deepseek-id"}]}]}`)
 
 	withoutCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "deepseek-v4")
@@ -31,7 +31,7 @@ func TestSanitizeClaudeMessagesForClaudeUpstreamPreservesOpaqueThinkingSignature
 
 	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "deepseek-v4", true)
 	part := gjson.GetBytes(withCompat, "messages.0.content.0")
-	if part.Get("type").String() != "thinking" || part.Get("signature").String() != "opaque-deepseek-id" {
-		t.Fatalf("compat sanitizer dropped opaque signature: %s", withCompat)
+	if part.Get("type").String() != "thinking" || part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer dropped opaque thinking block: %s", withCompat)
 	}
 }

--- a/internal/signature/claude_messages_sanitize_compat_test.go
+++ b/internal/signature/claude_messages_sanitize_compat_test.go
@@ -79,6 +79,24 @@ func TestSanitizeClaudeMessagesForClaudeUpstreamRejectsGrokOpaqueERInCompatMode(
 	}
 }
 
+func TestSanitizeClaudeMessagesForClaudeUpstreamStripsClientReplayProvenanceMarkerInCompatMode(t *testing.T) {
+	// Client-supplied _cliproxy_replay_provenance must not bypass signature
+	// validation. The marker is stripped and the foreign signature is cleared.
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"opaque-foreign-sig","_cliproxy_replay_provenance":true}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" {
+		t.Fatalf("compat sanitizer dropped the thinking block: %s", withCompat)
+	}
+	if part.Get("_cliproxy_replay_provenance").Exists() {
+		t.Fatalf("compat sanitizer did not strip client-supplied replay provenance marker: %s", withCompat)
+	}
+	if part.Get("signature").String() != "" {
+		t.Fatalf("compat sanitizer preserved foreign signature via client-supplied marker: %s", withCompat)
+	}
+}
+
 func TestSanitizeClaudeMessagesForClaudeUpstreamStripsOpaqueThinkingSignatureInCompatMode(t *testing.T) {
 	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"opaque-deepseek-id"}]}]}`)
 

--- a/internal/signature/claude_messages_sanitize_compat_test.go
+++ b/internal/signature/claude_messages_sanitize_compat_test.go
@@ -16,8 +16,8 @@ func TestSanitizeClaudeMessagesForClaudeUpstreamPreservesEmptyThinkingInCompatMo
 
 	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "deepseek-v4", true)
 	part := gjson.GetBytes(withCompat, "messages.0.content.0")
-	if part.Get("type").String() != "thinking" || part.Get("signature").String() != "" {
-		t.Fatalf("compat sanitizer dropped empty thinking: %s", withCompat)
+	if part.Get("type").String() != "thinking" || !part.Get("signature").Exists() {
+		t.Fatalf("compat sanitizer dropped empty thinking or its signature member: %s", withCompat)
 	}
 }
 
@@ -28,6 +28,16 @@ func TestSanitizeClaudeMessagesForClaudeUpstreamStripsGeminiPrefixInCompatMode(t
 	part := gjson.GetBytes(withCompat, "messages.0.content.0")
 	if part.Get("type").String() != "thinking" || part.Get("signature").String() != "" {
 		t.Fatalf("compat sanitizer preserved gemini-prefixed signature: %s", withCompat)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstreamStripsUnknownVendorPrefixInCompatMode(t *testing.T) {
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"vendor#EgI="}]}]}`)
+
+	withCompat, _ := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4", true)
+	part := gjson.GetBytes(withCompat, "messages.0.content.0")
+	if part.Get("type").String() != "thinking" || part.Get("signature").Exists() {
+		t.Fatalf("compat sanitizer preserved unknown vendor-prefixed signature: %s", withCompat)
 	}
 }
 

--- a/internal/translator/claude/gemini/claude_gemini_request.go
+++ b/internal/translator/claude/gemini/claude_gemini_request.go
@@ -6,24 +6,15 @@
 package gemini
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
-)
-
-var (
-	user    = ""
-	account = ""
-	session = ""
 )
 
 // ConvertGeminiRequestToClaude parses and transforms a Gemini API request into Claude Code API format.
@@ -47,19 +38,7 @@ var (
 func ConvertGeminiRequestToClaude(modelName string, inputRawJSON []byte, stream bool) []byte {
 	rawJSON := inputRawJSON
 
-	if account == "" {
-		u, _ := uuid.NewRandom()
-		account = u.String()
-	}
-	if session == "" {
-		u, _ := uuid.NewRandom()
-		session = u.String()
-	}
-	if user == "" {
-		sum := sha256.Sum256([]byte(account + session))
-		user = hex.EncodeToString(sum[:])
-	}
-	userID := fmt.Sprintf("user_%s_account_%s_session_%s", user, account, session)
+	userID := translatorcommon.DeriveClaudeUserID(rawJSON)
 
 	// Base Claude message payload
 	out := []byte(fmt.Sprintf(`{"model":"","max_tokens":32000,"messages":[],"metadata":{"user_id":"%s"}}`, userID))

--- a/internal/translator/claude/gemini/claude_gemini_response.go
+++ b/internal/translator/claude/gemini/claude_gemini_response.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	sigcompat "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -37,6 +38,11 @@ type ConvertAnthropicResponseToGeminiParams struct {
 	ToolUseNames map[int]string           // function/tool name per block index
 	ToolUseArgs  map[int]*strings.Builder // accumulates partial_json across deltas
 	ToolUseIDs   map[int]string           // tool use ID per block index
+
+	// Streaming state for thinking/signature handling
+	CurrentThinkingText      *strings.Builder
+	CurrentThinkingSignature string
+	CurrentBlockType         string
 }
 
 // ConvertClaudeResponseToGemini converts Claude Code streaming response format to Gemini format.
@@ -101,8 +107,13 @@ func ConvertClaudeResponseToGemini(_ context.Context, modelName string, original
 
 	case "content_block_start":
 		// Start of a content block - record tool_use name by index for functionCall assembly
+		// and record thinking block signatures for later replay.
 		if cb := root.Get("content_block"); cb.Exists() {
-			if cb.Get("type").String() == "tool_use" {
+			blockType := cb.Get("type").String()
+			(*param).(*ConvertAnthropicResponseToGeminiParams).CurrentBlockType = blockType
+			(*param).(*ConvertAnthropicResponseToGeminiParams).CurrentThinkingText = nil
+			(*param).(*ConvertAnthropicResponseToGeminiParams).CurrentThinkingSignature = ""
+			if blockType == "tool_use" {
 				idx := int(root.Get("index").Int())
 				if (*param).(*ConvertAnthropicResponseToGeminiParams).ToolUseNames == nil {
 					(*param).(*ConvertAnthropicResponseToGeminiParams).ToolUseNames = map[int]string{}
@@ -115,6 +126,11 @@ func ConvertClaudeResponseToGemini(_ context.Context, modelName string, original
 						(*param).(*ConvertAnthropicResponseToGeminiParams).ToolUseIDs = map[int]string{}
 					}
 					(*param).(*ConvertAnthropicResponseToGeminiParams).ToolUseIDs[idx] = toolID
+				}
+			}
+			if blockType == "thinking" {
+				if sig := cb.Get("signature").String(); sig != "" {
+					(*param).(*ConvertAnthropicResponseToGeminiParams).CurrentThinkingSignature = sigcompat.GeminiReplaySignatureOrBypass(sig, sigcompat.SignatureBlockKindGeminiModelPart)
 				}
 			}
 		}
@@ -138,7 +154,22 @@ func ConvertClaudeResponseToGemini(_ context.Context, modelName string, original
 				if text := delta.Get("thinking"); text.Exists() && text.String() != "" {
 					thinkingPart := []byte(`{"thought":true,"text":""}`)
 					thinkingPart, _ = sjson.SetBytes(thinkingPart, "text", text.String())
+					if (*param).(*ConvertAnthropicResponseToGeminiParams).CurrentThinkingSignature != "" {
+						thinkingPart, _ = sjson.SetBytes(thinkingPart, "thoughtSignature", (*param).(*ConvertAnthropicResponseToGeminiParams).CurrentThinkingSignature)
+					}
 					template, _ = sjson.SetRawBytes(template, "candidates.0.content.parts.-1", thinkingPart)
+				}
+			case "signature_delta":
+				// Signature for the current thinking block; emit as a carrier thought
+				// part so the next translator can attach it to the thinking block.
+				if sig := delta.Get("signature").String(); sig != "" {
+					replay := sigcompat.GeminiReplaySignatureOrBypass(sig, sigcompat.SignatureBlockKindGeminiModelPart)
+					sigPart := []byte(`{"thought":true,"text":"","thoughtSignature":""}`)
+					sigPart, _ = sjson.SetBytes(sigPart, "thoughtSignature", replay)
+					template, _ = sjson.SetRawBytes(template, "candidates.0.content.parts.-1", sigPart)
+					// The signature has been emitted as a carrier; clear it so a later
+					// content_block_stop does not duplicate it.
+					(*param).(*ConvertAnthropicResponseToGeminiParams).CurrentThinkingSignature = ""
 				}
 			case "input_json_delta":
 				// Tool use input delta - accumulate partial_json by index for later assembly at content_block_stop
@@ -161,10 +192,22 @@ func ConvertClaudeResponseToGemini(_ context.Context, modelName string, original
 		return [][]byte{template}
 
 	case "content_block_stop":
-		// End of content block - finalize tool calls if any
+		// End of content block - finalize tool calls if any, and reset thinking state.
 		idx := int(root.Get("index").Int())
 		// Claude's content_block_stop often doesn't include content_block payload (see docs/response-claude.txt)
 		// So we finalize using accumulated state captured during content_block_start and input_json_delta.
+
+		// If this was a thinking block, reset state so the next block starts
+		// fresh. The signature was either attached to a thinking_delta or
+		// emitted as a carrier by a signature_delta, so there is nothing left
+		// to flush at content_block_stop.
+		if (*param).(*ConvertAnthropicResponseToGeminiParams).CurrentBlockType == "thinking" {
+			(*param).(*ConvertAnthropicResponseToGeminiParams).CurrentBlockType = ""
+			(*param).(*ConvertAnthropicResponseToGeminiParams).CurrentThinkingSignature = ""
+			(*param).(*ConvertAnthropicResponseToGeminiParams).CurrentThinkingText = nil
+			return [][]byte{}
+		}
+
 		name := ""
 		if (*param).(*ConvertAnthropicResponseToGeminiParams).ToolUseNames != nil {
 			name = (*param).(*ConvertAnthropicResponseToGeminiParams).ToolUseNames[idx]
@@ -362,8 +405,13 @@ func ConvertClaudeResponseToGeminiNonStream(_ context.Context, modelName string,
 		case "content_block_start":
 			// Prepare for content block; record tool_use name by index for later functionCall assembly
 			idx := int(root.Get("index").Int())
+			newParam.CurrentBlockType = ""
+			newParam.CurrentThinkingSignature = ""
+			newParam.CurrentThinkingText = nil
 			if cb := root.Get("content_block"); cb.Exists() {
-				if cb.Get("type").String() == "tool_use" {
+				blockType := cb.Get("type").String()
+				newParam.CurrentBlockType = blockType
+				if blockType == "tool_use" {
 					if newParam.ToolUseNames == nil {
 						newParam.ToolUseNames = map[int]string{}
 					}
@@ -375,6 +423,11 @@ func ConvertClaudeResponseToGeminiNonStream(_ context.Context, modelName string,
 							newParam.ToolUseIDs = map[int]string{}
 						}
 						newParam.ToolUseIDs[idx] = toolID
+					}
+				}
+				if blockType == "thinking" {
+					if sig := cb.Get("signature").String(); sig != "" {
+						newParam.CurrentThinkingSignature = sigcompat.GeminiReplaySignatureOrBypass(sig, sigcompat.SignatureBlockKindGeminiModelPart)
 					}
 				}
 			}
@@ -395,9 +448,16 @@ func ConvertClaudeResponseToGeminiNonStream(_ context.Context, modelName string,
 				case "thinking_delta":
 					// Process reasoning/thinking content
 					if text := delta.Get("thinking"); text.Exists() && text.String() != "" {
-						partJSON := []byte(`{"thought":true,"text":""}`)
-						partJSON, _ = sjson.SetBytes(partJSON, "text", text.String())
-						allParts = append(allParts, partJSON)
+						if newParam.CurrentThinkingText == nil {
+							newParam.CurrentThinkingText = &strings.Builder{}
+						}
+						newParam.CurrentThinkingText.WriteString(text.String())
+					}
+				case "signature_delta":
+					// Signature for the current thinking block; replay through
+					// Gemini compatibility so a fallback to Gemini does not 400.
+					if sig := delta.Get("signature").String(); sig != "" {
+						newParam.CurrentThinkingSignature = sigcompat.GeminiReplaySignatureOrBypass(sig, sigcompat.SignatureBlockKindGeminiModelPart)
 					}
 				case "input_json_delta":
 					// accumulate args partial_json for this index
@@ -419,6 +479,24 @@ func ConvertClaudeResponseToGeminiNonStream(_ context.Context, modelName string,
 			idx := int(root.Get("index").Int())
 			// Claude's content_block_stop often doesn't include content_block payload (see docs/response-claude.txt)
 			// So we finalize using accumulated state captured during content_block_start and input_json_delta.
+
+			// Flush any thinking block accumulated during this content block.
+			if newParam.CurrentBlockType == "thinking" {
+				if newParam.CurrentThinkingText != nil || newParam.CurrentThinkingSignature != "" {
+					partJSON := []byte(`{"thought":true,"text":""}`)
+					if newParam.CurrentThinkingText != nil {
+						partJSON, _ = sjson.SetBytes(partJSON, "text", newParam.CurrentThinkingText.String())
+					}
+					if newParam.CurrentThinkingSignature != "" {
+						partJSON, _ = sjson.SetBytes(partJSON, "thoughtSignature", newParam.CurrentThinkingSignature)
+					}
+					allParts = append(allParts, partJSON)
+				}
+				newParam.CurrentBlockType = ""
+				newParam.CurrentThinkingText = nil
+				newParam.CurrentThinkingSignature = ""
+			}
+
 			name := ""
 			if newParam.ToolUseNames != nil {
 				name = newParam.ToolUseNames[idx]
@@ -535,6 +613,7 @@ func consolidateParts(parts [][]byte) [][]byte {
 	var consolidated [][]byte
 	var currentTextPart strings.Builder
 	var currentThoughtPart strings.Builder
+	var currentThoughtSignature string
 	var hasText, hasThought bool
 
 	flushText := func() {
@@ -550,11 +629,15 @@ func consolidateParts(parts [][]byte) [][]byte {
 
 	flushThought := func() {
 		// Flush accumulated thinking content to the consolidated parts array
-		if hasThought && currentThoughtPart.Len() > 0 {
+		if hasThought && (currentThoughtPart.Len() > 0 || currentThoughtSignature != "") {
 			thoughtPartJSON := []byte(`{"thought":true,"text":""}`)
 			thoughtPartJSON, _ = sjson.SetBytes(thoughtPartJSON, "text", currentThoughtPart.String())
+			if currentThoughtSignature != "" {
+				thoughtPartJSON, _ = sjson.SetBytes(thoughtPartJSON, "thoughtSignature", currentThoughtSignature)
+			}
 			consolidated = append(consolidated, thoughtPartJSON)
 			currentThoughtPart.Reset()
+			currentThoughtSignature = ""
 			hasThought = false
 		}
 	}
@@ -573,10 +656,13 @@ func consolidateParts(parts [][]byte) [][]byte {
 		if thought.Exists() && thought.Type == gjson.True {
 			// This is a thinking part - flush any pending text first
 			flushText() // Flush any pending text first
+			hasThought = true
 
 			if text := part.Get("text"); text.Exists() && text.Type == gjson.String {
 				currentThoughtPart.WriteString(text.String())
-				hasThought = true
+			}
+			if sig := part.Get("thoughtSignature"); sig.Exists() && sig.Type == gjson.String {
+				currentThoughtSignature = sig.String()
 			}
 		} else if text := part.Get("text"); text.Exists() && text.Type == gjson.String {
 			// This is a regular text part - flush any pending thought first

--- a/internal/translator/claude/gemini/claude_gemini_response_test.go
+++ b/internal/translator/claude/gemini/claude_gemini_response_test.go
@@ -2,6 +2,7 @@ package gemini
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -49,5 +50,57 @@ func TestConvertClaudeResponseToGeminiNonStreamPreservesToolUseID(t *testing.T) 
 	got := gjson.GetBytes(out, "candidates.0.content.parts.0.functionCall.id").String()
 	if got != "toolu_gateway" {
 		t.Fatalf("expected functionCall.id %q, got %q; chunk=%s", "toolu_gateway", got, string(out))
+	}
+}
+
+func TestConvertClaudeResponseToGemini_PreservesThinkingSignatureAsBypass(t *testing.T) {
+	ctx := context.Background()
+	var param any
+
+	events := []string{
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"step one"}}`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"opaque-claude-id"}}`,
+		`data: {"type":"content_block_stop","index":0}`,
+	}
+
+	var sigOut [][]byte
+	for i, ev := range events {
+		out := ConvertClaudeResponseToGemini(ctx, "gemini-2.5-pro", nil, nil, []byte(ev), &param)
+		if i == 2 {
+			sigOut = out
+		}
+		if i == len(events)-1 && len(out) != 0 {
+			t.Fatalf("expected no output from content_block_stop, got %d", len(out))
+		}
+	}
+
+	if len(sigOut) != 1 {
+		t.Fatalf("expected 1 signature chunk, got %d", len(sigOut))
+	}
+	part := gjson.GetBytes(sigOut[0], "candidates.0.content.parts.0")
+	if !part.Get("thought").Bool() {
+		t.Fatalf("expected a thought part for signature, got %s", sigOut[0])
+	}
+	if part.Get("thoughtSignature").String() != "skip_thought_signature_validator" {
+		t.Fatalf("expected Gemini bypass signature, got %s", sigOut[0])
+	}
+}
+
+func TestConvertClaudeResponseToGeminiNonStream_PreservesThinkingSignatureAsBypass(t *testing.T) {
+	ctx := context.Background()
+	raw := []byte(fmt.Sprintf(`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"step one"}}
+data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"opaque-claude-id"}}
+data: {"type":"content_block_stop","index":0}
+`))
+
+	out := ConvertClaudeResponseToGeminiNonStream(ctx, "gemini-2.5-pro", nil, nil, raw, nil)
+	part := gjson.GetBytes(out, "candidates.0.content.parts.0")
+	if !part.Get("thought").Bool() || part.Get("text").String() != "step one" {
+		t.Fatalf("expected thinking part with text, got %s", out)
+	}
+	if part.Get("thoughtSignature").String() != "skip_thought_signature_validator" {
+		t.Fatalf("expected Gemini bypass signature, got %s", out)
 	}
 }

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -6,24 +6,15 @@
 package chat_completions
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
-)
-
-var (
-	user    = ""
-	account = ""
-	session = ""
 )
 
 // ConvertOpenAIRequestToClaude parses and transforms an OpenAI Chat Completions API request into Claude Code API format.
@@ -56,19 +47,7 @@ func ConvertOpenAIRequestToClaudeWithCompat(modelName string, inputRawJSON []byt
 func convertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream, preserveEmptyThinkingBlocks bool) []byte {
 	rawJSON := inputRawJSON
 
-	if account == "" {
-		u, _ := uuid.NewRandom()
-		account = u.String()
-	}
-	if session == "" {
-		u, _ := uuid.NewRandom()
-		session = u.String()
-	}
-	if user == "" {
-		sum := sha256.Sum256([]byte(account + session))
-		user = hex.EncodeToString(sum[:])
-	}
-	userID := fmt.Sprintf("user_%s_account_%s_session_%s", user, account, session)
+	userID := common.DeriveClaudeUserID(rawJSON)
 
 	// Base Claude Code API template with default max_tokens value
 	out := []byte(fmt.Sprintf(`{"model":"","max_tokens":32000,"messages":[],"metadata":{"user_id":"%s"}}`, userID))

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -1,12 +1,9 @@
 package responses
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	sigcompat "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
@@ -14,12 +11,6 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
-)
-
-var (
-	user    = ""
-	account = ""
-	session = ""
 )
 
 // ConvertOpenAIResponsesRequestToClaude transforms an OpenAI Responses API request
@@ -46,19 +37,7 @@ func ConvertOpenAIResponsesRequestToClaudeWithCompat(modelName string, inputRawJ
 func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte, stream, preserveEmptyThinkingBlocks bool) []byte {
 	rawJSON := inputRawJSON
 
-	if account == "" {
-		u, _ := uuid.NewRandom()
-		account = u.String()
-	}
-	if session == "" {
-		u, _ := uuid.NewRandom()
-		session = u.String()
-	}
-	if user == "" {
-		sum := sha256.Sum256([]byte(account + session))
-		user = hex.EncodeToString(sum[:])
-	}
-	userID := fmt.Sprintf("user_%s_account_%s_session_%s", user, account, session)
+	userID := common.DeriveClaudeUserID(rawJSON)
 
 	// Base Claude message payload
 	out := []byte(fmt.Sprintf(`{"model":"","max_tokens":32000,"messages":[],"metadata":{"user_id":"%s"}}`, userID))

--- a/internal/translator/common/claude_user_id.go
+++ b/internal/translator/common/claude_user_id.go
@@ -1,0 +1,194 @@
+package common
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// DeriveClaudeUserID returns a stable value for the Claude request field
+// metadata.user_id. It preserves any caller-supplied metadata.user_id or
+// OpenAI Chat Completions user field, then derives a deterministic value from
+// stable client signals (prompt_cache_key, conversation_id, first user message
+// content, and the model/instructions). The same conversation therefore gets
+// the same user_id on every worker and every turn, while different
+// conversations get different values.
+func DeriveClaudeUserID(rawJSON []byte) string {
+	root := gjson.ParseBytes(rawJSON)
+
+	if v := root.Get("metadata.user_id"); v.Exists() {
+		if value := strings.TrimSpace(v.String()); value != "" {
+			return value
+		}
+	}
+	if v := root.Get("user"); v.Exists() {
+		if value := strings.TrimSpace(v.String()); value != "" {
+			return value
+		}
+	}
+
+	var seed strings.Builder
+
+	if v := root.Get("prompt_cache_key"); v.Exists() {
+		if value := strings.TrimSpace(v.String()); value != "" {
+			seed.WriteString("prompt_cache_key:")
+			seed.WriteString(value)
+		}
+	}
+
+	if seed.Len() == 0 {
+		if v := root.Get("conversation_id"); v.Exists() {
+			if value := strings.TrimSpace(v.String()); value != "" {
+				seed.WriteString("conversation_id:")
+				seed.WriteString(value)
+			}
+		}
+	}
+
+	if seed.Len() == 0 {
+		if content := firstStableRequestContent(root); content != "" {
+			seed.WriteString(content)
+		}
+	}
+
+	if seed.Len() == 0 {
+		if v := root.Get("model"); v.Exists() {
+			if value := strings.TrimSpace(v.String()); value != "" {
+				seed.WriteString("model:")
+				seed.WriteString(value)
+			}
+		}
+		if v := root.Get("instructions"); v.Exists() {
+			seed.WriteString(";instructions:")
+			seed.WriteString(v.String())
+		}
+		if v := root.Get("system"); v.Exists() {
+			seed.WriteString(";system:")
+			seed.WriteString(v.String())
+		}
+		if v := root.Get("system_instruction"); v.Exists() {
+			seed.WriteString(";system_instruction:")
+			seed.WriteString(v.String())
+		}
+	}
+
+	if seed.Len() == 0 {
+		return "unknown"
+	}
+
+	sum := sha256.Sum256([]byte(seed.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+func firstStableRequestContent(root gjson.Result) string {
+	if messages := root.Get("messages"); messages.IsArray() {
+		var content string
+		messages.ForEach(func(_, message gjson.Result) bool {
+			if message.Get("role").String() == "user" {
+				content = extractTextContent(message.Get("content"))
+				if content != "" {
+					return false
+				}
+			}
+			return true
+		})
+		if content != "" {
+			return content
+		}
+	}
+
+	if input := root.Get("input"); input.IsArray() {
+		var content string
+		input.ForEach(func(_, item gjson.Result) bool {
+			if isResponsesUserItem(item) {
+				content = extractResponsesItemText(item.Get("content"))
+				if content != "" {
+					return false
+				}
+			}
+			return true
+		})
+		if content != "" {
+			return content
+		}
+	}
+
+	if contents := root.Get("contents"); contents.IsArray() {
+		var content string
+		contents.ForEach(func(_, contentItem gjson.Result) bool {
+			if contentItem.Get("role").String() == "user" {
+				if parts := contentItem.Get("parts"); parts.IsArray() {
+					parts.ForEach(func(_, part gjson.Result) bool {
+						if text := part.Get("text"); text.Exists() {
+							content = text.String()
+							return false
+						}
+						return true
+					})
+				}
+				if content != "" {
+					return false
+				}
+			}
+			return true
+		})
+		if content != "" {
+			return content
+		}
+	}
+
+	return ""
+}
+
+func extractTextContent(content gjson.Result) string {
+	if content.Type == gjson.String {
+		return strings.TrimSpace(content.String())
+	}
+	if !content.IsArray() {
+		return ""
+	}
+	var texts []string
+	content.ForEach(func(_, part gjson.Result) bool {
+		if part.Get("type").String() == "text" {
+			if text := part.Get("text"); text.Exists() {
+				texts = append(texts, text.String())
+			}
+		}
+		return true
+	})
+	return strings.TrimSpace(strings.Join(texts, "\n"))
+}
+
+func isResponsesUserItem(item gjson.Result) bool {
+	role := item.Get("role").String()
+	typ := item.Get("type").String()
+	if role == "user" {
+		return true
+	}
+	if typ == "message" && role != "assistant" {
+		return true
+	}
+	return false
+}
+
+func extractResponsesItemText(content gjson.Result) string {
+	if content.Type == gjson.String {
+		return strings.TrimSpace(content.String())
+	}
+	if !content.IsArray() {
+		return ""
+	}
+	var texts []string
+	content.ForEach(func(_, part gjson.Result) bool {
+		switch part.Get("type").String() {
+		case "input_text", "output_text", "text":
+			if text := part.Get("text"); text.Exists() {
+				texts = append(texts, text.String())
+			}
+		}
+		return true
+	})
+	return strings.TrimSpace(strings.Join(texts, "\n"))
+}

--- a/internal/translator/common/claude_user_id_test.go
+++ b/internal/translator/common/claude_user_id_test.go
@@ -1,0 +1,94 @@
+package common
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestDeriveClaudeUserID_SameConversationIsStable(t *testing.T) {
+	raw := []byte(`{"model":"claude-test","messages":[{"role":"user","content":"hello"}]}`)
+	first := DeriveClaudeUserID(raw)
+	second := DeriveClaudeUserID(raw)
+	if first == "" {
+		t.Fatal("expected non-empty user_id")
+	}
+	if first != second {
+		t.Fatalf("same conversation produced different user_id: %q vs %q", first, second)
+	}
+}
+
+func TestDeriveClaudeUserID_PreservesCallerSuppliedMetadataUserID(t *testing.T) {
+	raw := []byte(`{"model":"claude-test","metadata":{"user_id":"caller-123"},"messages":[{"role":"user","content":"hello"}]}`)
+	if got := DeriveClaudeUserID(raw); got != "caller-123" {
+		t.Fatalf("caller-supplied metadata.user_id not preserved, got %q", got)
+	}
+}
+
+func TestDeriveClaudeUserID_PreservesOpenAIUserField(t *testing.T) {
+	raw := []byte(`{"model":"claude-test","user":"openai-user-456","messages":[{"role":"user","content":"hello"}]}`)
+	if got := DeriveClaudeUserID(raw); got != "openai-user-456" {
+		t.Fatalf("caller-supplied user not preserved, got %q", got)
+	}
+}
+
+func TestDeriveClaudeUserID_DifferentSessionsAreDifferent(t *testing.T) {
+	a := []byte(`{"model":"claude-test","prompt_cache_key":"session-a","messages":[{"role":"user","content":"hello"}]}`)
+	b := []byte(`{"model":"claude-test","prompt_cache_key":"session-b","messages":[{"role":"user","content":"hello"}]}`)
+	idA := DeriveClaudeUserID(a)
+	idB := DeriveClaudeUserID(b)
+	if idA == idB {
+		t.Fatalf("different prompt_cache_key produced same user_id: %q", idA)
+	}
+}
+
+func TestDeriveClaudeUserID_TurnGrowthKeepsSameUserID(t *testing.T) {
+	first := []byte(`{"model":"claude-test","prompt_cache_key":"session-1","messages":[{"role":"user","content":"hello"}]}`)
+	second := []byte(`{"model":"claude-test","prompt_cache_key":"session-1","messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"hi"},{"role":"user","content":"follow up"}]}`)
+	idFirst := DeriveClaudeUserID(first)
+	idSecond := DeriveClaudeUserID(second)
+	if idFirst != idSecond {
+		t.Fatalf("conversation turn growth changed user_id: %q vs %q", idFirst, idSecond)
+	}
+}
+
+func TestDeriveClaudeUserID_FirstMessageFallback(t *testing.T) {
+	raw := []byte(`{"model":"claude-test","messages":[{"role":"user","content":"stable message"}]}`)
+	id1 := DeriveClaudeUserID(raw)
+	id2 := DeriveClaudeUserID(raw)
+	if id1 != id2 {
+		t.Fatalf("same first message produced different user_id: %q vs %q", id1, id2)
+	}
+}
+
+func TestDeriveClaudeUserID_ResponsesInput(t *testing.T) {
+	raw := []byte(`{"model":"claude-test","prompt_cache_key":"resp-session","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}]}`)
+	id1 := DeriveClaudeUserID(raw)
+	id2 := DeriveClaudeUserID(raw)
+	if id1 != id2 {
+		t.Fatalf("same responses input produced different user_id: %q vs %q", id1, id2)
+	}
+}
+
+func TestDeriveClaudeUserID_GeminiContents(t *testing.T) {
+	raw := []byte(`{"model":"claude-test","contents":[{"role":"user","parts":[{"text":"hello"}]}]}`)
+	id1 := DeriveClaudeUserID(raw)
+	id2 := DeriveClaudeUserID(raw)
+	if id1 != id2 {
+		t.Fatalf("same gemini contents produced different user_id: %q vs %q", id1, id2)
+	}
+}
+
+func TestConvertOpenAIRequestToClaude_DeterministicMetadataUserID(t *testing.T) {
+	// This lives in common because the translator packages cannot import each other.
+	raw := []byte(`{"model":"claude-test","messages":[{"role":"user","content":"hello"}]}`)
+	out1 := DeriveClaudeUserID(raw)
+	out2 := DeriveClaudeUserID(raw)
+	if !bytes.Equal([]byte(out1), []byte(out2)) {
+		t.Fatalf("byte-identical user_id expected, got %q vs %q", out1, out2)
+	}
+	if gjson.GetBytes(raw, "metadata.user_id").Exists() {
+		t.Fatal("input should not have metadata.user_id")
+	}
+}

--- a/internal/translator/gemini-cli/claude/gemini-cli_claude_response.go
+++ b/internal/translator/gemini-cli/claude/gemini-cli_claude_response.go
@@ -76,6 +76,14 @@ func ConvertGeminiCLIResponseToClaude(_ context.Context, _ string, originalReque
 	appendEvent := func(event, payload string) {
 		output = translatorcommon.AppendSSEEventString(output, event, payload, 3)
 	}
+	appendSignatureDelta := func(signature string) {
+		if signature == "" || (*param).(*Params).ResponseType != 2 {
+			return
+		}
+		data, _ := sjson.SetBytes([]byte(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"signature_delta","signature":""}}`, (*param).(*Params).ResponseIndex)), "delta.signature", signature)
+		appendEvent("content_block_delta", string(data))
+		(*param).(*Params).HasContent = true
+	}
 
 	// Initialize the streaming session with a message_start event
 	// This is only sent for the very first response chunk to establish the streaming session
@@ -107,16 +115,32 @@ func ConvertGeminiCLIResponseToClaude(_ context.Context, _ string, originalReque
 			// Extract the different types of content from each part
 			partTextResult := partResult.Get("text")
 			functionCallResult := partResult.Get("functionCall")
+			thoughtSignatureResult := partResult.Get("thoughtSignature")
+			if !thoughtSignatureResult.Exists() {
+				thoughtSignatureResult = partResult.Get("thought_signature")
+			}
+			hasThoughtSignature := thoughtSignatureResult.Exists() && thoughtSignatureResult.String() != ""
+
+			// Signature-only part is a carrier for a previous thinking block.
+			if hasThoughtSignature && !partTextResult.Exists() && !functionCallResult.Exists() {
+				appendSignatureDelta(thoughtSignatureResult.String())
+				continue
+			}
 
 			// Handle text content (both regular content and thinking)
 			if partTextResult.Exists() {
 				// Process thinking content (internal reasoning)
-				if partResult.Get("thought").Bool() {
+				if partResult.Get("thought").Bool() || hasThoughtSignature {
+					if hasThoughtSignature && partTextResult.String() == "" {
+						appendSignatureDelta(thoughtSignatureResult.String())
+						continue
+					}
 					// Continue existing thinking block if already in thinking state
 					if (*param).(*Params).ResponseType == 2 {
 						data, _ := sjson.SetBytes([]byte(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"thinking_delta","thinking":""}}`, (*param).(*Params).ResponseIndex)), "delta.thinking", partTextResult.String())
 						appendEvent("content_block_delta", string(data))
 						(*param).(*Params).HasContent = true
+						appendSignatureDelta(thoughtSignatureResult.String())
 					} else {
 						// Transition from another state to thinking
 						// First, close any existing content block
@@ -136,6 +160,7 @@ func ConvertGeminiCLIResponseToClaude(_ context.Context, _ string, originalReque
 						appendEvent("content_block_delta", string(data))
 						(*param).(*Params).ResponseType = 2 // Set state to thinking
 						(*param).(*Params).HasContent = true
+						appendSignatureDelta(thoughtSignatureResult.String())
 					}
 				} else {
 					// Process regular text content (user-visible output)
@@ -269,6 +294,7 @@ func ConvertGeminiCLIResponseToClaudeNonStream(_ context.Context, _ string, orig
 	parts := root.Get("response.candidates.0.content.parts")
 	textBuilder := strings.Builder{}
 	thinkingBuilder := strings.Builder{}
+	var thinkingSignature string
 	toolIDCounter := 0
 	hasToolCall := false
 
@@ -283,21 +309,42 @@ func ConvertGeminiCLIResponseToClaudeNonStream(_ context.Context, _ string, orig
 	}
 
 	flushThinking := func() {
-		if thinkingBuilder.Len() == 0 {
+		if thinkingBuilder.Len() == 0 && thinkingSignature == "" {
 			return
 		}
 		block := []byte(`{"type":"thinking","thinking":""}`)
-		block, _ = sjson.SetBytes(block, "thinking", thinkingBuilder.String())
+		if thinkingBuilder.Len() > 0 {
+			block, _ = sjson.SetBytes(block, "thinking", thinkingBuilder.String())
+		}
+		if thinkingSignature != "" {
+			block, _ = sjson.SetBytes(block, "signature", thinkingSignature)
+		}
 		out, _ = sjson.SetRawBytes(out, "content.-1", block)
 		thinkingBuilder.Reset()
+		thinkingSignature = ""
 	}
 
 	if parts.IsArray() {
 		for _, part := range parts.Array() {
+			thoughtSignature := part.Get("thoughtSignature").String()
+			if thoughtSignature == "" {
+				thoughtSignature = part.Get("thought_signature").String()
+			}
+
+			if thoughtSignature != "" && !part.Get("text").Exists() && !part.Get("functionCall").Exists() {
+				flushText()
+				thinkingSignature = thoughtSignature
+				flushThinking()
+				continue
+			}
+
 			if text := part.Get("text"); text.Exists() && text.String() != "" {
-				if part.Get("thought").Bool() {
+				if part.Get("thought").Bool() || thoughtSignature != "" {
 					flushText()
 					thinkingBuilder.WriteString(text.String())
+					if thoughtSignature != "" {
+						thinkingSignature = thoughtSignature
+					}
 					continue
 				}
 				flushThinking()
@@ -322,6 +369,14 @@ func ConvertGeminiCLIResponseToClaudeNonStream(_ context.Context, _ string, orig
 				toolBlock, _ = sjson.SetRawBytes(toolBlock, "input", []byte(inputRaw))
 				out, _ = sjson.SetRawBytes(out, "content.-1", toolBlock)
 				continue
+			}
+
+			if thoughtSignature != "" {
+				// Signature-only part with no text: flush any previous thinking
+				// and emit it as its own block.
+				flushText()
+				thinkingSignature = thoughtSignature
+				flushThinking()
 			}
 		}
 	}

--- a/internal/translator/gemini-cli/claude/gemini-cli_claude_response_test.go
+++ b/internal/translator/gemini-cli/claude/gemini-cli_claude_response_test.go
@@ -1,0 +1,50 @@
+package claude
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestConvertGeminiCLIResponseToClaude_PreservesThoughtSignature(t *testing.T) {
+	ctx := context.Background()
+	var param any
+	raw := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"thought":true,"text":"step one","thoughtSignature":"opaque-gemini-id"}]},"finishReason":"STOP"}],"usageMetadata":{"candidatesTokenCount":5,"promptTokenCount":10}}}`)
+
+	out := ConvertGeminiCLIResponseToClaude(ctx, "gemini-cli", nil, nil, raw, &param)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 SSE chunk, got %d", len(out))
+	}
+
+	lines := strings.Split(string(out[0]), "\n")
+	hasSig := false
+	for i, line := range lines {
+		data := strings.TrimPrefix(line, "data: ")
+		if data == line {
+			continue
+		}
+		if gjson.Get(data, "type").String() == "content_block_delta" &&
+			gjson.Get(data, "delta.type").String() == "signature_delta" {
+			if got := gjson.Get(data, "delta.signature").String(); got == "opaque-gemini-id" {
+				hasSig = true
+			}
+		}
+		_ = i
+	}
+	if !hasSig {
+		t.Fatalf("expected a signature_delta with opaque-gemini-id, got %s", out[0])
+	}
+}
+
+func TestConvertGeminiCLIResponseToClaudeNonStream_PreservesThoughtSignature(t *testing.T) {
+	ctx := context.Background()
+	raw := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"thought":true,"text":"step one","thoughtSignature":"opaque-gemini-id"}]},"finishReason":"STOP"}],"usageMetadata":{"candidatesTokenCount":5,"promptTokenCount":10}}}`)
+
+	out := ConvertGeminiCLIResponseToClaudeNonStream(ctx, "gemini-cli", nil, nil, raw, nil)
+	sig := gjson.GetBytes(out, "content.0.signature").String()
+	if sig != "opaque-gemini-id" {
+		t.Fatalf("expected thinking signature to be preserved, got %q; response=%s", sig, out)
+	}
+}

--- a/internal/translator/gemini/claude/gemini_claude_compat_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_compat_test.go
@@ -6,6 +6,19 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func TestConvertClaudeRequestToGeminiWithCompatReplaysForeignSignatureAsBypass(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"opaque-claude-id"}]}]}`)
+
+	withCompat := ConvertClaudeRequestToGeminiWithCompat("gemini-2.5-pro", payload, false)
+	part := gjson.GetBytes(withCompat, "contents.0.parts.0")
+	if !part.Get("thought").Bool() || part.Get("text").String() != "reason" {
+		t.Fatalf("compat translation missing thought part: %s", withCompat)
+	}
+	if part.Get("thoughtSignature").String() != "skip_thought_signature_validator" {
+		t.Fatalf("foreign thinking signature should be replaced with Gemini bypass: %s", withCompat)
+	}
+}
+
 func TestConvertClaudeRequestToGeminiWithCompatPreservesEmptyThinking(t *testing.T) {
 	payload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":""}]}]}`)
 

--- a/internal/translator/gemini/claude/gemini_claude_request.go
+++ b/internal/translator/gemini/claude/gemini_claude_request.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	sigcompat "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/translator/gemini/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
@@ -117,9 +118,14 @@ func convertClaudeRequestToGemini(modelName string, inputRawJSON []byte, _ bool,
 						if !preserveEmptyThinkingBlocks {
 							return true
 						}
+						rawSignature := contentResult.Get("signature").String()
+						replaySignature := rawSignature
+						if strings.TrimSpace(rawSignature) != "" {
+							replaySignature = sigcompat.GeminiReplaySignatureOrBypass(rawSignature, sigcompat.SignatureBlockKindGeminiModelPart)
+						}
 						part := []byte(`{"text":"","thought":true,"thoughtSignature":""}`)
 						part, _ = sjson.SetBytes(part, "text", contentResult.Get("thinking").String())
-						part, _ = sjson.SetBytes(part, "thoughtSignature", contentResult.Get("signature").String())
+						part, _ = sjson.SetBytes(part, "thoughtSignature", replaySignature)
 						partItems = append(partItems, part)
 
 					case "tool_use":

--- a/sdk/cliproxy/auth/empty_completion.go
+++ b/sdk/cliproxy/auth/empty_completion.go
@@ -965,9 +965,10 @@ func (a *emptyCompletionAccum) evalGemini(data []byte) bool {
 				if strings.TrimSpace(part.Text) != "" {
 					a.hasContent = true
 				}
-				if strings.TrimSpace(part.ThoughtSignature) != "" || strings.TrimSpace(part.Thought_Signature) != "" {
-					a.hasContent = true
-				}
+				// A signature alone must not count as content: it can be replay
+				// metadata for an upstream that returned nothing. Visible text,
+				// tool calls, or positive token usage still keep the completion
+				// from being classified as empty.
 			}
 		}
 	}

--- a/sdk/cliproxy/auth/empty_completion_test.go
+++ b/sdk/cliproxy/auth/empty_completion_test.go
@@ -471,6 +471,26 @@ func TestEmptyCompletionPredicate(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "gemini non-stream thoughtSignature alone is empty",
+			payload:  []byte(`{"candidates":[{"content":{"role":"model","parts":[{"thoughtSignature":"opaque-dead-upstream"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":0}}`),
+			expected: true,
+		},
+		{
+			name:     "gemini non-stream thought_signature alone is empty",
+			payload:  []byte(`{"candidates":[{"content":{"role":"model","parts":[{"thought_signature":"opaque-dead-upstream"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":0}}`),
+			expected: true,
+		},
+		{
+			name:     "gemini non-stream thoughtSignature with visible text is not empty",
+			payload:  []byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"answer","thoughtSignature":"opaque"}]},"finishReason":"STOP"}]}`),
+			expected: false,
+		},
+		{
+			name:     "gemini non-stream thoughtSignature with positive usage is not empty",
+			payload:  []byte(`{"candidates":[{"content":{"role":"model","parts":[{"thoughtSignature":"opaque"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":1}}`),
+			expected: false,
+		},
+		{
 			name:     "gemini sse stream with empty text and thought flag is empty",
 			payload:  []byte("data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"thought\":true,\"text\":\"\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"candidatesTokenCount\":0}}\n\n"),
 			expected: true,
@@ -2473,31 +2493,31 @@ func TestMultiValueJSONMixedUnknownEmptyCompletion(t *testing.T) {
 }
 
 func TestGeminiThoughtSignatureEmptyCompletion(t *testing.T) {
-	t.Run("gemini STOP with thoughtSignature and omitted candidatesTokenCount is not empty", func(t *testing.T) {
+	t.Run("gemini STOP with thoughtSignature and omitted candidatesTokenCount is empty", func(t *testing.T) {
 		payload := []byte(`{"candidates":[{"content":{"role":"model","parts":[{"thoughtSignature":"sig_gemini_thought_123"}]},"finishReason":"STOP"}]}`)
-		if IsEmptyCompletionPayload(payload) {
-			t.Fatal("IsEmptyCompletionPayload() = true for non-empty thoughtSignature with omitted token count, want false")
+		if !IsEmptyCompletionPayload(payload) {
+			t.Fatal("IsEmptyCompletionPayload() = false for non-empty thoughtSignature with omitted token count, want true")
 		}
 	})
 
-	t.Run("gemini STOP with thought_signature and omitted candidatesTokenCount is not empty", func(t *testing.T) {
+	t.Run("gemini STOP with thought_signature and omitted candidatesTokenCount is empty", func(t *testing.T) {
 		payload := []byte(`{"candidates":[{"content":{"role":"model","parts":[{"thought_signature":"sig_gemini_thought_123"}]},"finishReason":"STOP"}]}`)
-		if IsEmptyCompletionPayload(payload) {
-			t.Fatal("IsEmptyCompletionPayload() = true for non-empty thought_signature with omitted token count, want false")
+		if !IsEmptyCompletionPayload(payload) {
+			t.Fatal("IsEmptyCompletionPayload() = false for non-empty thought_signature with omitted token count, want true")
 		}
 	})
 
-	t.Run("gemini STOP with thoughtSignature and zero candidatesTokenCount is not empty", func(t *testing.T) {
-		payload := []byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"","thoughtSignature":"sig_gemini_thought_123"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":0}}`)
+	t.Run("gemini STOP with thoughtSignature and positive candidatesTokenCount is not empty", func(t *testing.T) {
+		payload := []byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"","thoughtSignature":"sig_gemini_thought_123"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":1}}`)
 		if IsEmptyCompletionPayload(payload) {
-			t.Fatal("IsEmptyCompletionPayload() = true for non-empty thoughtSignature with zero token count, want false")
+			t.Fatal("IsEmptyCompletionPayload() = true for non-empty thoughtSignature with positive token count, want false")
 		}
 	})
 
-	t.Run("gemini STOP with thought_signature and zero candidatesTokenCount is not empty", func(t *testing.T) {
-		payload := []byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"","thought_signature":"sig_gemini_thought_123"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":0}}`)
+	t.Run("gemini STOP with thought_signature and positive candidatesTokenCount is not empty", func(t *testing.T) {
+		payload := []byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"","thought_signature":"sig_gemini_thought_123"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":1}}`)
 		if IsEmptyCompletionPayload(payload) {
-			t.Fatal("IsEmptyCompletionPayload() = true for non-empty thought_signature with zero token count, want false")
+			t.Fatal("IsEmptyCompletionPayload() = true for non-empty thought_signature with positive token count, want false")
 		}
 	})
 


### PR DESCRIPTION
## Summary

Test-only PR pinning airouters-11's replay-alias rules in the alias registry:

- (a) **Compaction-stable scopes**: a compacted follow-up (first user message removed) still resolves to the original conversation scope.
- (b) **Home-KV alias cap per credential**: flooding one credential does not evict another credential's aliases; the per-credential index is isolated across model names.
- (c) **Atomic alias eviction with index update**: alias values are rolled back when the per-credential index CAS fails, and no value is deleted before the index update and re-read succeed.
- (d) **Identical vs distinct conversation scopes**: identical conversations resolve to the same scope; conversations with the same visible messages but different first-user context never collapse.

Each doctrine test calls `requireReplayAliasSupport()` and `t.Skip`s with `Plus #209` / `stock #5150` references when the replay-alias registry is not active.

This branch was rebuilt to contain only the focused test delta on top of Plus #209 (`ao/airouters-11-fix-signature-boundary-plus`), removing the 42-commit/33-file history baggage. Once Plus #209 lands in `main`, the PR diff will show only `internal/cache/replay_alias_doctrine_test.go`.

## Cross-links
- Stock implementation: router-for-me/CLIProxyAPI#5150
- Plus implementation: #209
- Doctrine harness pattern: #219

## Test plan
- [x] `go test -run TestReplayAliasDoctrine ./internal/cache` (6 passed)