### PR TITLE
Add missing claude-opus-4.8 Kiro alias

### DIFF
--- a/internal/runtime/executor/kiro_executor.go
+++ b/internal/runtime/executor/kiro_executor.go
@@ -1590,6 +1590,7 @@ var kiroVersionAliases = [...]struct {
 	{"claude-sonnet-4-6", "claude-sonnet-4.6"},
 	{"claude-opus-4-5", "claude-opus-4.5"},
 	{"claude-opus-4-7", "claude-opus-4.7"},
+	{"claude-opus-4-8", "claude-opus-4.8"},
 	{"claude-haiku-4-5", "claude-haiku-4.5"},
 	// Other Kiro backend families
 	{"minimax-m2-1", "minimax-m2.1"},

--- a/internal/runtime/executor/kiro_executor_test.go
+++ b/internal/runtime/executor/kiro_executor_test.go
@@ -471,6 +471,11 @@ func TestMapModelToKiro_MapsClaudeOpus47Variants(t *testing.T) {
 			expected: "claude-opus-4.5",
 		},
 		{
+			name:     "claude opus 4.8 hyphenated alias",
+			model:    "kiro-claude-opus-4-8",
+			expected: "claude-opus-4.8",
+		},
+		{
 			name:     "claude haiku 4.5 hyphenated alias",
 			model:    "kiro-claude-haiku-4-5",
 			expected: "claude-haiku-4.5",


### PR DESCRIPTION
The Kiro executor's hyphenated-to-canonical version alias table was missing an entry for `claude-opus-4.8`, so requests using the hyphenated form (`claude-opus-4-8`) would not normalize to the canonical model ID `claude-opus-4.8`, unlike other Opus/Sonnet/Haiku versions already covered in PR https://github.com/kaitranntt/CLIProxyAPIPlus/pull/162.

**Alias table**
- Added `{"claude-opus-4-8", "claude-opus-4.8"}` to `kiroVersionAliases` in `internal/runtime/executor/kiro_executor.go`, following the existing pattern for other Claude version aliases.

**Tests**
- Added a test case to `kiro_executor_test.go` verifying `kiro-claude-opus-4-8` normalizes to `claude-opus-4.8`.

```go
{"claude-opus-4-8", "claude-opus-4.8"},
```