### PR TITLE
fix(management): expose Qoder quota snapshots in auth file entries

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
+	qoderauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/qoder"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/credentialweight"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
@@ -423,6 +424,27 @@ func (h *Handler) buildAuthFileEntryLocked(auth *coreauth.Auth) gin.H {
 	}
 	if websockets, ok := authWebsocketsValue(auth); ok {
 		entry["websockets"] = websockets
+	}
+	if strings.EqualFold(strings.TrimSpace(auth.Provider), "qoder") {
+		if storage, ok := auth.Storage.(*qoderauth.QoderTokenStorage); ok {
+			if info := storage.GetUsageInfo(); info != nil {
+				usage := map[string]any{
+					"total":                  info.UserQuota.Total,
+					"used":                   info.UserQuota.Used,
+					"remaining":              info.UserQuota.Remaining,
+					"percentage":             info.UserQuota.Percentage,
+					"unit":                   info.UserQuota.Unit,
+					"total_usage_percentage": info.TotalUsagePercentage,
+					"is_quota_exceeded":      info.IsQuotaExceeded,
+					"expires_at":             info.ExpiresAt,
+				}
+				org := info.OrgResourcePackage
+				if org.Unit != "" || org.Total != 0 || org.Used != 0 || org.Remaining != 0 || org.Percentage != 0 {
+					usage["org_resource_remaining"] = org.Remaining
+				}
+				entry["usage"] = usage
+			}
+		}
 	}
 	return entry
 }

--- a/internal/api/handlers/management/auth_files_qoder_usage_test.go
+++ b/internal/api/handlers/management/auth_files_qoder_usage_test.go
@@ -1,0 +1,86 @@
+package management
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qoderauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/qoder"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestBuildAuthFileEntryIncludesQoderUsageSnapshot(t *testing.T) {
+	authDir := t.TempDir()
+	filePath := filepath.Join(authDir, "qoder-user@example.com.json")
+	if errWrite := os.WriteFile(filePath, []byte(`{"type":"qoder","email":"user@example.com"}`), 0o600); errWrite != nil {
+		t.Fatalf("write auth file: %v", errWrite)
+	}
+
+	storage := &qoderauth.QoderTokenStorage{}
+	storage.SetUsageInfo(&qoderauth.QoderUsageInfo{
+		UserQuota: qoderauth.QoderQuota{
+			Total:      3000,
+			Used:       250,
+			Remaining:  2750,
+			Percentage: 0.0833,
+			Unit:       "credits",
+		},
+		OrgResourcePackage:   qoderauth.QoderQuota{Remaining: 1200},
+		TotalUsagePercentage: 0.0833,
+		IsQuotaExceeded:      false,
+		ExpiresAt:            1790755390618,
+	})
+
+	auth := &coreauth.Auth{
+		ID:       "qoder-user@example.com.json",
+		FileName: "qoder-user@example.com.json",
+		Provider: "qoder",
+		Status:   coreauth.StatusActive,
+		Storage:  storage,
+		Attributes: map[string]string{
+			"path": filePath,
+		},
+	}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+
+	entry := h.buildAuthFileEntry(auth)
+	usage, ok := entry["usage"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected Qoder usage snapshot, got %#v", entry["usage"])
+	}
+	if got := usage["remaining"]; got != float64(2750) {
+		t.Fatalf("remaining = %#v, want 2750", got)
+	}
+	if got := usage["org_resource_remaining"]; got != float64(1200) {
+		t.Fatalf("org_resource_remaining = %#v, want 1200", got)
+	}
+	if got := usage["expires_at"]; got != int64(1790755390618) {
+		t.Fatalf("expires_at = %#v, want 1790755390618", got)
+	}
+}
+
+func TestBuildAuthFileEntryOmitsQoderUsageBeforeSync(t *testing.T) {
+	authDir := t.TempDir()
+	filePath := filepath.Join(authDir, "qoder-user@example.com.json")
+	if errWrite := os.WriteFile(filePath, []byte(`{"type":"qoder"}`), 0o600); errWrite != nil {
+		t.Fatalf("write auth file: %v", errWrite)
+	}
+
+	auth := &coreauth.Auth{
+		ID:       "qoder-user@example.com.json",
+		FileName: "qoder-user@example.com.json",
+		Provider: "qoder",
+		Status:   coreauth.StatusActive,
+		Storage:  &qoderauth.QoderTokenStorage{},
+		Attributes: map[string]string{
+			"path": filePath,
+		},
+	}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+
+	entry := h.buildAuthFileEntry(auth)
+	if _, ok := entry["usage"]; ok {
+		t.Fatalf("usage should be absent before Qoder sync")
+	}
+}


### PR DESCRIPTION
Fixes #229

## Summary

Expose the in-memory Qoder quota snapshot through the management `/auth-files` response.

The management UI reads Qoder quota data from `file.usage`, while the backend previously stored it only in `QoderTokenStorage.UsageInfo`.

## Changes

- Detect Qoder auth records in `buildAuthFileEntryLocked`.
- Read the synchronized snapshot with `GetUsageInfo()`.
- Map personal quota fields into the `usage` object expected by the management UI.
- Include organization remaining credits when an organization package exists.
- Keep `usage` omitted when synchronization has not produced a snapshot.
- Add regression coverage for synchronized and unsynchronized states.

## Testing

```bash
go test ./internal/api/handlers/management \
  -run 'TestBuildAuthFileEntry(Includes|Omits)QoderUsage' \
  -count=1

go test ./internal/api/handlers/management ./internal/runtime/executor -count=1
go test ./... -count=1
go build -o /tmp/cliproxy-pr-native ./cmd/server
```

All commands pass.

The branch was also built for Linux amd64 and tested against a live Docker deployment with sanitized account data:

- Two Qoder auth entries returned non-null `usage` snapshots through the public management API.
- Both zero-quota and non-zero-quota responses rendered the expected normalized fields.
- An OpenAI-compatible `qoder/performance` request returned HTTP 200.
- The existing non-Qoder service remained healthy.

No credentials, account identifiers, deployment hostnames, or keys are included in this change.
